### PR TITLE
Add slot hold and approval workflow to booking UI

### DIFF
--- a/lib/components/my_court_time.dart
+++ b/lib/components/my_court_time.dart
@@ -1,7 +1,57 @@
 // lib/components/my_court_time.dart
+import 'package:badminton_booking_app/models/slot_reservation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'dart:ui' as ui;
+
+typedef SlotStateResolver = SlotCellState? Function(
+    int courtIndex, int slotIndex);
+
+class SlotCellState {
+  const SlotCellState({
+    required this.status,
+    this.holdUntil,
+    this.note,
+  });
+
+  final SlotReservationStatus status;
+  final DateTime? holdUntil;
+  final String? note;
+}
+
+Color slotStatusBackground(
+    SlotReservationStatus? status, ColorScheme _) {
+  switch (status) {
+    case SlotReservationStatus.holding:
+      return const Color(0xFFFFF3CD); // vàng nhạt
+    case SlotReservationStatus.awaitingApproval:
+      return const Color(0xFFD6E4FF); // xanh dương nhạt
+    case SlotReservationStatus.booked:
+      return const Color(0xFFFFCDD2); // đỏ nhạt
+    case SlotReservationStatus.locked:
+      return const Color(0xFFEEEEEE); // xám nhạt
+    case SlotReservationStatus.heldByOthers:
+      return const Color(0xFFFFEBEE);
+    case null:
+      return Colors.white;
+  }
+}
+
+Color slotStatusBorder(SlotReservationStatus? status, ColorScheme _) {
+  switch (status) {
+    case SlotReservationStatus.holding:
+      return const Color(0xFFFFB300);
+    case SlotReservationStatus.awaitingApproval:
+      return const Color(0xFF3F51B5);
+    case SlotReservationStatus.booked:
+    case SlotReservationStatus.heldByOthers:
+      return const Color(0xFFE53935);
+    case SlotReservationStatus.locked:
+      return const Color(0xFF9E9E9E);
+    case null:
+      return const Color(0xFFE0E0E0);
+  }
+}
 
 /// Header kiểu “timeline” với vạch giờ & vạch 30’:
 /// - Mỗi ô (grid) = 1 giờ.
@@ -18,6 +68,9 @@ class CourtTimeline extends StatefulWidget {
     this.leftColumnWidth = 90, // cột tên sân (cố định)
     this.headerHeight = 56.0,
     this.headerLeadingInset = 24.0, // khoảng trống trái của HEADER
+    this.slotStateResolver,
+    this.onSlotTap,
+    this.slotInnerPadding = const EdgeInsets.all(4),
   });
 
   final int startHour;
