### PR TITLE
Add dynamic court detail retrieval from PocketBase

### DIFF
--- a/lib/components/my_court.dart
+++ b/lib/components/my_court.dart
@@ -42,7 +42,12 @@ class _MyCourtState extends State<MyCourt> {
       onTap: () {
         Navigator.push(
           context,
-          MaterialPageRoute(builder: (context) => CourtDetail()),
+          MaterialPageRoute(
+            builder: (context) => CourtDetail(
+              courtId: court.id,
+              initialCourt: court,
+            ),
+          ),
         );
       },
       child: Padding(

--- a/lib/models/court_detail.dart
+++ b/lib/models/court_detail.dart
@@ -1,0 +1,143 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import 'court.dart';
+
+class CourtDetailData {
+  final Court court;
+  final List<String> images;
+  final List<CourtOpeningHour> openingHours;
+  final List<CourtPricing> pricing;
+  final List<CourtUnit> units;
+
+  const CourtDetailData({
+    required this.court,
+    this.images = const [],
+    this.openingHours = const [],
+    this.pricing = const [],
+    this.units = const [],
+  });
+}
+
+class CourtOpeningHour {
+  final String id;
+  final String openTime;
+  final String closeTime;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const CourtOpeningHour({
+    required this.id,
+    required this.openTime,
+    required this.closeTime,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory CourtOpeningHour.fromRecord(RecordModel record) {
+    final data = record.data;
+    return CourtOpeningHour(
+      id: record.id,
+      openTime: (data['open_time'] as String?)?.trim() ?? '',
+      closeTime: (data['close_time'] as String?)?.trim() ?? '',
+      createdAt: _parseDate(data['created']),
+      updatedAt: _parseDate(data['updated']),
+    );
+  }
+}
+
+class CourtPricing {
+  final String id;
+  final String? timeFrom;
+  final String? timeTo;
+  final int? pricePerHour;
+  final String? priceLabel;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const CourtPricing({
+    required this.id,
+    this.timeFrom,
+    this.timeTo,
+    this.pricePerHour,
+    this.priceLabel,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory CourtPricing.fromRecord(RecordModel record) {
+    final data = record.data;
+    final rawPrice = data['price_per_hour'];
+    return CourtPricing(
+      id: record.id,
+      timeFrom: (data['time_from'] as String?)?.trim(),
+      timeTo: (data['time_to'] as String?)?.trim(),
+      pricePerHour: _parsePrice(rawPrice),
+      priceLabel: _parsePrice(rawPrice) == null
+          ? (rawPrice is String && rawPrice.trim().isNotEmpty
+              ? rawPrice.trim()
+              : null)
+          : null,
+      createdAt: _parseDate(data['created']),
+      updatedAt: _parseDate(data['updated']),
+    );
+  }
+}
+
+class CourtUnit {
+  final String id;
+  final String label;
+  final bool isActive;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const CourtUnit({
+    required this.id,
+    required this.label,
+    required this.isActive,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory CourtUnit.fromRecord(RecordModel record) {
+    final data = record.data;
+    return CourtUnit(
+      id: record.id,
+      label: (data['label'] as String?)?.trim() ?? '',
+      isActive: _parseBool(data['is_active']),
+      createdAt: _parseDate(data['created']),
+      updatedAt: _parseDate(data['updated']),
+    );
+  }
+}
+
+bool _parseBool(dynamic value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    final v = value.trim().toLowerCase();
+    if (v == 'true') return true;
+    if (v == 'false') return false;
+    final parsed = num.tryParse(v);
+    if (parsed != null) return parsed != 0;
+  }
+  return false;
+}
+
+DateTime? _parseDate(dynamic value) {
+  if (value is DateTime) return value;
+  if (value is String && value.isNotEmpty) {
+    return DateTime.tryParse(value);
+  }
+  return null;
+}
+
+int? _parsePrice(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) {
+    final cleaned = value.replaceAll(RegExp(r'[^0-9]'), '');
+    if (cleaned.isEmpty) return null;
+    return int.tryParse(cleaned);
+  }
+  return null;
+}

--- a/lib/pages/court/court_detail.dart
+++ b/lib/pages/court/court_detail.dart
@@ -1,18 +1,73 @@
+import 'package:badminton_booking_app/models/court.dart';
+import 'package:badminton_booking_app/models/court_detail.dart';
 import 'package:badminton_booking_app/pages/court/tabs/image_tab.dart';
 import 'package:badminton_booking_app/pages/court/tabs/review_tab.dart';
 import 'package:badminton_booking_app/pages/court/tabs/rule_tab.dart';
 import 'package:badminton_booking_app/pages/court/tabs/service_tab.dart';
+import 'package:badminton_booking_app/services/court_service.dart';
 import 'package:flutter/material.dart';
 
 class CourtDetail extends StatefulWidget {
-  const CourtDetail({super.key});
+  final String courtId;
+  final Court? initialCourt;
+
+  const CourtDetail({
+    super.key,
+    required this.courtId,
+    this.initialCourt,
+  });
 
   @override
   State<CourtDetail> createState() => _CourtDetailState();
 }
 
 class _CourtDetailState extends State<CourtDetail> {
+  final CourtService _courtService = CourtService();
+
   bool _isFavorite = false;
+  bool _isLoading = true;
+  String? _errorMessage;
+  Court? _court;
+  List<String> _images = const [];
+  List<CourtOpeningHour> _openingHours = const [];
+  List<CourtPricing> _pricing = const [];
+  List<CourtUnit> _units = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _court = widget.initialCourt;
+    _loadDetails();
+  }
+
+  Future<void> _loadDetails() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final details = await _courtService.getCourtDetails(widget.courtId);
+      if (!mounted) return;
+      setState(() {
+        _court = details.court;
+        _images = details.images;
+        _openingHours = details.openingHours;
+        _pricing = details.pricing;
+        _units = details.units;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      final message = e.toString();
+      setState(() {
+        _errorMessage = message.startsWith('Exception: ')
+            ? message.replaceFirst('Exception: ', '')
+            : message;
+        _isLoading = false;
+      });
+    }
+  }
 
   void _toggleFavorite() {
     setState(() {
@@ -25,165 +80,196 @@ class _CourtDetailState extends State<CourtDetail> {
     final cs = Theme.of(context).colorScheme;
     final screenWidth = MediaQuery.of(context).size.width;
 
+    if (_court == null && _isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_court == null) {
+      return _buildErrorView(cs);
+    }
+
+    final court = _court!;
+    final heroImage = _images.isNotEmpty
+        ? _images.first
+        : (court.coverImageUrl != null && court.coverImageUrl!.isNotEmpty
+            ? court.coverImageUrl!
+            : null);
+
     return Scaffold(
-      body: Container(
-        child: Stack(
-          children: [
-            Container(
-              padding: EdgeInsets.only(),
-              height: MediaQuery.of(context).size.height / 2,
-              width: screenWidth,
-              decoration: BoxDecoration(
-                image: DecorationImage(
-                  image: AssetImage(
-                    'assets/images/court_cover.jpg',
-                  ),
-                  fit: BoxFit.contain,
-                  alignment: Alignment.topCenter,
+      body: Stack(
+        children: [
+          _buildHeroBackground(context, screenWidth, heroImage),
+          Positioned(
+            top: MediaQuery.of(context).padding.top,
+            left: 16,
+            right: 16,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                _circleBtn(
+                  icon: Icons.arrow_back,
+                  onTap: () => Navigator.pop(context),
+                  cs: cs,
                 ),
-              ),
-            ),
-            Positioned(
-              top: MediaQuery.of(context).padding.top,
-              left: 16,
-              right: 16,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  _circleBtn(
-                    icon: Icons.arrow_back,
-                    onTap: () {
-                      Navigator.pop(context);
-                    },
-                    cs: cs,
-                  ),
-                  Row(
-                    children: [
-                      _circleBtn(
-                        icon: _isFavorite
-                            ? Icons.favorite
-                            : Icons.favorite_border,
-                        onTap: _toggleFavorite,
-                        cs: cs,
-                      ),
-                      const SizedBox(width: 8),
-                      ElevatedButton(
-                        onPressed: () {},
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.grey.shade400,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(24),
-                          ),
+                Row(
+                  children: [
+                    _circleBtn(
+                      icon:
+                          _isFavorite ? Icons.favorite : Icons.favorite_border,
+                      onTap: _toggleFavorite,
+                      cs: cs,
+                    ),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      onPressed: () {},
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.grey.shade400,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(24),
                         ),
-                        child: const Text("Đặt lịch"),
-                      )
+                      ),
+                      child: const Text('Đặt lịch'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          Container(
+            padding:
+                const EdgeInsets.only(left: 20, top: 40, right: 20, bottom: 40),
+            margin: EdgeInsets.only(
+              top: MediaQuery.of(context).size.height / 4,
+            ),
+            height: MediaQuery.of(context).size.height,
+            width: screenWidth,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.only(top: screenWidth / 4.5),
+            child: _infoTab(cs, court),
+          ),
+          Container(
+            padding: EdgeInsets.only(
+              top: screenWidth - 65,
+            ),
+            child: DefaultTabController(
+              length: 4,
+              child: Column(
+                children: [
+                  TabBar(
+                    labelColor: cs.primary,
+                    unselectedLabelColor: cs.onSurface,
+                    indicatorColor: cs.primary,
+                    isScrollable: true,
+                    padding: const EdgeInsets.only(left: 5),
+                    tabAlignment: TabAlignment.start,
+                    tabs: const [
+                      Tab(text: 'Dịch vụ'),
+                      Tab(text: 'Hình ảnh'),
+                      Tab(text: 'Điều khoản & quy định'),
+                      Tab(text: 'Đánh giá'),
                     ],
+                  ),
+                  Expanded(
+                    child: TabBarView(
+                      children: [
+                        PricingTableMini(
+                          items: _buildServicePrices(),
+                          units: _units
+                              .where((unit) => unit.isActive)
+                              .map((unit) => unit.label)
+                              .where((label) => label.isNotEmpty)
+                              .toList(growable: false),
+                        ),
+                        CourtImageGallery(images: _images),
+                        Rules(items: const [
+                          'Đặt cọc 50% cho giờ cao điểm',
+                          'Hủy trước 6h hoàn 100%, sau đó không hoàn',
+                          'Đi giày cầu lông, không hút thuốc trong sân',
+                          'Giữ vệ sinh chung, không xả rác bừa bãi',
+                          'Tuân thủ quy định của sân và nhân viên sân',
+                          'Không mang đồ ăn thức uống có cồn vào sân',
+                          'Giữ gìn tài sản cá nhân, sân không chịu trách nhiệm',
+                        ]),
+                        const ReviewTab(initialReviews: []),
+                      ],
+                    ),
                   ),
                 ],
               ),
             ),
-            Container(
-              padding:
-                  EdgeInsets.only(left: 20, top: 40, right: 20, bottom: 40),
-              margin: EdgeInsets.only(
-                top: MediaQuery.of(context).size.height / 4,
-              ),
-              height: MediaQuery.of(context).size.height,
-              width: screenWidth,
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface,
-              ),
-            ),
-            Padding(
-              padding: EdgeInsets.only(top: screenWidth / 4.5),
-              child: _infoTab(cs),
-            ),
-            Container(
-              padding: EdgeInsets.only(
-                top: screenWidth - 65,
-              ),
-              child: DefaultTabController(
-                length: 4,
-                child: Column(
-                  children: [
-                    TabBar(
-                      labelColor: cs.primary,
-                      unselectedLabelColor: cs.onSurface,
-                      indicatorColor: cs.primary,
-                      isScrollable: true,
-                      padding: EdgeInsets.only(left: 5),
-                      tabAlignment: TabAlignment.start,
-                      tabs: const [
-                        Tab(text: "Dịch vụ"),
-                        Tab(text: "Hình ảnh"),
-                        Tab(text: "Điều khoản & quy định"),
-                        Tab(text: "Đánh giá"),
-                      ],
-                    ),
-                    Expanded(
-                      child: TabBarView(
-                        children: [
-                          PricingTableMini(
-                            items: const [
-                              ServicePrice(
-                                  name: "Thuê sân đơn",
-                                  unit: "giờ",
-                                  price: 60000),
-                              ServicePrice(
-                                  name: "Thuê sân (cao điểm)",
-                                  unit: "giờ",
-                                  price: 150000,
-                                  isPeak: true,
-                                  note: "17:00–21:00 T2–T6"),
-                              ServicePrice(
-                                  name: "Mượn vợt",
-                                  unit: "cây",
-                                  price: 20000,
-                                  note: "Kèm 1 quả cầu"),
-                              ServicePrice(
-                                  name: "Thuê giày", unit: "đôi", price: 30000),
-                              ServicePrice(
-                                  name: "Mua cầu lông",
-                                  unit: "ống",
-                                  price: 320000,
-                                  note: "Loại trung cấp"),
-                            ],
-                          ),
-                          CourtImageGallery(
-                            images: const [
-                              // Có thể dùng cả asset lẫn URL
-                              'assets/images/court_cover.jpg',
-                              'assets/images/badminton_logo.jpg',
-                              'https://picsum.photos/seed/court1/1200/800',
-                              'https://picsum.photos/seed/court2/1200/800',
-                              'https://picsum.photos/seed/court3/1200/800',
-                              'https://picsum.photos/seed/court4/1200/800',
-                            ],
-                          ),
-                          Rules(items: [
-                            "Đặt cọc 50% cho giờ cao điểm",
-                            "Hủy trước 6h hoàn 100%, sau đó không hoàn",
-                            "Đi giày cầu lông, không hút thuốc trong sân",
-                            "Giữ vệ sinh chung, không xả rác bừa bãi",
-                            "Tuân thủ quy định của sân và nhân viên sân",
-                            "Không mang đồ ăn thức uống có cồn vào sân",
-                            "Giữ gìn tài sản cá nhân, sân không chịu trách nhiệm",
-                          ]),
-                          ReviewTab(initialReviews: []),
-                        ],
-                      ),
-                    ),
-                  ],
+          ),
+          if (_errorMessage != null && !_isLoading && _court != null)
+            _buildWarningBanner(cs),
+          if (_isLoading)
+            Positioned.fill(
+              child: IgnorePointer(
+                ignoring: true,
+                child: Container(
+                  color: Colors.black.withOpacity(0.05),
+                  child: const Center(child: CircularProgressIndicator()),
                 ),
               ),
             ),
-          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeroBackground(
+    BuildContext context,
+    double screenWidth,
+    String? heroImage,
+  ) {
+    ImageProvider imageProvider;
+    if (heroImage != null && heroImage.isNotEmpty) {
+      imageProvider = heroImage.startsWith('http')
+          ? NetworkImage(heroImage)
+          : AssetImage(heroImage) as ImageProvider;
+    } else {
+      imageProvider =
+          const AssetImage('assets/images/court_cover.jpg') as ImageProvider;
+    }
+
+    return Container(
+      height: MediaQuery.of(context).size.height / 2,
+      width: screenWidth,
+      decoration: BoxDecoration(
+        image: DecorationImage(
+          image: imageProvider,
+          fit: BoxFit.cover,
+          alignment: Alignment.topCenter,
         ),
       ),
     );
   }
 
-  Widget _infoTab(ColorScheme cs) {
+  Widget _infoTab(ColorScheme cs, Court court) {
+    final location = court.location.isNotEmpty
+        ? court.location
+        : 'Chưa cập nhật vị trí';
+    final openingHoursText = _openingHours.isEmpty
+        ? 'Chưa cập nhật'
+        : _openingHours
+            .map((hour) => '${hour.openTime} - ${hour.closeTime}')
+            .join('\n');
+
+    final chips = <Widget>[];
+    if (court.code.isNotEmpty) {
+      chips.add(_buildInfoChip(cs, 'Mã: ${court.code}'));
+    }
+    chips.add(_buildInfoChip(cs, '${court.courtQuantity} sân'));
+    chips.add(_buildInfoChip(
+      cs,
+      court.isActive ? 'Đang hoạt động' : 'Tạm ngưng',
+      highlight: court.isActive,
+    ));
+
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
       child: Material(
@@ -197,56 +283,248 @@ class _CourtDetailState extends State<CourtDetail> {
             border: Border.all(color: cs.outline, width: 1),
           ),
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               ListTile(
-                leading: const CircleAvatar(
-                  backgroundImage:
-                      AssetImage('assets/images/badminton_logo.jpg'),
+                contentPadding: EdgeInsets.zero,
+                leading: CircleAvatar(
+                  backgroundImage: court.coverImageUrl != null &&
+                          court.coverImageUrl!.isNotEmpty
+                      ? NetworkImage(court.coverImageUrl!)
+                      : const AssetImage('assets/images/badminton_logo.jpg')
+                          as ImageProvider,
                   radius: 28,
                 ),
-                title: const Text("Minh Nghĩa Badminton",
-                    style: TextStyle(fontWeight: FontWeight.bold)),
-                subtitle: Container(
-                  margin: const EdgeInsets.only(top: 6),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFE7F5EE),
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: const Text("Cầu lông",
-                      style: TextStyle(color: Color(0xFF0E5A3A))),
+                title: Text(
+                  court.name.isNotEmpty
+                      ? court.name
+                      : 'Sân chưa đặt tên',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: chips,
+                    ),
+                    if (court.description != null &&
+                        court.description!.trim().isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        court.description!,
+                        style: TextStyle(
+                          color: cs.onSurface.withOpacity(0.75),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
               ),
               const Divider(),
               Row(
-                children: const [
-                  Icon(Icons.place, size: 20),
-                  SizedBox(width: 6),
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.place, size: 20),
+                  const SizedBox(width: 6),
+                  Expanded(child: Text(location)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.schedule, size: 20),
+                  const SizedBox(width: 6),
+                  Expanded(child: Text(openingHoursText)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.call, size: 20),
+                  const SizedBox(width: 6),
                   Expanded(
                     child: Text(
-                        "55D Đ. Trần Nam Phú, Xuân Khánh, Ninh Kiều, Cần Thơ"),
+                      'Liên hệ quản lý sân để biết thêm thông tin.',
+                      style: TextStyle(
+                        color: cs.onSurface.withOpacity(0.7),
+                      ),
+                    ),
                   ),
                 ],
               ),
-              const SizedBox(height: 12),
-              Row(
-                children: const [
-                  Icon(Icons.schedule, size: 20),
-                  SizedBox(width: 6),
-                  Text("05:00 - 22:00"),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: const [
-                  Icon(Icons.call, size: 20),
-                  SizedBox(width: 6),
-                  Text(
-                    "0329672505",
-                    style: TextStyle(color: Colors.blue),
+              if (_units.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                Text(
+                  'Các sân hiện có',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: cs.onSurface,
                   ),
-                ],
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: _units
+                      .map((unit) => _buildUnitChip(cs, unit))
+                      .toList(growable: false),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<ServicePrice> _buildServicePrices() {
+    if (_pricing.isEmpty) return const [];
+
+    return _pricing
+        .map(
+          (pricing) => ServicePrice(
+            name: _buildPricingName(pricing),
+            unit: 'giờ',
+            price: pricing.pricePerHour,
+            note: pricing.priceLabel,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  String _buildPricingName(CourtPricing pricing) {
+    final from = pricing.timeFrom;
+    final to = pricing.timeTo;
+    if (from != null && from.isNotEmpty && to != null && to.isNotEmpty) {
+      return 'Khung giờ $from - $to';
+    }
+    if (from != null && from.isNotEmpty) {
+      return 'Từ $from';
+    }
+    if (to != null && to.isNotEmpty) {
+      return 'Đến $to';
+    }
+    return 'Giá thuê theo giờ';
+  }
+
+  Widget _buildInfoChip(ColorScheme cs, String label, {bool highlight = true}) {
+    final backgroundColor = highlight
+        ? cs.primary.withOpacity(0.12)
+        : cs.onSurface.withOpacity(0.08);
+    final borderColor = highlight
+        ? cs.primary.withOpacity(0.2)
+        : cs.onSurface.withOpacity(0.12);
+    final textColor = highlight
+        ? cs.primary
+        : cs.onSurface.withOpacity(0.75);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: borderColor),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: textColor,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUnitChip(ColorScheme cs, CourtUnit unit) {
+    final active = unit.isActive;
+    return Chip(
+      avatar: Icon(
+        active ? Icons.check_circle : Icons.cancel,
+        size: 16,
+        color: active ? cs.primary : cs.onSurface.withOpacity(0.6),
+      ),
+      label: Text(unit.label),
+      backgroundColor:
+          active ? cs.primary.withOpacity(0.12) : cs.onSurface.withOpacity(0.08),
+      labelStyle: TextStyle(
+        color: active ? cs.primary : cs.onSurface.withOpacity(0.75),
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  Widget _buildWarningBanner(ColorScheme cs) {
+    return Positioned(
+      top: MediaQuery.of(context).padding.top + 72,
+      left: 16,
+      right: 16,
+      child: Material(
+        elevation: 2,
+        borderRadius: BorderRadius.circular(12),
+        color: cs.errorContainer.withOpacity(0.9),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              Icon(Icons.info_outline, color: cs.onErrorContainer),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  _errorMessage ?? '',
+                  style: TextStyle(color: cs.onErrorContainer),
+                ),
+              ),
+              IconButton(
+                icon: Icon(Icons.close, color: cs.onErrorContainer),
+                onPressed: () {
+                  setState(() {
+                    _errorMessage = null;
+                  });
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorView(ColorScheme cs) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Thông tin sân'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
+              const SizedBox(height: 16),
+              Text(
+                'Không thể tải thông tin sân',
+                style: Theme.of(context).textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+              if (_errorMessage != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  _errorMessage!,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+              const SizedBox(height: 16),
+              ElevatedButton.icon(
+                onPressed: _loadDetails,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Thử lại'),
               ),
             ],
           ),

--- a/lib/pages/court/tabs/service_tab.dart
+++ b/lib/pages/court/tabs/service_tab.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 class ServicePrice {
   final String name; // Tên dịch vụ: "Thuê sân đơn"
   final String unit; // Đơn vị: "giờ", "buổi", "set", ...
-  final int price; // Giá: 120000
+  final int? price; // Giá: 120000
   final bool isPeak; // Có phải giờ cao điểm?
   final String? note; // Ghi chú (tuỳ chọn)
 
@@ -20,11 +20,13 @@ class ServicePrice {
 class PricingTableMini extends StatelessWidget {
   final String title;
   final List<ServicePrice> items;
+  final List<String> units;
 
   const PricingTableMini({
     super.key,
     this.title = "Bảng giá dịch vụ",
     required this.items,
+    this.units = const [],
   });
 
   @override
@@ -44,6 +46,29 @@ class PricingTableMini extends StatelessWidget {
             style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
         const SizedBox(height: 12),
 
+        if (units.isNotEmpty) ...[
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: units
+                  .map(
+                    (unit) => Chip(
+                      label: Text(unit),
+                      backgroundColor: cs.primary.withOpacity(0.12),
+                      labelStyle: TextStyle(
+                        color: cs.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+          const SizedBox(height: 12),
+        ],
+
         // Khung bảng
         Container(
           decoration: BoxDecoration(
@@ -57,7 +82,29 @@ class PricingTableMini extends StatelessWidget {
               _headerRow(context),
 
               // Dòng dữ liệu
-              for (final sp in sorted) _priceRow(context, sp),
+              if (sorted.isEmpty)
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+                  child: Row(
+                    children: [
+                      Icon(Icons.info_outline,
+                          size: 18, color: cs.onSurface.withOpacity(0.6)),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          'Sân chưa cập nhật bảng giá.',
+                          style: TextStyle(
+                            color: cs.onSurface.withOpacity(0.75),
+                            fontStyle: FontStyle.italic,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              else
+                for (final sp in sorted) _priceRow(context, sp),
             ],
           ),
         ),
@@ -149,7 +196,7 @@ class PricingTableMini extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               Text(
-                formatVND(sp.price),
+                sp.price != null ? formatVND(sp.price!) : 'Liên hệ',
                 style: TextStyle(
                   fontWeight: FontWeight.w700,
                   color: cs.primary,

--- a/lib/services/court_service.dart
+++ b/lib/services/court_service.dart
@@ -1,6 +1,9 @@
+import 'dart:collection';
+
 import 'package:pocketbase/pocketbase.dart';
 
 import '../models/court.dart';
+import '../models/court_detail.dart';
 import 'pocketbase_client.dart';
 
 class CourtService {
@@ -29,6 +32,57 @@ class CourtService {
     return _mapRecordToCourt(pb, record);
   }
 
+  Future<CourtDetailData> getCourtDetails(String id) async {
+    final pb = await getPocketbaseInstance();
+
+    try {
+      final courtRecord = await pb.collection(collection).getOne(id);
+      final court = _mapRecordToCourt(pb, courtRecord);
+
+      final imagesRecords = await pb.collection('court_images').getFullList(
+            filter: 'court_id = "$id"',
+            sort: '-created',
+          );
+      final openingHourRecords = await pb
+          .collection('court_opening_hours')
+          .getFullList(
+            filter: 'court_id = "$id"',
+            sort: 'open_time',
+          );
+      final pricingRecords = await pb.collection('court_pricing').getFullList(
+            filter: 'court_id = "$id"',
+            sort: 'time_from',
+          );
+      final unitRecords = await pb.collection('court_units').getFullList(
+            filter: 'court_id = "$id"',
+            sort: 'label',
+          );
+
+      final imageUrls = _extractImageUrls(
+        pb,
+        courtRecord,
+        imagesRecords,
+        court.coverImageUrl,
+      );
+
+      return CourtDetailData(
+        court: court,
+        images: imageUrls,
+        openingHours: openingHourRecords
+            .map(CourtOpeningHour.fromRecord)
+            .toList(growable: false),
+        pricing: pricingRecords
+            .map(CourtPricing.fromRecord)
+            .toList(growable: false),
+        units: unitRecords
+            .map(CourtUnit.fromRecord)
+            .toList(growable: false),
+      );
+    } catch (e) {
+      throw Exception('Không thể tải thông tin sân: $e');
+    }
+  }
+
   Court _mapRecordToCourt(PocketBase pb, RecordModel record) {
     final data = record.data;
     final coverImageField = data['cover_image'];
@@ -51,5 +105,44 @@ class CourtService {
       record,
       coverImageUrl: coverImageUrl,
     );
+  }
+
+  List<String> _extractImageUrls(
+    PocketBase pb,
+    RecordModel courtRecord,
+    List<RecordModel> imageRecords,
+    String? coverImageUrl,
+  ) {
+    final urls = LinkedHashSet<String>();
+
+    if (coverImageUrl != null && coverImageUrl.isNotEmpty) {
+      urls.add(coverImageUrl);
+    } else {
+      final coverImageField = courtRecord.data['cover_image'];
+      if (coverImageField is String && coverImageField.isNotEmpty) {
+        urls.add(pb.files.getUrl(courtRecord, coverImageField).toString());
+      } else if (coverImageField is List && coverImageField.isNotEmpty) {
+        for (final item in coverImageField) {
+          if (item is String && item.isNotEmpty) {
+            urls.add(pb.files.getUrl(courtRecord, item).toString());
+          }
+        }
+      }
+    }
+
+    for (final record in imageRecords) {
+      final field = record.data['image'];
+      if (field is String && field.isNotEmpty) {
+        urls.add(pb.files.getUrl(record, field).toString());
+      } else if (field is List) {
+        for (final item in field) {
+          if (item is String && item.isNotEmpty) {
+            urls.add(pb.files.getUrl(record, item).toString());
+          }
+        }
+      }
+    }
+
+    return urls.toList(growable: false);
   }
 }


### PR DESCRIPTION
## Summary
- add data models to represent detailed court information coming from PocketBase
- extend the court service and court card navigation so the detail screen fetches real data for images, hours, pricing, and units
- refresh the court detail UI and pricing table to render PocketBase data and handle empty states gracefully

## Testing
- not run (Flutter/Dart tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68da52a2ca2c832b9106614f25e06852