### PR TITLE
Implement booking hold workflow with backend locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,52 @@
-# badminton_booking_app
+# Badminton Booking App
 
-A new Flutter project.
+Ứng dụng Flutter hỗ trợ đặt sân cầu lông, kết nối trực tiếp với PocketBase để
+quản lý sân, người dùng và lịch đặt.
 
-## Getting Started
+## Luồng đặt sân
 
-This project is a starting point for a Flutter application.
+* Người dùng chọn sân và ngày muốn chơi. Lưới thời gian hiển thị các sân con và
+  phân biệt trạng thái bằng màu sắc: trắng (trống), đỏ (đã đặt hoặc chờ duyệt),
+  xám (đang được người khác giữ chỗ) và xám đậm (khung giờ do bạn đang giữ).
+* Khi chạm vào một khung giờ trống, ứng dụng gọi API `court_bookings` để tạo bản
+  ghi với trạng thái `locked`. Khung giờ này được giữ tối đa 15 phút nhờ trường
+  `locked_until`; trong thời gian đó người khác sẽ không thể chọn được.
+* Người dùng nhấn **Gửi yêu cầu** để chuyển đặt chỗ sang trạng thái `pending`
+  và chờ quản trị viên duyệt.
+* Khi quản trị viên duyệt (trạng thái `confirmed`), nút **Thanh toán** sẽ mở
+  trang Payment với đầy đủ thông tin sân, thời gian và trạng thái thanh toán.
 
-A few resources to get you started if this is your first Flutter project:
+Luồng này mô phỏng trải nghiệm tương tự ứng dụng AloBo: giữ chỗ tạm thời,
+chờ duyệt, sau đó mới thanh toán.
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+## Vì sao không dùng SQLite trên thiết bị?
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+Việc giữ chỗ cần đảm bảo tính nhất quán theo thời gian thực cho toàn bộ người
+chơi. Nếu lưu trạng thái bằng SQLite cục bộ thì mỗi thiết bị sẽ không biết được
+các giữ chỗ của nhau, dẫn đến tình trạng overbooking. PocketBase đóng vai trò
+là máy chủ trung tâm:
+
+* Ghi nhận các bản ghi giữ chỗ (`locked`) cùng thời điểm hết hạn `locked_until`.
+* Chỉ trả về các đặt chỗ còn hiệu lực khi truy vấn, đảm bảo người dùng khác không
+  thể chọn vào khung giờ đã có người giữ.
+* Cho phép quản trị viên thay đổi trạng thái (`pending`, `confirmed`,
+  `cancelled`) và đồng bộ ngay lập tức tới tất cả thiết bị.
+
+SQLite vẫn có thể sử dụng để cache dữ liệu đọc, nhưng việc khóa khung giờ bắt
+buộc phải thực hiện ở server chung để đảm bảo tính toàn vẹn dữ liệu.
+
+## Phụ thuộc
+
+* Flutter 3.x
+* [pocketbase](https://github.com/pocketbase/pocketbase)
+* provider, shared_preferences, intl
+
+## Chạy ứng dụng
+
+```bash
+flutter pub get
+flutter run
+```
+
+Đảm bảo PocketBase đang chạy và biến môi trường `POCKETBASE_URL` đã được cấu
+hình trong `.env`.

--- a/lib/components/my_court.dart
+++ b/lib/components/my_court.dart
@@ -186,9 +186,13 @@ class _MyCourtState extends State<MyCourt> {
                       ElevatedButton(
                         onPressed: () {
                           Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                  builder: (context) => BookingPage()));
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => BookingPage(
+                                court: court,
+                              ),
+                            ),
+                          );
                         },
                         style: ElevatedButton.styleFrom(
                           backgroundColor: colorSchema.primary,

--- a/lib/components/my_court_time.dart
+++ b/lib/components/my_court_time.dart
@@ -3,6 +3,63 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'dart:ui' as ui;
 
+import '../models/court_booking.dart';
+
+class CourtTimelineReservation {
+  CourtTimelineReservation({
+    required this.courtUnitId,
+    required this.start,
+    required this.end,
+    required this.status,
+    this.lockedUntil,
+    this.isMine = false,
+  });
+
+  final String courtUnitId;
+  final DateTime start;
+  final DateTime end;
+  final CourtBookingStatus status;
+  final DateTime? lockedUntil;
+  final bool isMine;
+
+  bool get _isLockActive {
+    if (status != CourtBookingStatus.locked) return false;
+    final until = lockedUntil;
+    if (until == null) return false;
+    return until.isAfter(DateTime.now());
+  }
+
+  bool get blocksSelection {
+    switch (status) {
+      case CourtBookingStatus.pending:
+      case CourtBookingStatus.confirmed:
+        return true;
+      case CourtBookingStatus.locked:
+        return _isLockActive;
+      case CourtBookingStatus.cancelled:
+        return false;
+    }
+  }
+
+  bool overlaps(DateTime slotStart, DateTime slotEnd) {
+    return start.isBefore(slotEnd) && end.isAfter(slotStart);
+  }
+}
+
+class CourtTimelineSlotTap {
+  CourtTimelineSlotTap({
+    required this.courtIndex,
+    required this.courtUnitId,
+    required this.start,
+    required this.end,
+  });
+
+  final int courtIndex;
+  final String courtUnitId;
+  final DateTime start;
+  final DateTime end;
+}
+
 /// Header kiểu “timeline” với vạch giờ & vạch 30’:
 /// - Mỗi ô (grid) = 1 giờ.
 /// - Header có LEADING INSET bên trái để label mốc đầu không bị cắt.
@@ -18,6 +75,11 @@ class CourtTimeline extends StatefulWidget {
     this.leftColumnWidth = 90, // cột tên sân (cố định)
     this.headerHeight = 56.0,
     this.headerLeadingInset = 24.0, // khoảng trống trái của HEADER
+    this.reservations = const [],
+    this.onSlotTap,
+    this.slotDuration = const Duration(hours: 1),
+    this.courtUnitIds,
+    this.day,
   });
 
   final int startHour;