@@ -28,6 +81,9 @@ class CourtTimeline extends StatefulWidget {
   final double leftColumnWidth;
   final double headerHeight;
   final double headerLeadingInset;
+  final SlotStateResolver? slotStateResolver;
+  final void Function(int courtIndex, int slotIndex)? onSlotTap;
+  final EdgeInsets slotInnerPadding;
 
   @override
   State<CourtTimeline> createState() => _CourtTimelineState();
@@ -188,14 +244,29 @@ class _CourtTimelineState extends State<CourtTimeline> {
                           itemCount: widget.courts.length,
                           itemBuilder: (_, row) => SizedBox(
                             height: widget.rowHeight,
-                            child: CustomPaint(
-                              painter: _GridRowPainter(
-                                totalSlots: _slotCount,
-                                slotWidth: widget.slotWidth,
-                                lineColor: const Color(0x33000000),
-                                background: Colors.white,
-                              ),
-                              child: const SizedBox.expand(),
+                            child: Stack(
+                              fit: StackFit.expand,
+                              children: [
+                                CustomPaint(
+                                  painter: _GridRowPainter(
+                                    totalSlots: _slotCount,
+                                    slotWidth: widget.slotWidth,
+                                    lineColor: const Color(0x33000000),
+                                    background: Colors.white,
+                                  ),
+                                  child: const SizedBox.expand(),
+                                ),
+                                if (_totalWidth > 0)
+                                  _SlotOverlay(
+                                    row: row,
+                                    slotCount: _slotCount,
+                                    slotWidth: widget.slotWidth,
+                                    startHour: widget.startHour,
+                                    slotStateResolver: widget.slotStateResolver,
+                                    onSlotTap: widget.onSlotTap,
+                                    padding: widget.slotInnerPadding,
+                                  ),
+                              ],
                             ),
                           ),
                           separatorBuilder: (_, __) =>
@@ -210,6 +281,131 @@ class _CourtTimelineState extends State<CourtTimeline> {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _SlotOverlay extends StatelessWidget {
+  const _SlotOverlay({
+    required this.row,
+    required this.slotCount,
+    required this.slotWidth,
+    required this.startHour,
+    required this.slotStateResolver,
+    required this.onSlotTap,
+    required this.padding,
+  });
+
+  final int row;
+  final int slotCount;
+  final double slotWidth;
+  final int startHour;
+  final SlotStateResolver? slotStateResolver;
+  final void Function(int courtIndex, int slotIndex)? onSlotTap;
+  final EdgeInsets padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final cells = List.generate(slotCount, (index) {
+      final state = slotStateResolver?.call(row, index);
+      final background =
+          slotStatusBackground(state?.status, Theme.of(context).colorScheme);
+      final border =
+          slotStatusBorder(state?.status, Theme.of(context).colorScheme);
+      final canTap = onSlotTap != null &&
+          (state == null || state.status == SlotReservationStatus.holding);
+
+      return SizedBox(
+        width: slotWidth,
+        child: Padding(
+          padding: padding,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: canTap ? () => onSlotTap!(row, index) : null,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              decoration: BoxDecoration(
+                color: background,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: border, width: 1.4),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 6),
+              child: _SlotCellContent(
+                hourLabel: '${startHour + index}:00',
+                state: state,
+              ),
+            ),
+          ),
+        ),
+      );
+    });
+
+    return IgnorePointer(
+      ignoring: onSlotTap == null,
+      child: SizedBox(
+        width: slotCount * slotWidth,
+        child: Row(children: cells),
+      ),
+    );
+  }
+}
+
+class _SlotCellContent extends StatelessWidget {
+  const _SlotCellContent({required this.hourLabel, this.state});
+
+  final String hourLabel;
+  final SlotCellState? state;
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = <String>[hourLabel];
+    final status = state?.status;
+    final holdUntil = state?.holdUntil;
+    final note = state?.note;
+
+    if (status != null) {
+      switch (status) {
+        case SlotReservationStatus.holding:
+          if (holdUntil != null) {
+            texts.add('Giữ đến ${DateFormat('HH:mm').format(holdUntil)}');
+          } else {
+            texts.add('Đang giữ chỗ');
+          }
+          break;
+        case SlotReservationStatus.awaitingApproval:
+          texts.add('Chờ admin duyệt');
+          break;
+        case SlotReservationStatus.booked:
+          texts.add('Đã đặt');
+          break;
+        case SlotReservationStatus.locked:
+          texts.add('Đã khóa');
+          break;
+        case SlotReservationStatus.heldByOthers:
+          texts.add('Người khác đang giữ');
+          break;
+      }
+    }
+
+    if (note != null && note.isNotEmpty) {
+      texts.add(note);
+    }
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: texts
+          .map((text) => Text(
+                text,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      fontWeight: text == hourLabel
+                          ? FontWeight.w600
+                          : FontWeight.w500,
+                    ),
+              ))
+          .toList(),
     );
   }
 }

