### PR TITLE
Add Google sign-in flow

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,14 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="com.example.badminton_booking_app"
+                    android:host="oauth-callback" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,16 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>com.example.badminton_booking_app</string>
+                        </array>
+                </dict>
+        </array>
 </dict>
 </plist>

--- a/lib/pages/auth/auth_manager.dart
+++ b/lib/pages/auth/auth_manager.dart
@@ -38,6 +38,10 @@ class AuthManager with ChangeNotifier {
     return _authService.login(email, password);
   }
 
+  Future<User> loginWithGoogle() {
+    return _authService.loginWithGoogle();
+  }
+
   Future<bool> tryAutoLogin() async {
     final user = await _authService.getUserFromStore();
     if (user != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   shared_preferences: ^2.2.3
   provider: ^6.1.2
   flutter_dotenv: ^6.0.0
+  flutter_web_auth_2: ^2.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add the flutter_web_auth_2 dependency and implement a PocketBase Google OAuth login flow in the auth service
- expose the Google login action through the auth manager and refresh the login screen UI to handle asynchronous Google sign-in
- configure Android and iOS URL scheme callbacks required for Google OAuth redirects

## Testing
- `flutter pub get` *(fails: Flutter is not available in the execution environment)*
- `dart analyze` *(fails: Dart SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6672681c832bbbbc66b3a5426246