### PR TITLE
Add provider-backed court list to court page

### DIFF
--- a/lib/components/my_court.dart
+++ b/lib/components/my_court.dart
@@ -1,8 +1,11 @@
+import 'package:badminton_booking_app/models/court.dart';
 import 'package:badminton_booking_app/pages/court/court_detail.dart';
 import 'package:flutter/material.dart';
 
 class MyCourt extends StatefulWidget {
-  const MyCourt({super.key});
+  const MyCourt({super.key, required this.court});
+
+  final Court court;
 
   @override
   State<MyCourt> createState() => _MyCourtState();
@@ -21,6 +24,19 @@ class _MyCourtState extends State<MyCourt> {
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
     final colorSchema = Theme.of(context).colorScheme;
+    final court = widget.court;
+    final courtName = court.name.isNotEmpty
+        ? court.name
+        : 'Sân không tên';
+    final location = court.location.isNotEmpty
+        ? court.location
+        : 'Địa chỉ chưa cập nhật';
+    final quantityText = court.courtQuantity > 0
+        ? '${court.courtQuantity} sân'
+        : 'Chưa rõ số sân';
+    final courtCode = court.code.isNotEmpty
+        ? court.code
+        : 'Chưa có mã';
 
     return GestureDetector(
       onTap: () {
@@ -49,12 +65,7 @@ class _MyCourtState extends State<MyCourt> {
                         topLeft: Radius.circular(20),
                         topRight: Radius.circular(20),
                       ),
-                      child: Image.asset(
-                        'assets/images/court_cover.jpg',
-                        width: screenWidth,
-                        height: 150,
-                        fit: BoxFit.cover,
-                      ),
+                      child: _buildCoverImage(screenWidth),
                     ),
                     Positioned(
                       top: 12,
@@ -88,10 +99,14 @@ class _MyCourtState extends State<MyCourt> {
                         height: 56,
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(50),
-                          image: const DecorationImage(
-                            image:
-                                AssetImage("assets/images/badminton_logo.jpg"),
-                            fit: BoxFit.contain,
+                          image: DecorationImage(
+                            image: court.coverImageUrl != null
+                                ? NetworkImage(court.coverImageUrl!)
+                                    as ImageProvider
+                                : const AssetImage(
+                                    "assets/images/badminton_logo.jpg",
+                                  ),
+                            fit: BoxFit.cover,
                           ),
                         ),
                       ),
@@ -100,9 +115,9 @@ class _MyCourtState extends State<MyCourt> {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            const Text(
-                              "CÂU LẠC BỘ PICKLEBALL C-CLUB",
-                              style: TextStyle(
+                            Text(
+                              courtName,
+                              style: const TextStyle(
                                 color: Color(0xFF0E5A3A),
                                 fontWeight: FontWeight.w800,
                                 fontSize: 16,
@@ -112,21 +127,11 @@ class _MyCourtState extends State<MyCourt> {
                               overflow: TextOverflow.ellipsis,
                             ),
                             Row(
-                              children: const [
-                                Text(
-                                  "(606.8m)",
-                                  style: TextStyle(
-                                    color: Color(0xFFE76E37),
-                                    fontWeight: FontWeight.w600,
-                                    fontSize: 14,
-                                    height: 1.2,
-                                  ),
-                                ),
-                                SizedBox(width: 6),
+                              children: [
                                 Expanded(
                                   child: Text(
-                                    "146H1 đường Trần Văn Hoài, P. Xuân Khánh, TP. Nha Trang",
-                                    style: TextStyle(
+                                    location,
+                                    style: const TextStyle(
                                       color: Colors.black54,
                                       fontWeight: FontWeight.w600,
                                       fontSize: 14,
@@ -140,23 +145,23 @@ class _MyCourtState extends State<MyCourt> {
                             ),
                             Row(
                               children: [
-                                const Icon(Icons.schedule,
+                                const Icon(Icons.sports_tennis,
                                     size: 16, color: Colors.black87),
                                 const SizedBox(width: 6),
-                                const Text(
-                                  "05:00 - 22:00",
-                                  style: TextStyle(
+                                Text(
+                                  quantityText,
+                                  style: const TextStyle(
                                     color: Colors.black87,
                                     fontWeight: FontWeight.w700,
                                     fontSize: 14,
                                   ),
                                 ),
                                 const SizedBox(width: 14),
-                                const Icon(Icons.call, size: 16),
+                                const Icon(Icons.qr_code, size: 16),
                                 const SizedBox(width: 6),
                                 Expanded(
                                   child: Text(
-                                    "0292 2246 777",
+                                    courtCode,
                                     style: TextStyle(
                                       color: colorSchema.primary,
                                       fontWeight: FontWeight.w700,
@@ -199,6 +204,41 @@ class _MyCourtState extends State<MyCourt> {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildCoverImage(double screenWidth) {
+    final court = widget.court;
+    final placeholder = Image.asset(
+      'assets/images/court_cover.jpg',
+      width: screenWidth,
+      height: 150,
+      fit: BoxFit.cover,
+    );
+
+    final coverImageUrl = court.coverImageUrl;
+    if (coverImageUrl == null || coverImageUrl.isEmpty) {
+      return placeholder;
+    }
+
+    return Image.network(
+      coverImageUrl,
+      width: screenWidth,
+      height: 150,
+      fit: BoxFit.cover,
+      loadingBuilder: (context, child, loadingProgress) {
+        if (loadingProgress == null) return child;
+        return SizedBox(
+          width: screenWidth,
+          height: 150,
+          child: const Center(
+            child: CircularProgressIndicator(),
+          ),
+        );
+      },
+      errorBuilder: (context, error, stackTrace) {
+        return placeholder;
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:flutter/material.dart';
@@ -28,6 +29,9 @@ class MyApp extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create: (ctx) => UserManager(),
+        ),
+        ChangeNotifierProvider(
+          create: (ctx) => CourtManager(),
         ),
       ],
       child: Consumer<AuthManager>(

--- a/lib/pages/court/court_manager.dart
+++ b/lib/pages/court/court_manager.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+
+import '../../models/court.dart';
+import '../../services/court_service.dart';
+
+class CourtManager with ChangeNotifier {
+  CourtManager({CourtService? courtService})
+      : _courtService = courtService ?? CourtService() {
+    loadCourts();
+  }
+
+  final CourtService _courtService;
+
+  bool _isLoading = false;
+  String? _errorMessage;
+  List<Court> _courts = const [];
+
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+  List<Court> get courts => List.unmodifiable(_courts);
+
+  Future<void> loadCourts({bool forceRefresh = false}) async {
+    if (_isLoading) return;
+    if (_courts.isNotEmpty && !forceRefresh) return;
+
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final result = await _courtService.listCourts();
+      _courts = result;
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        print('Failed to load courts: $error');
+        print(stackTrace);
+      }
+      _errorMessage = error.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refresh() {
+    return loadCourts(forceRefresh: true);
+  }
+}

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -1,12 +1,28 @@
 import 'package:badminton_booking_app/components/my_court.dart';
+import 'package:badminton_booking_app/models/court.dart';
+import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class CourtPage extends StatelessWidget {
   CourtPage({super.key});
-  final TextEditingController controller = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
+    final courtManager = context.watch<CourtManager>();
+
+    Widget body;
+
+    if (courtManager.isLoading) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (courtManager.errorMessage != null) {
+      body = _buildErrorState(context, courtManager.errorMessage!);
+    } else if (courtManager.courts.isEmpty) {
+      body = _buildEmptyState(context);
+    } else {
+      body = _buildContent(context, courtManager.courts);
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -20,104 +36,139 @@ class CourtPage extends StatelessWidget {
         centerTitle: true,
       ),
       backgroundColor: Theme.of(context).colorScheme.surface,
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+      body: body,
+    );
+  }
+
+  Widget _buildContent(BuildContext context, List<Court> courts) {
+    final recommended = courts.take(5).toList();
+    final remainingAfterRecommended = courts.skip(recommended.length).toList();
+    final nearby = remainingAfterRecommended.take(5).toList();
+    final popular = remainingAfterRecommended.skip(nearby.length).toList();
+
+    final sections = <Widget>[
+      const SizedBox(height: 10),
+      _buildCourtSection(context, 'Có Thể Bạn Sẽ Thích', recommended),
+    ];
+
+    if (nearby.isNotEmpty) {
+      sections.add(_buildCourtSection(context, 'Sân Gần Bạn', nearby));
+    }
+
+    if (popular.isNotEmpty) {
+      sections.add(_buildCourtSection(context, 'Sân Phổ Biến', popular));
+    }
+
+    sections.add(const SizedBox(height: 100));
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: sections,
+      ),
+    );
+  }
+
+  Widget _buildCourtSection(
+    BuildContext context,
+    String title,
+    List<Court> courts,
+  ) {
+    if (courts.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
           children: [
-            const SizedBox(height: 10),
-            Row(
-              children: [
-                Container(
-                  width: 5,
-                  height: 24,
-                  color: Theme.of(context).colorScheme.primary,
-                  margin: const EdgeInsets.only(
-                    left: 12,
-                    right: 8,
-                  ),
-                ),
-                Text(
-                  "Có Thể Bạn Sẽ Thích",
-                  style: const TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.w800,
-                  ),
-                ),
-              ],
-            ),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                children: [
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                ],
+            Container(
+              width: 5,
+              height: 24,
+              color: Theme.of(context).colorScheme.primary,
+              margin: const EdgeInsets.only(
+                left: 12,
+                right: 8,
               ),
             ),
-            const SizedBox(height: 10),
-            Row(
-              children: [
-                Container(
-                  width: 5,
-                  height: 24,
-                  color: Theme.of(context).colorScheme.primary,
-                  margin: const EdgeInsets.only(left: 12, right: 8),
-                ),
-                Text(
-                  "Sân Gần Bạn",
-                  style: const TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.w800,
-                  ),
-                ),
-              ],
-            ),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                children: [
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                ],
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w800,
               ),
             ),
-            const SizedBox(height: 10),
-            Row(
-              children: [
-                Container(
-                  width: 5,
-                  height: 24,
-                  color: Theme.of(context).colorScheme.primary,
-                  margin: const EdgeInsets.only(left: 12, right: 8),
-                ),
-                Text(
-                  "Sân Phổ Biến",
-                  style: const TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.w800,
-                  ),
-                ),
-              ],
+          ],
+        ),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: courts
+                .map((court) => MyCourt(court: court))
+                .toList(growable: false),
+          ),
+        ),
+        const SizedBox(height: 10),
+      ],
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context, String errorMessage) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
+            const SizedBox(height: 16),
+            Text(
+              'Không thể tải danh sách sân',
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
             ),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                children: [
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                  MyCourt(),
-                ],
-              ),
+            const SizedBox(height: 8),
+            Text(
+              errorMessage,
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
             ),
-            const SizedBox(height: 100),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: () =>
+                  context.read<CourtManager>().refresh(),
+              icon: const Icon(Icons.refresh),
+              label: const Text('Thử lại'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sports_tennis,
+              size: 48,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Hiện chưa có sân nào',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Hãy quay lại sau nhé!',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add a provider-based `CourtManager` to load courts from the service layer
- register the court manager with the app's `MultiProvider`
- update court UI widgets to render real court data with loading, error, and empty states

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f8c402f8832bbce01beb417a8635