--- a/lib/models/slot_reservation.dart
+++ b/lib/models/slot_reservation.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart';
+
+/// Trạng thái đặt chỗ của một khung giờ trên sân.
+enum SlotReservationStatus {
+  /// Người dùng đang giữ chỗ tạm thời.
+  holding,
+
+  /// Người dùng đã xác nhận và đang chờ admin duyệt.
+  awaitingApproval,
+
+  /// Khung giờ đã được đặt cố định (không thể chọn).
+  booked,
+
+  /// Khung giờ đã bị khóa bởi quản lý.
+  locked,
+
+  /// Khung giờ đang được giữ bởi người dùng khác.
+  heldByOthers,
+}
+
+/// Thông tin hiển thị cho một khung giờ đã giữ/đặt.
+@immutable
+class SlotReservationInfo {
+  const SlotReservationInfo({
+    required this.courtName,
+    required this.courtIndex,
+    required this.startHour,
+    required this.status,
+    required this.holdUntil,
+  });
+
+  final String courtName;
+  final int courtIndex;
+  final int startHour;
+  final SlotReservationStatus status;
+  final DateTime? holdUntil;
+
+  SlotReservationInfo copyWith({
+    SlotReservationStatus? status,
+    DateTime? holdUntil,
+  }) {
+    return SlotReservationInfo(
+      courtName: courtName,
+      courtIndex: courtIndex,
+      startHour: startHour,
+      status: status ?? this.status,
+      holdUntil: holdUntil ?? this.holdUntil,
+    );
+  }
+}

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:badminton_booking_app/components/my_court_time.dart';
+import 'package:badminton_booking_app/models/slot_reservation.dart';
 import 'package:badminton_booking_app/pages/court/payment_page.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class BookingPage extends StatefulWidget {
   const BookingPage({super.key});
