### PR TITLE
Prevent overlapping bookings and auto-confirm payments

### DIFF
--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -591,8 +591,8 @@ class _BookingPageState extends State<BookingPage> {
             width: double.infinity,
             child: OutlinedButton(
               onPressed: hasAwaitingPayment
-                  ? () {
-                      Navigator.push(
+                  ? () async {
+                      final result = await Navigator.push<bool>(
                         context,
                         MaterialPageRoute(
                           builder: (context) => PaymentPage(
@@ -600,9 +600,14 @@ class _BookingPageState extends State<BookingPage> {
                             bookings:
                                 _awaitingPaymentForUser.toList(), // CHANGED
                             slotDuration: widget.slotDuration,
+                            bookingService: _bookingService,
                           ),
                         ),
                       );
+
+                      if (result == true && mounted) {
+                        await _loadBookings();
+                      }
                     }
                   : null,
               child: const Text('Thanh toán'),

--- a/lib/pages/court/payment_page.dart
+++ b/lib/pages/court/payment_page.dart
@@ -1,24 +1,41 @@
 import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court_detail.dart';
+import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-class PaymentPage extends StatelessWidget {
+class PaymentPage extends StatefulWidget {
   const PaymentPage({
     super.key,
     required this.detailData,
     required this.bookings,
     this.slotDuration = const Duration(hours: 1),
+    this.bookingService,
   });
 
   final CourtDetailData detailData;
   final List<CourtBooking> bookings;
   final Duration slotDuration;
+  final BookingService? bookingService;
+
+  @override
+  State<PaymentPage> createState() => _PaymentPageState();
+}
+
+class _PaymentPageState extends State<PaymentPage> {
+  late BookingService _bookingService;
+  bool _processing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _bookingService = widget.bookingService ?? BookingService();
+  }
 
   List<SelectedSlot> get _slots {
-    return bookings
-        .expand((booking) => booking.splitToSlots(slotDuration))
+    return widget.bookings
+        .expand((booking) => booking.splitToSlots(widget.slotDuration))
         .map((slot) => SelectedSlot(
               courtUnitId: slot.courtUnitId,
               startTime: slot.startTime.toUtc(),
@@ -38,7 +55,7 @@ class PaymentPage extends StatelessWidget {
   double get _totalPrice {
     var total = 0.0;
     for (final slot in _slots) {
-      total += calculateSlotPrice(detailData, slot, slotDuration);
+      total += calculateSlotPrice(widget.detailData, slot, widget.slotDuration);
     }
     return total;
   }
@@ -62,13 +79,13 @@ class PaymentPage extends StatelessWidget {
             _buildCourtInfoCard(cs),
             const SizedBox(height: 16),
             Expanded(
-              child: bookings.isEmpty
+              child: widget.bookings.isEmpty
                   ? _buildEmptyState()
                   : ListView.builder(
-                      itemCount: bookings.length,
+                      itemCount: widget.bookings.length,
                       itemBuilder: (context, index) {
-                        final booking = bookings[index];
-                        final slots = booking.splitToSlots(slotDuration);
+                        final booking = widget.bookings[index];
+                        final slots = booking.splitToSlots(widget.slotDuration);
                         return _buildBookingCard(cs, booking, slots);
                       },
                     ),
@@ -79,10 +96,16 @@ class PaymentPage extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: bookings.isEmpty
+                onPressed: widget.bookings.isEmpty || _processing
                     ? null
-                    : () => _showPaymentSuccess(context),
-                child: const Text('Thanh toán ngay'),
+                    : _handlePayment,
+                child: _processing
+                    ? const SizedBox(
+                        height: 22,
+                        width: 22,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Thanh toán ngay'),
               ),
             ),
             const SizedBox(height: 16),
@@ -108,7 +131,7 @@ class PaymentPage extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              detailData.court.name,
+              widget.detailData.court.name,
               style: TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.bold,
@@ -120,7 +143,7 @@ class PaymentPage extends StatelessWidget {
               children: [
                 const Icon(Icons.place, size: 18),
                 const SizedBox(width: 6),
-                Expanded(child: Text(detailData.court.location)),
+                Expanded(child: Text(widget.detailData.court.location)),
               ],
             ),
             const SizedBox(height: 6),
@@ -128,7 +151,7 @@ class PaymentPage extends StatelessWidget {
               children: [
                 const Icon(Icons.phone, size: 18),
                 const SizedBox(width: 6),
-                Text(detailData.court.phone),
+                Text(widget.detailData.court.phone),
               ],
             ),
           ],
@@ -172,7 +195,8 @@ class PaymentPage extends StatelessWidget {
   Widget _buildSlotRow(ColorScheme cs, SelectedSlot slot) {
     final timeLabel =
         '${DateFormat.Hm().format(slot.startTime.toLocal())} - ${DateFormat.Hm().format(slot.endTime.toLocal())}';
-    final price = calculateSlotPrice(detailData, slot, slotDuration);
+    final price =
+        calculateSlotPrice(widget.detailData, slot, widget.slotDuration);
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -245,14 +269,37 @@ class PaymentPage extends StatelessWidget {
         children: const [
           Icon(Icons.inbox_outlined, size: 48),
           SizedBox(height: 12),
-          Text('Chưa có lượt đặt sân nào được duyệt.'),
+          Text('Chưa có lượt đặt sân nào chờ thanh toán.'),
         ],
       ),
     );
   }
 
-  void _showPaymentSuccess(BuildContext context) {
-    showDialog<void>(
+  Future<void> _handlePayment() async {
+    setState(() => _processing = true);
+
+    try {
+      for (final booking in widget.bookings) {
+        await _bookingService.markAsConfirmed(booking.id);
+      }
+
+      if (!mounted) return;
+      await _showPaymentSuccess(context);
+      if (!mounted) return;
+      Navigator.of(context).pop(true);
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_describeError(error))),
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() => _processing = false);
+    }
+  }
+
+  Future<void> _showPaymentSuccess(BuildContext context) {
+    return showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Thanh toán thành công'),
@@ -260,9 +307,7 @@ class PaymentPage extends StatelessWidget {
             'Chúng tôi đã ghi nhận giao dịch của bạn. Chúc bạn có buổi chơi vui vẻ!'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.of(context)
-              ..pop()
-              ..maybePop(),
+            onPressed: () => Navigator.of(context).pop(),
             child: const Text('Hoàn tất'),
           ),
         ],
@@ -270,11 +315,18 @@ class PaymentPage extends StatelessWidget {
     );
   }
 
+  String _describeError(Object error) {
+    if (error is BookingServiceException) {
+      return error.message;
+    }
+    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
+  }
+
   String _resolveCourtLabel(String courtUnitId) {
-    if (detailData.units.isEmpty) return 'Sân';
-    final unit = detailData.units.firstWhere(
+    if (widget.detailData.units.isEmpty) return 'Sân';
+    final unit = widget.detailData.units.firstWhere(
       (unit) => unit.id == courtUnitId,
-      orElse: () => detailData.units.first,
+      orElse: () => widget.detailData.units.first,
     );
     return unit.label.isEmpty ? 'Sân' : unit.label;
   }

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -69,8 +69,17 @@ class BookingService {
     };
 
     try {
+      await _ensureNoConflictingBookings(
+        pb: pb,
+        courtId: courtId,
+        courtUnitId: courtUnitId,
+        startTime: startTime,
+        endTime: endTime,
+      );
       final record = await pb.collection(collection).create(body: body);
       return CourtBooking.fromRecord(record);
+    } on BookingServiceException {
+      rethrow;
     } on ClientException catch (error) {
       throw BookingServiceException(_mapClientException(error));
     } catch (_) {
@@ -122,6 +131,55 @@ class BookingService {
     } catch (_) {
       throw BookingServiceException(
           'Không thể xác nhận đặt sân. Vui lòng thử lại.');
+    }
+  }
+
+  Future<void> _ensureNoConflictingBookings({
+    required PocketBase pb,
+    required String courtId,
+    required String courtUnitId,
+    required DateTime startTime,
+    required DateTime endTime,
+  }) async {
+    final startIso = startTime.toUtc().toIso8601String();
+    final endIso = endTime.toUtc().toIso8601String();
+    final escapedCourt = _escapeFilterValue(courtId);
+    final escapedUnit = _escapeFilterValue(courtUnitId);
+
+    final filter =
+        "court_id='$escapedCourt' && court_unit_id='$escapedUnit' && start_time < '$endIso' && end_time > '$startIso' && status != 'cancelled' && status != 'expired'";
+
+    try {
+      final result = await pb.collection(collection).getList(
+            page: 1,
+            perPage: 200,
+            filter: filter,
+          );
+
+      final now = DateTime.now().toUtc();
+      for (final record in result.items) {
+        final booking = CourtBooking.fromRecord(record);
+
+        final isBlockingStatus = booking.status == BookingStatus.confirmed ||
+            booking.status == BookingStatus.awaitingPayment ||
+            (booking.status == BookingStatus.held &&
+                (booking.lockedUntil == null ||
+                    booking.lockedUntil!.isAfter(now)));
+
+        if (isBlockingStatus) {
+          throw BookingServiceException(
+            'Khung giờ này đã có lượt đặt khác. Vui lòng chọn thời gian khác.',
+          );
+        }
+      }
+    } on BookingServiceException {
+      rethrow;
+    } on ClientException catch (error) {
+      throw BookingServiceException(_mapClientException(error));
+    } catch (_) {
+      throw BookingServiceException(
+        'Không thể kiểm tra tình trạng sân. Vui lòng thử lại.',
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- block new holds when an overlapping booking already exists for a court unit
- convert the payment flow into a stateful experience that confirms bookings after payment and surfaces errors
- refresh the booking page after returning from payment using the shared booking service instance