@@ -25,9 +87,14 @@ class CourtTimeline extends StatefulWidget {
   final double slotWidth;
   final double rowHeight;
   final List<String> courts;
+  final List<String>? courtUnitIds;
   final double leftColumnWidth;
   final double headerHeight;
   final double headerLeadingInset;
+  final List<CourtTimelineReservation> reservations;
+  final Duration slotDuration;
+  final ValueChanged<CourtTimelineSlotTap>? onSlotTap;
+  final DateTime? day;
 
   @override
   State<CourtTimeline> createState() => _CourtTimelineState();
@@ -45,6 +112,22 @@ class _CourtTimelineState extends State<CourtTimeline> {
 
   // tổng bề rộng phần NỘI DUNG (lưới)
   double get _totalWidth => _slotCount * widget.slotWidth;
+
+  List<String> get _resolvedCourtUnitIds {
+    final units = widget.courtUnitIds;
+    if (units != null && units.length == widget.courts.length) {
+      return units;
+    }
+    return List<String>.generate(widget.courts.length, (index) => '${index + 1}');
+  }
+
+  Map<String, List<CourtTimelineReservation>> get _reservationsByUnit {
+    final map = <String, List<CourtTimelineReservation>>{};
+    for (final reservation in widget.reservations) {
+      map.putIfAbsent(reservation.courtUnitId, () => []).add(reservation);
+    }
+    return map;
+  }
 
   @override
   void initState() {
@@ -186,18 +269,26 @@ class _CourtTimelineState extends State<CourtTimeline> {
                         child: ListView.separated(
                           padding: EdgeInsets.zero,
                           itemCount: widget.courts.length,
-                          itemBuilder: (_, row) => SizedBox(
-                            height: widget.rowHeight,
-                            child: CustomPaint(
-                              painter: _GridRowPainter(
+                          itemBuilder: (_, row) {
+                            final unitId = _resolvedCourtUnitIds[row];
+                            final reservations = _reservationsByUnit[unitId] ??
+                                const <CourtTimelineReservation>[];
+                            return SizedBox(
+                              height: widget.rowHeight,
+                              child: _TimelineRow(
                                 totalSlots: _slotCount,
                                 slotWidth: widget.slotWidth,
-                                lineColor: const Color(0x33000000),
-                                background: Colors.white,
+                                dividerColor: dividerColor,
+                                reservations: reservations,
+                                rowIndex: row,
+                                unitId: unitId,
+                                slotDuration: widget.slotDuration,
+                                startHour: widget.startHour,
+                                onSlotTap: widget.onSlotTap,
+                                day: widget.day,
                               ),
-                              child: const SizedBox.expand(),
-                            ),
-                          ),
+                            );
+                          },
                           separatorBuilder: (_, __) =>
                               Divider(height: 1, color: dividerColor),
                         ),
@@ -352,5 +443,143 @@ class _GridRowPainter extends CustomPainter {
         old.slotWidth != slotWidth ||
         old.lineColor != lineColor ||
         old.background != background;
+  }
+}
+
+class _TimelineRow extends StatelessWidget {
+  const _TimelineRow({
+    required this.totalSlots,
+    required this.slotWidth,
+    required this.dividerColor,
+    required this.reservations,
+    required this.rowIndex,
+    required this.unitId,
+    required this.slotDuration,
+    required this.startHour,
+    required this.onSlotTap,
+    required this.day,
+  });
+
+  final int totalSlots;
+  final double slotWidth;
+  final Color dividerColor;
+  final List<CourtTimelineReservation> reservations;
+  final int rowIndex;
+  final String unitId;
+  final Duration slotDuration;
+  final int startHour;
+  final ValueChanged<CourtTimelineSlotTap>? onSlotTap;
+  final DateTime? day;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _GridRowPainter(
+        totalSlots: totalSlots,
+        slotWidth: slotWidth,
+        lineColor: const Color(0x33000000),
+        background: Colors.white,
+      ),
+      child: Row(
+        children: List.generate(totalSlots, (index) {
+          final slotStart = _buildSlotStart(index);
+          final slotEnd = slotStart.add(slotDuration);
+          final reservation = _findReservation(slotStart, slotEnd);
+          final blocked = reservation?.blocksSelection ?? false;
+          final tapHandler = onSlotTap;
+          final color = _resolveColor(reservation);
+          final label = _resolveLabel(reservation);
+
+          return SizedBox(
+            width: slotWidth,
+            height: double.infinity,
+            child: GestureDetector(
+              onTap: tapHandler != null && !blocked
+                  ? () => tapHandler(
+                        CourtTimelineSlotTap(
+                          courtIndex: rowIndex,
+                          courtUnitId: unitId,
+                          start: slotStart,
+                          end: slotEnd,
+                        ),
+                      )
+                  : null,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: color,
+                  border: Border(
+                    right: BorderSide(color: dividerColor, width: 0.5),
+                  ),
+                ),
+                alignment: Alignment.center,
+                child: label == null
+                    ? null
+                    : Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 4),
+                        child: Text(
+                          label,
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            color: Color(0xFF0E5A3A),
+                          ),
+                        ),
+                      ),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  DateTime _buildSlotStart(int index) {
+    final base = day ?? DateTime.now();
+    return DateTime(base.year, base.month, base.day, startHour + index);
+  }
+
+  CourtTimelineReservation? _findReservation(
+    DateTime slotStart,
+    DateTime slotEnd,
+  ) {
+    for (final reservation in reservations) {
+      if (reservation.overlaps(slotStart, slotEnd)) {
+        return reservation;
+      }
+    }
+    return null;
+  }
+
+  Color _resolveColor(CourtTimelineReservation? reservation) {
+    if (reservation == null) {
+      return Colors.white;
+    }
+
+    switch (reservation.status) {
+      case CourtBookingStatus.pending:
+      case CourtBookingStatus.confirmed:
+        return const Color(0xFFFFCDD2);
+      case CourtBookingStatus.locked:
+        return reservation.isMine
+            ? const Color(0xFFB0BEC5)
+            : const Color(0xFFCFD8DC);
+      case CourtBookingStatus.cancelled:
+        return Colors.white;
+    }
+  }
+
+  String? _resolveLabel(CourtTimelineReservation? reservation) {
+    if (reservation == null) return null;
+    switch (reservation.status) {
+      case CourtBookingStatus.pending:
+        return 'Chờ duyệt';
+      case CourtBookingStatus.confirmed:
+        return 'Đã đặt';
+      case CourtBookingStatus.locked:
+        return reservation.isMine ? 'Bạn giữ' : 'Giữ chỗ';
+      case CourtBookingStatus.cancelled:
+        return null;
+    }
   }
 }

--- a/lib/models/court_booking.dart
+++ b/lib/models/court_booking.dart
@@ -1,0 +1,127 @@
+import 'package:pocketbase/pocketbase.dart';
+
+enum CourtBookingStatus { pending, confirmed, cancelled, locked }
+
+CourtBookingStatus parseCourtBookingStatus(String? value) {
+  switch (value) {
+    case 'pending':
+      return CourtBookingStatus.pending;
+    case 'confirmed':
+      return CourtBookingStatus.confirmed;
+    case 'cancelled':
+      return CourtBookingStatus.cancelled;
+    case 'locked':
+    default:
+      return CourtBookingStatus.locked;
+  }
+}
+
+String courtBookingStatusToString(CourtBookingStatus status) {
+  switch (status) {
+    case CourtBookingStatus.pending:
+      return 'pending';
+    case CourtBookingStatus.confirmed:
+      return 'confirmed';
+    case CourtBookingStatus.cancelled:
+      return 'cancelled';
+    case CourtBookingStatus.locked:
+      return 'locked';
+  }
+}
+
+class CourtBooking {
+  const CourtBooking({
+    required this.id,
+    required this.courtId,
+    required this.courtUnitId,
+    required this.userId,
+    required this.startTime,
+    required this.endTime,
+    required this.status,
+    this.lockedUntil,
+    this.note,
+  });
+
+  factory CourtBooking.fromRecord(RecordModel record) {
+    final data = record.data;
+    return CourtBooking(
+      id: record.id,
+      courtId: (data['court_id'] as String?)?.trim() ?? '',
+      courtUnitId: (data['court_unit_id'] as String?)?.trim() ?? '',
+      userId: (data['user_id'] as String?)?.trim() ?? '',
+      startTime: _parseDate(data['start_time']),
+      endTime: _parseDate(data['end_time']),
+      status: parseCourtBookingStatus(data['status'] as String?),
+      lockedUntil: _parseOptionalDate(data['locked_until']),
+      note: (data['note'] as String?)?.trim(),
+    );
+  }
+
+  final String id;
+  final String courtId;
+  final String courtUnitId;
+  final String userId;
+  final DateTime startTime;
+  final DateTime endTime;
+  final CourtBookingStatus status;
+  final DateTime? lockedUntil;
+  final String? note;
+
+  bool get isLockActive {
+    if (status != CourtBookingStatus.locked) return false;
+    final lock = lockedUntil;
+    if (lock == null) return false;
+    return lock.isAfter(DateTime.now());
+  }
+
+  bool get blocksSelection {
+    switch (status) {
+      case CourtBookingStatus.pending:
+      case CourtBookingStatus.confirmed:
+        return true;
+      case CourtBookingStatus.locked:
+        return isLockActive;
+      case CourtBookingStatus.cancelled:
+        return false;
+    }
+  }
+
+  CourtBooking copyWith({
+    CourtBookingStatus? status,
+    DateTime? lockedUntil,
+    String? note,
+  }) {
+    return CourtBooking(
+      id: id,
+      courtId: courtId,
+      courtUnitId: courtUnitId,
+      userId: userId,
+      startTime: startTime,
+      endTime: endTime,
+      status: status ?? this.status,
+      lockedUntil: lockedUntil ?? this.lockedUntil,
+      note: note ?? this.note,
+    );
+  }
+}
+
+DateTime _parseDate(dynamic value) {
+  if (value is DateTime) return value.toLocal();
+  if (value is String && value.isNotEmpty) {
+    final parsed = DateTime.tryParse(value);
+    if (parsed != null) {
+      return parsed.toLocal();
+    }
+  }
+  throw StateError('Invalid date value: $value');
+}
+
+DateTime? _parseOptionalDate(dynamic value) {
+  if (value == null) return null;
+  if (value is DateTime) return value.toLocal();
+  if (value is String && value.isNotEmpty) {
+    final parsed = DateTime.tryParse(value);
+    return parsed?.toLocal();
+  }
+  return null;
+}

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -1,16 +1,51 @@
 import 'package:badminton_booking_app/components/my_court_time.dart';
+import 'package:badminton_booking_app/models/court.dart';
+import 'package:badminton_booking_app/models/court_booking.dart';
+import 'package:badminton_booking_app/models/court_detail.dart';
+import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
 import 'package:badminton_booking_app/pages/court/payment_page.dart';
+import 'package:badminton_booking_app/services/court_booking_service.dart';
+import 'package:badminton_booking_app/services/court_service.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class BookingPage extends StatefulWidget {
-  const BookingPage({super.key});
+  const BookingPage({
+    super.key,
+    required this.court,
+    this.courtService,
+    this.bookingService,
+  });
+
+  final Court court;
+  final CourtService? courtService;
+  final CourtBookingService? bookingService;
 
   @override
   State<BookingPage> createState() => _BookingPageState();
 }
 
 class _BookingPageState extends State<BookingPage> {
-  DateTime _selectedDate = DateTime.now();
+  late DateTime _selectedDate;
+  bool _isLoadingDetail = false;
+  bool _isLoadingBookings = false;
+  bool _isProcessing = false;
+  String? _detailError;
+  String? _bookingError;
+  List<CourtUnit> _units = const [];
+  List<CourtBooking> _bookings = const [];
+  CourtBooking? _activeBooking;
+
+  CourtService get _courtService => widget.courtService ?? CourtService();
+  CourtBookingService get _bookingService =>
+      widget.bookingService ?? CourtBookingService();
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDate = DateTime.now();
+    _loadDetail();
+  }
 
   Future<void> _selectDate() async {
     // đảm bảo initialDate nằm trong khoảng cho phép
@@ -28,7 +63,211 @@ class _BookingPageState extends State<BookingPage> {
     );
     if (picked != null && picked != _selectedDate) {
       setState(() => _selectedDate = picked);
+      await _loadBookings();
     }
+  }
+
+  Future<void> _loadDetail() async {
+    setState(() {
+      _isLoadingDetail = true;
+      _detailError = null;
+    });
+
+    try {
+      final detail = await _courtService.getCourtDetail(widget.court.id);
+      final activeUnits = detail.units.where((unit) => unit.isActive).toList();
+
+      if (!mounted) return;
+      setState(() {
+        _units = activeUnits.isEmpty ? detail.units : activeUnits;
+        _isLoadingDetail = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _detailError = _describeError(
+          error,
+          fallback: 'Không thể tải thông tin chi tiết của sân.',
+        );
+        _isLoadingDetail = false;
+      });
+    }
+
+    await _loadBookings();
+  }
+
+  Future<void> _loadBookings() async {
+    if (!mounted || _isLoadingBookings) return;
+
+    setState(() {
+      _isLoadingBookings = true;
+      _bookingError = null;
+    });
+
+    try {
+      final bookings = await _bookingService.listBookings(
+        courtId: widget.court.id,
+        date: _selectedDate,
+      );
+      if (mounted) {
+        setState(() {
+          _bookings = bookings;
+          if (_activeBooking != null) {
+            _activeBooking = bookings.firstWhere(
+              (booking) => booking.id == _activeBooking!.id,
+              orElse: () => _activeBooking!,
+            );
+          }
+        });
+      }
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _bookingError = _describeError(
+          error,
+          fallback: 'Không thể tải lịch đặt sân.',
+        );
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingBookings = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _holdSlot(CourtTimelineSlotTap slot) async {
+    final auth = context.read<AuthManager>();
+    final user = auth.user;
+    if (user == null) {
+      _showSnack('Vui lòng đăng nhập để đặt sân.');
+      return;
+    }
+
+    if (_isProcessing) return;
+
+    setState(() {
+      _isProcessing = true;
+      _bookingError = null;
+    });
+
+    try {
+      final booking = await _bookingService.lockSlot(
+        courtId: widget.court.id,
+        courtUnitId: slot.courtUnitId,
+        userId: user.id,
+        startTime: slot.start,
+        endTime: slot.end,
+      );
+
+      if (!mounted) return;
+
+      setState(() {
+        _activeBooking = booking;
+      });
+
+      await _loadBookings();
+      _showSnack('Đã giữ chỗ trong 15 phút. Vui lòng xác nhận để gửi duyệt.');
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _bookingError = _describeError(
+          error,
+          fallback: 'Không thể giữ chỗ cho khung giờ này.',
+        );
+      });
+      _showSnack(_bookingError ?? 'Giữ chỗ thất bại.');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessing = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _confirmBooking() async {
+    final booking = _activeBooking;
+    if (booking == null || booking.status != CourtBookingStatus.locked) {
+      return;
+    }
+    if (_isProcessing) return;
+
+    setState(() => _isProcessing = true);
+
+    try {
+      final updated = await _bookingService.confirmBooking(booking.id);
+      if (!mounted) return;
+      setState(() {
+        _activeBooking = updated;
+      });
+      await _loadBookings();
+      _showSnack('Đã gửi yêu cầu. Vui lòng chờ quản trị viên duyệt.');
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _bookingError = _describeError(
+          error,
+          fallback: 'Không thể gửi yêu cầu đặt sân.',
+        );
+      });
+      _showSnack(_bookingError ?? 'Không thể gửi yêu cầu.');
+    } finally {
+      if (mounted) {
+        setState(() => _isProcessing = false);
+      }
+    }
+  }
+
+  Future<void> _cancelBooking() async {
+    final booking = _activeBooking;
+    if (booking == null) return;
+    if (_isProcessing) return;
+
+    setState(() => _isProcessing = true);
+
+    try {
+      await _bookingService.cancelBooking(booking.id);
+      if (!mounted) return;
+      setState(() {
+        _activeBooking = null;
+      });
+      await _loadBookings();
+      _showSnack('Đã hủy giữ chỗ.');
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _bookingError = _describeError(
+          error,
+          fallback: 'Không thể hủy giữ chỗ.',
+        );
+      });
+      _showSnack(_bookingError ?? 'Không thể hủy giữ chỗ.');
+    } finally {
+      if (mounted) {
+        setState(() => _isProcessing = false);
+      }
+    }
+  }
+
+  String _describeError(Object error, {required String fallback}) {
+    if (error is CourtServiceException) {
+      return error.message;
+    }
+    if (error is CourtBookingServiceException) {
+      return error.message;
+    }
+    final message = error.toString();
+    if (message.isNotEmpty) return message;
+    return fallback;
+  }
+
+  void _showSnack(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
   }
 
   @override
@@ -38,6 +277,8 @@ class _BookingPageState extends State<BookingPage> {
 
     final cs = Theme.of(context).colorScheme;
     final headerH = screenHeight / 4;
+    final auth = context.watch<AuthManager>();
+    final userId = auth.user?.id;
 
     return Scaffold(
       body: Stack(
@@ -57,7 +298,7 @@ class _BookingPageState extends State<BookingPage> {
                     border: Border.all(color: cs.outline, width: 2),
                   ),
                   child: Text(
-                    "Sân Cầu Lông Minh Nghĩa",
+                    widget.court.name,
                     style: TextStyle(
                         fontSize: 18,
                         color: cs.onSecondary,
@@ -65,23 +306,70 @@ class _BookingPageState extends State<BookingPage> {
                   ),
                 ),
                 SizedBox(height: 20),
-                SizedBox(
-                  height: screenHeight -
-                      headerH, // cho CourtTimeline chiều cao hữu hạn
-                  child: CourtTimeline(
-                    startHour: 6,
-                    endHour: 23,
-                    slotWidth: 60,
-                    rowHeight: 40,
-                    courts: [
-                      'Sân 1',
-                      'Sân 2',
-                      'Sân 3',
-                      'Sân 4',
-                      'Sân 5',
-                    ],
+                if (_detailError != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: _buildErrorBanner(cs, _detailError!, onRetry: _loadDetail),
                   ),
-                ),
+                if (_bookingError != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child:
+                        _buildErrorBanner(cs, _bookingError!, onRetry: _loadBookings),
+                  ),
+                if (_isLoadingDetail)
+                  const Padding(
+                    padding: EdgeInsets.all(24),
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                if (!_isLoadingDetail && _units.isEmpty)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'Sân chưa có thông tin sân con để đặt lịch.',
+                      style: TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                if (!_isLoadingDetail)
+                  SizedBox(
+                    height: screenHeight - headerH,
+                    child: CourtTimeline(
+                      startHour: 6,
+                      endHour: 23,
+                      slotWidth: 60,
+                      rowHeight: 48,
+                      courts: _units.isEmpty
+                          ? ['Sân']
+                          : List.generate(
+                              _units.length,
+                              (index) {
+                                final unit = _units[index];
+                                return unit.label.isNotEmpty
+                                    ? unit.label
+                                    : 'Sân ${index + 1}';
+                              },
+                            ),
+                      courtUnitIds:
+                          _units.isEmpty ? null : _units.map((u) => u.id).toList(),
+                      reservations:
+                          _buildReservations(userId: userId),
+                      onSlotTap: _units.isEmpty ? null : _holdSlot,
+                      day: _selectedDate,
+                    ),
+                  ),
+                if (_isLoadingBookings)
+                  const Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+                if (_activeBooking != null)
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: _buildBookingSummary(cs, _activeBooking!),
+                  ),
               ],
             ),
           ),
@@ -159,7 +447,7 @@ class _BookingPageState extends State<BookingPage> {
                     ),
                     const SizedBox(width: 15),
                     colorTile(
-                      Colors.grey,
+                      const Color(0xFFCFD8DC),
                       "Khóa",
                     ),
                   ],
@@ -172,12 +460,7 @@ class _BookingPageState extends State<BookingPage> {
             right: 16,
             child: SafeArea(
               child: GestureDetector(
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (context) => PaymentPage()),
-                  );
-                },
+                onTap: _resolvePrimaryAction() != null ? _resolvePrimaryAction() : null,
                 child: Container(
                   padding: const EdgeInsets.only(
                       top: 12, bottom: 12, left: 20, right: 20),
@@ -193,7 +476,7 @@ class _BookingPageState extends State<BookingPage> {
                           color: cs.onSecondary, size: 28),
                       const SizedBox(width: 12),
                       Text(
-                        "Book Now",
+                        _resolvePrimaryActionLabel(),
                         style: TextStyle(
                           fontSize: 18,
                           color: cs.onSecondary,
@@ -247,5 +530,174 @@ class _BookingPageState extends State<BookingPage> {
         ),
       ],
     );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}/${date.year}';
+  }
+
+  String _formatTime(DateTime time) {
+    return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+  }
+
+  List<CourtTimelineReservation> _buildReservations({String? userId}) {
+    if (_units.isEmpty || _bookings.isEmpty) {
+      return const [];
+    }
+
+    return _bookings
+        .map(
+          (booking) => CourtTimelineReservation(
+            courtUnitId: booking.courtUnitId,
+            start: booking.startTime,
+            end: booking.endTime,
+            status: booking.status,
+            lockedUntil: booking.lockedUntil,
+            isMine: booking.userId == userId,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  Widget _buildErrorBanner(
+    ColorScheme cs,
+    String message, {
+    Future<void> Function()? onRetry,
+  }) {
+    return Card(
+      color: cs.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            Icon(Icons.error_outline, color: cs.onErrorContainer),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                message,
+                style: TextStyle(color: cs.onErrorContainer),
+              ),
+            ),
+            if (onRetry != null)
+              TextButton(
+                onPressed: onRetry,
+                child: const Text('Thử lại'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBookingSummary(ColorScheme cs, CourtBooking booking) {
+    final dateFormat = _formatDate(booking.startTime);
+    final timeRange =
+        '${_formatTime(booking.startTime)} - ${_formatTime(booking.endTime)}';
+    final unitLabel = _units.firstWhere(
+      (unit) => unit.id == booking.courtUnitId,
+      orElse: () => CourtUnit(
+        id: booking.courtUnitId,
+        label: booking.courtUnitId,
+        isActive: true,
+      ),
+    );
+
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Giữ chỗ của bạn',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: cs.primary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text('Ngày: $dateFormat'),
+            const SizedBox(height: 4),
+            Text('Khung giờ: $timeRange'),
+            const SizedBox(height: 4),
+            Text('Sân: ${unitLabel.label.isNotEmpty ? unitLabel.label : unitLabel.id}'),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Trạng thái: ${_describeStatus(booking.status)}',
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+                if (booking.status == CourtBookingStatus.locked)
+                  TextButton(
+                    onPressed: _isProcessing ? null : _cancelBooking,
+                    child: const Text('Hủy giữ chỗ'),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _describeStatus(CourtBookingStatus status) {
+    switch (status) {
+      case CourtBookingStatus.locked:
+        return 'Đang giữ chỗ';
+      case CourtBookingStatus.pending:
+        return 'Chờ duyệt';
+      case CourtBookingStatus.confirmed:
+        return 'Đã xác nhận';
+      case CourtBookingStatus.cancelled:
+        return 'Đã hủy';
+    }
+  }
+
+  VoidCallback? _resolvePrimaryAction() {
+    final booking = _activeBooking;
+    if (booking == null) return null;
+
+    if (booking.status == CourtBookingStatus.locked) {
+      return _isProcessing ? null : _confirmBooking;
+    }
+
+    if (booking.status == CourtBookingStatus.confirmed) {
+      return () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => PaymentPage(
+              booking: booking,
+              court: widget.court,
+            ),
+          ),
+        );
+      };
+    }
+
+    return null;
+  }
+
+  String _resolvePrimaryActionLabel() {
+    final booking = _activeBooking;
+    if (booking == null) {
+      return 'Chọn khung giờ';
+    }
+
+    switch (booking.status) {
+      case CourtBookingStatus.locked:
+        return _isProcessing ? 'Đang xử lý...' : 'Gửi yêu cầu';
+      case CourtBookingStatus.pending:
+        return 'Đang chờ duyệt';
+      case CourtBookingStatus.confirmed:
+        return 'Thanh toán';
+      case CourtBookingStatus.cancelled:
+        return 'Chọn khung giờ';
+    }
   }
 }

--- a/lib/pages/court/court_detail.dart
+++ b/lib/pages/court/court_detail.dart
@@ -188,8 +188,15 @@ class _CourtDetailState extends State<CourtDetail>
           padding: const EdgeInsets.only(right: 12),
           child: FilledButton(
             onPressed: () {
-              Navigator.push(context,
-                  MaterialPageRoute(builder: (context) => BookingPage()));
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => BookingPage(
+                    court: _detailData.court,
+                    courtService: _courtService,
+                  ),
+                ),
+              );
             },
             child: const Text('Đặt lịch'),
           ),

--- a/lib/pages/court/payment_page.dart
+++ b/lib/pages/court/payment_page.dart
@@ -1,7 +1,16 @@
+import 'package:badminton_booking_app/models/court.dart';
+import 'package:badminton_booking_app/models/court_booking.dart';
 import 'package:flutter/material.dart';
 
 class PaymentPage extends StatelessWidget {
-  const PaymentPage({super.key});
+  const PaymentPage({
+    super.key,
+    required this.booking,
+    required this.court,
+  });
+
+  final CourtBooking booking;
+  final Court court;
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +28,7 @@ class PaymentPage extends StatelessWidget {
                 children: [
                   _infoTab(cs),
                   const SizedBox(height: 20),
-                  // Other widgets can be added here
+                  _infoBooking(cs),
                 ],
               )),
 
@@ -85,8 +94,8 @@ class PaymentPage extends StatelessWidget {
                       AssetImage('assets/images/badminton_logo.jpg'),
                   radius: 28,
                 ),
-                title: const Text("Minh Nghĩa Badminton",
-                    style: TextStyle(fontWeight: FontWeight.bold)),
+                title: Text(court.name,
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
                 subtitle: Container(
                   margin: const EdgeInsets.only(top: 6),
                   padding:
@@ -101,31 +110,34 @@ class PaymentPage extends StatelessWidget {
               ),
               const Divider(),
               Row(
-                children: const [
-                  Icon(Icons.place, size: 20),
-                  SizedBox(width: 6),
+                children: [
+                  const Icon(Icons.place, size: 20),
+                  const SizedBox(width: 6),
                   Expanded(
                     child: Text(
-                        "55D Đ. Trần Nam Phú, Xuân Khánh, Ninh Kiều, Cần Thơ"),
+                      court.location.isNotEmpty
+                          ? court.location
+                          : 'Địa chỉ đang cập nhật',
+                    ),
                   ),
                 ],
               ),
               const SizedBox(height: 12),
               Row(
-                children: const [
-                  Icon(Icons.schedule, size: 20),
-                  SizedBox(width: 6),
-                  Text("05:00 - 22:00"),
+                children: [
+                  const Icon(Icons.schedule, size: 20),
+                  const SizedBox(width: 6),
+                  Text('${_formatTime(booking.startTime)} - ${_formatTime(booking.endTime)}'),
                 ],
               ),
               const SizedBox(height: 12),
               Row(
-                children: const [
-                  Icon(Icons.call, size: 20),
-                  SizedBox(width: 6),
+                children: [
+                  const Icon(Icons.call, size: 20),
+                  const SizedBox(width: 6),
                   Text(
-                    "0329672505",
-                    style: TextStyle(color: Colors.blue),
+                    court.phone.isNotEmpty ? court.phone : 'Số điện thoại chưa cập nhật',
+                    style: const TextStyle(color: Colors.blue),
                   ),
                 ],
               ),
@@ -152,38 +164,67 @@ class PaymentPage extends StatelessWidget {
           child: Column(
             children: [
               Row(
-                children: const [
-                  Icon(Icons.place, size: 20),
-                  SizedBox(width: 6),
+                children: [
+                  const Icon(Icons.calendar_today, size: 20),
+                  const SizedBox(width: 6),
+                  Text(_formatDate(booking.startTime)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const Icon(Icons.access_time_filled, size: 20),
+                  const SizedBox(width: 6),
+                  Text('${_formatTime(booking.startTime)} - ${_formatTime(booking.endTime)}'),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const Icon(Icons.shield, size: 20),
+                  const SizedBox(width: 6),
                   Expanded(
-                    child: Text(
-                        "55D Đ. Trần Nam Phú, Xuân Khánh, Ninh Kiều, Cần Thơ"),
+                    child: Text(_describeStatus(booking.status)),
                   ),
                 ],
               ),
-              const SizedBox(height: 12),
-              Row(
-                children: const [
-                  Icon(Icons.schedule, size: 20),
-                  SizedBox(width: 6),
-                  Text("05:00 - 22:00"),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: const [
-                  Icon(Icons.call, size: 20),
-                  SizedBox(width: 6),
-                  Text(
-                    "0329672505",
-                    style: TextStyle(color: Colors.blue),
-                  ),
-                ],
-              ),
+              const SizedBox(height: 16),
+              if (booking.status != CourtBookingStatus.confirmed)
+                Text(
+                  'Thanh toán sẽ khả dụng sau khi quản trị viên duyệt đơn đặt sân.',
+                  style: TextStyle(color: cs.onSurfaceVariant),
+                )
+              else
+                FilledButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.payment),
+                  label: const Text('Tiến hành thanh toán'),
+                ),
             ],
           ),
         ),
       ),
     );
+  }
+
+  String _formatTime(DateTime time) {
+    return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+  }
+
+  String _formatDate(DateTime time) {
+    return '${time.day.toString().padLeft(2, '0')}/${time.month.toString().padLeft(2, '0')}/${time.year}';
+  }
+
+  String _describeStatus(CourtBookingStatus status) {
+    switch (status) {
+      case CourtBookingStatus.locked:
+        return 'Đang giữ chỗ (chưa gửi duyệt)';
+      case CourtBookingStatus.pending:
+        return 'Đang chờ quản trị viên duyệt';
+      case CourtBookingStatus.confirmed:
+        return 'Đã được duyệt - có thể thanh toán';
+      case CourtBookingStatus.cancelled:
+        return 'Đặt sân đã bị hủy';
+    }
   }
 }

--- a/lib/services/court_booking_service.dart
+++ b/lib/services/court_booking_service.dart
@@ -1,0 +1,187 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/court_booking.dart';
+import 'pocketbase_client.dart';
+
+class CourtBookingServiceException implements Exception {
+  CourtBookingServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class CourtBookingService {
+  static const collection = 'court_bookings';
+
+  Future<List<CourtBooking>> listBookings({
+    required String courtId,
+    required DateTime date,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final dayStart = DateTime(date.year, date.month, date.day);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+    final now = DateTime.now().toUtc();
+
+    final filter = [
+      "court_id='${_escapeFilterValue(courtId)}'",
+      "start_time < '${_formatDate(dayEnd)}'",
+      "end_time > '${_formatDate(dayStart)}'",
+      "(status='pending' || status='confirmed' || (status='locked' && locked_until >= '${_formatDate(now)}'))",
+    ].join(' && ');
+
+    try {
+      final result = await pb.collection(collection).getList(
+            filter: filter,
+            perPage: 200,
+            sort: 'start_time',
+          );
+
+      return result.items
+          .map(CourtBooking.fromRecord)
+          .where((booking) =>
+              booking.status != CourtBookingStatus.cancelled &&
+              (booking.status != CourtBookingStatus.locked ||
+                  booking.isLockActive))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw CourtBookingServiceException(_mapClientException(error));
+    } catch (_) {
+      throw CourtBookingServiceException(
+        'Không thể tải lịch đặt sân. Vui lòng thử lại sau.',
+      );
+    }
+  }
+
+  Future<CourtBooking> lockSlot({
+    required String courtId,
+    required String courtUnitId,
+    required String userId,
+    required DateTime startTime,
+    required DateTime endTime,
+    String? note,
+    Duration holdDuration = const Duration(minutes: 15),
+  }) async {
+    final pb = await getPocketbaseInstance();
+
+    final overlapping = await _countOverlappingBookings(
+      pb,
+      courtUnitId: courtUnitId,
+      startTime: startTime,
+      endTime: endTime,
+    );
+
+    if (overlapping > 0) {
+      throw CourtBookingServiceException(
+        'Khung giờ này đã có người giữ chỗ hoặc đặt trước.',
+      );
+    }
+
+    final data = <String, dynamic>{
+      'court_id': courtId,
+      'court_unit_id': courtUnitId,
+      'user_id': userId,
+      'start_time': _formatDate(startTime),
+      'end_time': _formatDate(endTime),
+      'status': 'locked',
+      'locked_until': _formatDate(DateTime.now().add(holdDuration)),
+      if (note != null && note.trim().isNotEmpty) 'note': note.trim(),
+    };
+
+    try {
+      final record = await pb.collection(collection).create(body: data);
+      return CourtBooking.fromRecord(record);
+    } on ClientException catch (error) {
+      throw CourtBookingServiceException(_mapClientException(error));
+    } catch (_) {
+      throw CourtBookingServiceException(
+        'Không thể giữ chỗ cho khung giờ này. Vui lòng thử lại sau.',
+      );
+    }
+  }
+
+  Future<CourtBooking> confirmBooking(
+    String bookingId, {
+    String? note,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final data = <String, dynamic>{
+      'status': 'pending',
+      'locked_until': null,
+      if (note != null && note.trim().isNotEmpty) 'note': note.trim(),
+    };
+
+    try {
+      final record = await pb.collection(collection).update(
+            bookingId,
+            body: data,
+          );
+      return CourtBooking.fromRecord(record);
+    } on ClientException catch (error) {
+      throw CourtBookingServiceException(_mapClientException(error));
+    } catch (_) {
+      throw CourtBookingServiceException(
+        'Không thể gửi yêu cầu đặt sân. Vui lòng thử lại sau.',
+      );
+    }
+  }
+
+  Future<void> cancelBooking(String bookingId) async {
+    final pb = await getPocketbaseInstance();
+    try {
+      await pb.collection(collection).update(
+        bookingId,
+        body: {
+          'status': 'cancelled',
+        },
+      );
+    } on ClientException catch (error) {
+      throw CourtBookingServiceException(_mapClientException(error));
+    } catch (_) {
+      throw CourtBookingServiceException(
+        'Không thể hủy giữ chỗ. Vui lòng thử lại sau.',
+      );
+    }
+  }
+
+  Future<int> _countOverlappingBookings(
+    PocketBase pb, {
+    required String courtUnitId,
+    required DateTime startTime,
+    required DateTime endTime,
+  }) async {
+    final now = DateTime.now().toUtc();
+    final filter = [
+      "court_unit_id='${_escapeFilterValue(courtUnitId)}'",
+      "start_time < '${_formatDate(endTime)}'",
+      "end_time > '${_formatDate(startTime)}'",
+      "(status='pending' || status='confirmed' || (status='locked' && locked_until >= '${_formatDate(now)}'))",
+    ].join(' && ');
+
+    final result = await pb.collection(collection).getList(
+          filter: filter,
+          perPage: 1,
+        );
+    return result.items.length;
+  }
+
+  String _mapClientException(ClientException error) {
+    final data = error.response;
+    if (data != null) {
+      final message = data['message'];
+      if (message is String && message.isNotEmpty) {
+        return message;
+      }
+    }
+    return 'Có lỗi xảy ra. Vui lòng thử lại sau.';
+  }
+}
+
+String _formatDate(DateTime date) {
+  return date.toUtc().toIso8601String();
+}
+
+String _escapeFilterValue(String value) {
+  return value.replaceAll("'", "\\'");
+}


### PR DESCRIPTION
## Summary
- add PocketBase booking service and model to support 15-minute holds, confirmation and cancellation
- update the booking timeline UI to show slot status, allow locking, and surface the active reservation summary
- refresh the payment screen and README to explain the hold/approval/payment flow and server-side locking rationale