@@ -10,7 +14,196 @@ class BookingPage extends StatefulWidget {
 }
 
 class _BookingPageState extends State<BookingPage> {
+  static const int _timelineStartHour = 6;
+  static const int _timelineEndHour = 23;
   DateTime _selectedDate = DateTime.now();
+  final Map<String, _HeldSlotData> _heldSlots = {};
+
+  List<String> get _courtNames => const [
+        'Sân 1',
+        'Sân 2',
+        'Sân 3',
+        'Sân 4',
+        'Sân 5',
+      ];
+
+  @override
+  void dispose() {
+    for (final slot in _heldSlots.values) {
+      slot.cancelTimer();
+    }
+    super.dispose();
+  }
+
+  SlotCellState? _buildSlotState(int courtIndex, int slotIndex) {
+    final key = _slotKey(courtIndex, slotIndex);
+    final hold = _heldSlots[key];
+    if (hold == null) {
+      return null;
+    }
+    return SlotCellState(
+      status: hold.status,
+      holdUntil: hold.status == SlotReservationStatus.holding
+          ? hold.holdUntil
+          : null,
+    );
+  }
+
+  void _handleSlotTap(int courtIndex, int slotIndex) {
+    final key = _slotKey(courtIndex, slotIndex);
+    final current = _heldSlots[key];
+    if (current != null) {
+      if (current.status == SlotReservationStatus.holding) {
+        _releaseSlot(key);
+      }
+      return;
+    }
+
+    final startHour = _timelineStartHour + slotIndex;
+    final holdUntil = DateTime.now().add(const Duration(minutes: 15));
+    final slot = _HeldSlotData(
+      courtName: _courtNames[courtIndex],
+      courtIndex: courtIndex,
+      startHour: startHour,
+      holdUntil: holdUntil,
+      status: SlotReservationStatus.holding,
+      onExpired: () {
+        if (mounted) {
+          setState(() {
+            _heldSlots.remove(key);
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                  'Hết thời gian giữ chỗ ${_courtNames[courtIndex]} ${_hourLabel(startHour)}'),
+            ),
+          );
+        }
+      },
+    );
+
+    slot.startTimer();
+
+    setState(() {
+      _heldSlots[key] = slot;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+            'Đang giữ chỗ ${slot.courtName} ${_hourLabel(slot.startHour)} trong 15 phút'),
+      ),
+    );
+  }
+
+  String _hourLabel(int hour) => '${hour.toString().padLeft(2, '0')}:00';
+
+  void _releaseSlot(String key) {
+    final slot = _heldSlots.remove(key);
+    slot?.cancelTimer();
+    if (slot != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+              'Đã hủy giữ chỗ ${slot.courtName} ${_hourLabel(slot.startHour)}'),
+        ),
+      );
+      setState(() {});
+    }
+  }
+
+  String _slotKey(int courtIndex, int slotIndex) => '$courtIndex-$slotIndex';
+
+  Future<List<SlotReservationInfo>> _confirmPayment() async {
+    final updates = <SlotReservationInfo>[];
+    setState(() {
+      _heldSlots.updateAll((key, slot) {
+        slot.cancelTimer();
+        slot.status = SlotReservationStatus.awaitingApproval;
+        updates.add(slot.toInfo());
+        return slot;
+      });
+    });
+    return updates;
+  }
+
+  void _handlePaymentNavigation() {
+    if (_heldSlots.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Vui lòng chọn ít nhất 1 khung giờ.')),
+      );
+      return;
+    }
+
+    final infoList = _heldSlots.values.map((slot) => slot.toInfo()).toList();
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => PaymentPage(
+          holds: infoList,
+          onConfirmPayment: _confirmPayment,
+          onPayNow: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                  content: Text('Vui lòng thanh toán theo hướng dẫn.')),
+            );
+          },
+        ),
+      ),
+    ).then((_) {
+      setState(() {});
+    });
+  }
+
+  Widget _holdingBanner(ColorScheme cs) {
+    final format = DateFormat('HH:mm');
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outline, width: 1),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Khung giờ đang giữ (${_heldSlots.length})',
+            style: TextStyle(
+              color: cs.onSurface,
+              fontWeight: FontWeight.bold,
+              fontSize: 16,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: _heldSlots.values.map((slot) {
+              final status = slot.status;
+              final String label;
+              if (status == SlotReservationStatus.awaitingApproval) {
+                label = 'Chờ admin duyệt';
+              } else if (slot.holdUntil != null) {
+                label = 'Giữ đến ${format.format(slot.holdUntil!)}';
+              } else {
+                label = 'Đang giữ chỗ';
+              }
+              return Chip(
+                backgroundColor: slotStatusBackground(status, cs),
+                side: BorderSide(color: slotStatusBorder(status, cs)),
+                label: Text(
+                  '${slot.courtName} ${_hourLabel(slot.startHour)} • $label',
+                  style: TextStyle(color: cs.onSurface),
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
 
   Future<void> _selectDate() async {
     // đảm bảo initialDate nằm trong khoảng cho phép
@@ -65,21 +258,23 @@ class _BookingPageState extends State<BookingPage> {
                   ),
                 ),
                 SizedBox(height: 20),
+                if (_heldSlots.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: _holdingBanner(cs),
+                  ),
+                SizedBox(height: _heldSlots.isNotEmpty ? 16 : 0),
                 SizedBox(
                   height: screenHeight -
                       headerH, // cho CourtTimeline chiều cao hữu hạn
                   child: CourtTimeline(
-                    startHour: 6,
-                    endHour: 23,
+                    startHour: _timelineStartHour,
+                    endHour: _timelineEndHour,
                     slotWidth: 60,
                     rowHeight: 40,
-                    courts: [
-                      'Sân 1',
-                      'Sân 2',
-                      'Sân 3',
-                      'Sân 4',
-                      'Sân 5',
-                    ],
+                    courts: _courtNames,
+                    slotStateResolver: _buildSlotState,
+                    onSlotTap: _handleSlotTap,
                   ),
                 ),
               ],
@@ -145,24 +340,49 @@ class _BookingPageState extends State<BookingPage> {
                   ),
                 ),
                 const SizedBox(height: 20),
-                Row(
-                  children: [
-                    const SizedBox(width: 15),
-                    colorTile(
-                      Colors.white,
-                      "Trống",
-                    ),
-                    const SizedBox(width: 15),
-                    colorTile(
-                      Colors.red,
-                      "Đã Đặt",
-                    ),
-                    const SizedBox(width: 15),
-                    colorTile(
-                      Colors.grey,
-                      "Khóa",
-                    ),
-                  ],
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 15),
+                  child: Wrap(
+                    spacing: 12,
+                    runSpacing: 8,
+                    children: [
+                      colorTile(
+                        slotStatusBackground(null, cs),
+                        slotStatusBorder(null, cs),
+                        "Trống",
+                        cs.onSurface,
+                      ),
+                      colorTile(
+                        slotStatusBackground(
+                            SlotReservationStatus.booked, cs),
+                        slotStatusBorder(SlotReservationStatus.booked, cs),
+                        "Đã Đặt",
+                        cs.onSurface,
+                      ),
+                      colorTile(
+                        slotStatusBackground(
+                            SlotReservationStatus.locked, cs),
+                        slotStatusBorder(SlotReservationStatus.locked, cs),
+                        "Khóa",
+                        cs.onSurface,
+                      ),
+                      colorTile(
+                        slotStatusBackground(
+                            SlotReservationStatus.holding, cs),
+                        slotStatusBorder(SlotReservationStatus.holding, cs),
+                        "Đang giữ (15')",
+                        cs.onSurface,
+                      ),
+                      colorTile(
+                        slotStatusBackground(
+                            SlotReservationStatus.awaitingApproval, cs),
+                        slotStatusBorder(
+                            SlotReservationStatus.awaitingApproval, cs),
+                        "Chờ duyệt",
+                        cs.onSurface,
+                      ),
+                    ],
+                  ),
                 )
               ],
             ),
@@ -172,35 +392,35 @@ class _BookingPageState extends State<BookingPage> {
             right: 16,
             child: SafeArea(
               child: GestureDetector(
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (context) => PaymentPage()),
-                  );
-                },
-                child: Container(
-                  padding: const EdgeInsets.only(
-                      top: 12, bottom: 12, left: 20, right: 20),
-                  decoration: BoxDecoration(
-                    color: cs.secondary,
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(color: cs.outline, width: 2),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.event_available,
-                          color: cs.onSecondary, size: 28),
-                      const SizedBox(width: 12),
-                      Text(
-                        "Book Now",
-                        style: TextStyle(
-                          fontSize: 18,
-                          color: cs.onSecondary,
-                          fontWeight: FontWeight.bold,
+                onTap: _heldSlots.isNotEmpty ? _handlePaymentNavigation : null,
+                child: Opacity(
+                  opacity: _heldSlots.isNotEmpty ? 1 : 0.5,
+                  child: Container(
+                    padding: const EdgeInsets.only(
+                        top: 12, bottom: 12, left: 20, right: 20),
+                    decoration: BoxDecoration(
+                      color: cs.secondary,
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(color: cs.outline, width: 2),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.event_available,
+                            color: cs.onSecondary, size: 28),
+                        const SizedBox(width: 12),
+                        Text(
+                          _heldSlots.isNotEmpty
+                              ? "Book Now (${_heldSlots.length})"
+                              : "Chọn khung giờ",
+                          style: TextStyle(
+                            fontSize: 18,
+                            color: cs.onSecondary,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),
@@ -223,17 +443,21 @@ class _BookingPageState extends State<BookingPage> {
   }
 
   Widget colorTile(
-    Color color,
+    Color fillColor,
+    Color borderColor,
     String text,
+    Color textColor,
   ) {
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         Container(
           width: 25,
           height: 25,
           decoration: BoxDecoration(
-            color: color,
+            color: fillColor,
             borderRadius: BorderRadius.circular(5),
+            border: Border.all(color: borderColor, width: 1.5),
           ),
         ),
         const SizedBox(width: 10),
@@ -241,11 +465,57 @@ class _BookingPageState extends State<BookingPage> {
           text,
           style: TextStyle(
             fontSize: 15,
-            color: Colors.white,
+            color: textColor,
             fontWeight: FontWeight.bold,
           ),
         ),
       ],
+    );
+  }
+}
+
+class _HeldSlotData {
+  _HeldSlotData({
+    required this.courtName,
+    required this.courtIndex,
+    required this.startHour,
+    required this.holdUntil,
+    required this.status,
+    required this.onExpired,
+  });
+
+  final String courtName;
+  final int courtIndex;
+  final int startHour;
+  DateTime? holdUntil;
+  SlotReservationStatus status;
+  final VoidCallback onExpired;
+  Timer? _timer;
+
+  void startTimer() {
+    final until = holdUntil;
+    if (until == null) return;
+    cancelTimer();
+    final duration = until.difference(DateTime.now());
+    if (duration.isNegative) {
+      onExpired();
+      return;
+    }
+    _timer = Timer(duration, onExpired);
+  }
+
+  void cancelTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  SlotReservationInfo toInfo() {
+    return SlotReservationInfo(
+      courtName: courtName,
+      courtIndex: courtIndex,
+      startHour: startHour,
+      status: status,
+      holdUntil: holdUntil,
     );
   }
 }

--- a/lib/pages/court/payment_page.dart
+++ b/lib/pages/court/payment_page.dart
@@ -1,7 +1,37 @@
+import 'package:badminton_booking_app/components/my_court_time.dart';
+import 'package:badminton_booking_app/models/slot_reservation.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
-class PaymentPage extends StatelessWidget {
-  const PaymentPage({super.key});
+class PaymentPage extends StatefulWidget {
+  const PaymentPage({
+    super.key,
+    required this.holds,
+    required this.onConfirmPayment,
+    required this.onPayNow,
+  });
+
+  final List<SlotReservationInfo> holds;
+  final Future<List<SlotReservationInfo>> Function() onConfirmPayment;
+  final VoidCallback onPayNow;
+
+  @override
+  State<PaymentPage> createState() => _PaymentPageState();
+}
+
+class _PaymentPageState extends State<PaymentPage> {
+  late List<SlotReservationInfo> _holds;
+  bool _isProcessing = false;
+
+  bool get _isAwaitingApproval => _holds.isNotEmpty &&
+      _holds.every((element) =>
+          element.status == SlotReservationStatus.awaitingApproval);
+
+  @override
+  void initState() {
+    super.initState();
+    _holds = widget.holds;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -13,15 +43,19 @@ class PaymentPage extends StatelessWidget {
         children: [
           // List Sân
           Container(
-              margin: EdgeInsets.only(top: screenHeight / 13),
-              padding: const EdgeInsets.only(top: 20, bottom: 40),
-              child: ListView(
-                children: [
-                  _infoTab(cs),
-                  const SizedBox(height: 20),
-                  // Other widgets can be added here
-                ],
-              )),
+            margin: EdgeInsets.only(top: screenHeight / 13),
+            padding: const EdgeInsets.only(top: 20, bottom: 40),
+            child: ListView(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              children: [
+                _infoTab(cs),
+                const SizedBox(height: 20),
+                _bookingSummary(cs),
+                const SizedBox(height: 20),
+                _actionSection(cs),
+              ],
+            ),
+          ),
 
           // Title
           Container(
@@ -136,53 +170,178 @@ class PaymentPage extends StatelessWidget {
     );
   }
 
-  Widget _infoBooking(ColorScheme cs) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16),
-      child: Material(
-        elevation: 5,
-        borderRadius: BorderRadius.circular(16),
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(16),
-            color: cs.surface,
-            border: Border.all(color: cs.outline, width: 1),
+  Widget _bookingSummary(ColorScheme cs) {
+    final format = DateFormat('HH:mm');
+    return Material(
+      elevation: 5,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: cs.surface,
+          border: Border.all(color: cs.outline, width: 1),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Tóm tắt đặt sân',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: cs.onSurface,
+              ),
+            ),
+            const SizedBox(height: 12),
+            if (_holds.isEmpty)
+              Text(
+                'Bạn chưa chọn khung giờ nào.',
+                style: TextStyle(color: cs.onSurface),
+              )
+            else
+              ..._holds.map(
+                (slot) => Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: _reservationTile(slot, cs, format),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _reservationTile(
+      SlotReservationInfo slot, ColorScheme cs, DateFormat format) {
+    final statusColor = slotStatusBorder(slot.status, cs);
+    final timeLabel =
+        '${slot.startHour.toString().padLeft(2, '0')}:00 - ${(slot.startHour + 1).toString().padLeft(2, '0')}:00';
+    final holdLabel = slot.status == SlotReservationStatus.awaitingApproval
+        ? 'Đang chờ admin duyệt'
+        : (slot.holdUntil != null
+            ? 'Giữ đến ${format.format(slot.holdUntil!)}'
+            : 'Đang giữ chỗ');
+
+    return Container(
+      decoration: BoxDecoration(
+        color: slotStatusBackground(slot.status, cs).withOpacity(0.7),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: statusColor, width: 1.2),
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${slot.courtName} • $timeLabel',
+            style: TextStyle(
+              fontWeight: FontWeight.w600,
+              fontSize: 16,
+              color: cs.onSurface,
+            ),
           ),
-          child: Column(
+          const SizedBox(height: 6),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
-                children: const [
-                  Icon(Icons.place, size: 20),
-                  SizedBox(width: 6),
-                  Expanded(
-                    child: Text(
-                        "55D Đ. Trần Nam Phú, Xuân Khánh, Ninh Kiều, Cần Thơ"),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: const [
-                  Icon(Icons.schedule, size: 20),
-                  SizedBox(width: 6),
-                  Text("05:00 - 22:00"),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: const [
-                  Icon(Icons.call, size: 20),
-                  SizedBox(width: 6),
-                  Text(
-                    "0329672505",
-                    style: TextStyle(color: Colors.blue),
-                  ),
-                ],
+              Icon(Icons.info_outline, size: 16, color: statusColor),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  '${_statusLabel(slot.status)} • $holdLabel',
+                  style: TextStyle(color: cs.onSurface, fontSize: 14),
+                ),
               ),
             ],
           ),
+        ],
+      ),
+    );
+  }
+
+  Widget _actionSection(ColorScheme cs) {
+    return Material(
+      elevation: 5,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: cs.surface,
+          border: Border.all(color: cs.outline, width: 1),
         ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton(
+              onPressed: _isAwaitingApproval || _isProcessing
+                  ? null
+                  : _handleConfirm,
+              child: _isProcessing
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Xác nhận thanh toán'),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton(
+              onPressed: _holds.isEmpty ? null : _handlePayNow,
+              child: const Text('Thanh toán ngay'),
+            ),
+            if (_isAwaitingApproval)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: Text(
+                  'Yêu cầu của bạn đang chờ admin duyệt. Bạn vẫn có thể hoàn tất thanh toán trong lúc này.',
+                  style: TextStyle(color: cs.onSurface),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _statusLabel(SlotReservationStatus status) {
+    switch (status) {
+      case SlotReservationStatus.holding:
+        return 'Đang giữ chỗ tạm thời';
+      case SlotReservationStatus.awaitingApproval:
+        return 'Đã gửi yêu cầu';
+      case SlotReservationStatus.booked:
+        return 'Đã được đặt';
+      case SlotReservationStatus.locked:
+        return 'Khung giờ đã khóa';
+      case SlotReservationStatus.heldByOthers:
+        return 'Người khác đang giữ';
+    }
+  }
+
+  Future<void> _handleConfirm() async {
+    setState(() {
+      _isProcessing = true;
+    });
+    final updated = await widget.onConfirmPayment();
+    if (!mounted) return;
+    setState(() {
+      _holds = updated;
+      _isProcessing = false;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Đã gửi yêu cầu, vui lòng chờ admin duyệt.'),
+      ),
+    );
+  }
+
+  void _handlePayNow() {
+    widget.onPayNow();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Vui lòng thực hiện thanh toán theo hướng dẫn của sân.'),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add reusable slot reservation model and timeline cell overlays to visualise booking states
- let the booking screen hold selected slots for 15 minutes, surface status legends, and require a selection before checkout
- refresh the payment screen to show held slots, handle confirmation awaiting admin approval, and keep payment actions available

## Testing
- not run (Flutter/Dart tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e61b5e39e4832bac056536e3f20ba5