### PR TITLE
Add realtime booking updates via PocketBase subscriptions

### DIFF
--- a/lib/components/my_court_time.dart
+++ b/lib/components/my_court_time.dart
@@ -42,6 +42,7 @@ class CourtTimeline extends StatefulWidget {
     this.headerLeadingInset = 24.0,
     this.bookings = const [],
     this.selectedSlots = const {},
+    this.otherBookedSlots = const {},
     this.currentUserId,
     this.onSlotTap,
   }) : assert(endHour > startHour, 'endHour must be greater than startHour');
@@ -60,6 +61,7 @@ class CourtTimeline extends StatefulWidget {
   final Set<SelectedSlot> selectedSlots;
   final String? currentUserId;
   final void Function(SelectedSlot slot, bool shouldSelect)? onSlotTap;
+  final Set<SelectedSlot> otherBookedSlots;
 
   @override
   State<CourtTimeline> createState() => _CourtTimelineState();
@@ -113,11 +115,14 @@ class _CourtTimelineState extends State<CourtTimeline> {
       _rowIndexById = _buildRowIndexMap(widget.rows);
     }
 
+    // THÊM ĐIỀU KIỆN MỚI
     if (!listEquals(oldWidget.bookings, widget.bookings) ||
         oldWidget.currentUserId != widget.currentUserId ||
         oldWidget.date != widget.date ||
         oldWidget.startHour != widget.startHour ||
-        oldWidget.endHour != widget.endHour) {
+        oldWidget.endHour != widget.endHour ||
+        !setEquals(oldWidget.otherBookedSlots, widget.otherBookedSlots)) {
+      // DÒNG MỚI
       _statusMatrix = _buildStatusMatrix();
     }
   }
@@ -198,27 +203,59 @@ class _CourtTimelineState extends State<CourtTimeline> {
       growable: false,
     );
 
-    if (widget.bookings.isEmpty || _slotCount == 0) {
+    if (_slotCount == 0) {
       return matrix;
     }
 
-    final now = DateTime.now().toUtc();
+    // Bước 1: Tô màu cho các booking đã được xác nhận hoặc chờ thanh toán
+    // Đây là trạng thái có độ ưu tiên cao nhất, thuộc về bất kỳ ai
     for (final booking in widget.bookings) {
       final rowIndex = _rowIndexById[booking.courtUnitId];
       if (rowIndex == null) continue;
-      final status = _mapBookingToStatus(booking, now);
-      if (status == CourtSlotStatus.available) continue;
+
+      final status = _mapBookingToStatus(booking, DateTime.now().toUtc());
+      if (status == CourtSlotStatus.available ||
+          status == CourtSlotStatus.heldByMe ||
+          status == CourtSlotStatus.heldByOther) {
+        continue; // Bỏ qua trạng thái "held" và "available" ở bước này
+      }
 
       final startIndex = _indexFromDate(booking.startTime);
       final endIndex = _indexFromDate(booking.endTime);
       for (var column = startIndex; column < endIndex; column++) {
         if (column < 0 || column >= _slotCount) continue;
-        final current = matrix[rowIndex][column];
-        if (_statusPriority(status) >= _statusPriority(current)) {
-          matrix[rowIndex][column] = status;
+        matrix[rowIndex][column] = status;
+      }
+    }
+
+    // Bước 2: Tô màu cho các slot đã được người khác giữ (heldByOther)
+    // Logic này sẽ ghi đè lên các slot "available"
+    for (final slot in widget.otherBookedSlots) {
+      final rowIndex = _rowIndexById[slot.courtUnitId];
+      if (rowIndex == null) continue;
+      final columnIndex = _indexFromDate(slot.startTime);
+
+      if (columnIndex >= 0 && columnIndex < _slotCount) {
+        if (matrix[rowIndex][columnIndex] == CourtSlotStatus.available) {
+          matrix[rowIndex][columnIndex] = CourtSlotStatus.heldByOther;
         }
       }
     }
+
+    // Bước 3: Tô màu cho các slot được giữ bởi người dùng hiện tại (heldByMe)
+    // Logic này sẽ ghi đè lên các slot "available" và "heldByOther"
+    // Vì trạng thái này có ưu tiên cao hơn (để người dùng thấy slot của mình)
+    for (final slot in widget.selectedSlots) {
+      final rowIndex = _rowIndexById[slot.courtUnitId];
+      if (rowIndex == null) continue;
+      final columnIndex = _indexFromDate(slot.startTime);
+
+      if (columnIndex >= 0 && columnIndex < _slotCount) {
+        // Logic ưu tiên:heldByMe sẽ ghi đè các trạng thái khác
+        matrix[rowIndex][columnIndex] = CourtSlotStatus.heldByMe;
+      }
+    }
+
     return matrix;
   }
 

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -29,6 +29,8 @@ class _BookingPageState extends State<BookingPage> {
   late DateTime _selectedDate;
   late BookingService _bookingService;
 
+  final Set<SelectedSlot> _otherBookedSlots = {};
+
   final Set<SelectedSlot> _selectedSlots = <SelectedSlot>{};
   final Map<SelectedSlot, CourtBooking> _heldBookings = {};
   final Set<SelectedSlot> _processingSlots = {};
@@ -106,17 +108,31 @@ class _BookingPageState extends State<BookingPage> {
     if (!mounted) return;
     final newSelected = <SelectedSlot>{};
     final newHeld = <SelectedSlot, CourtBooking>{};
+    final newOtherBooked = <SelectedSlot>{};
 
-    if (_currentUserId != null) {
-      for (final booking in bookings) {
-        // CHANGED: dùng BookingStatus.held thay cho locked
-        if (booking.userId == _currentUserId &&
-            booking.status == BookingStatus.held &&
-            booking.isActiveLock) {
+    final now = DateTime.now().toUtc();
+
+    for (final booking in bookings) {
+      // Phân loại booking theo trạng thái
+      final isConfirmed = booking.status == BookingStatus.confirmed;
+      final isAwaitingPayment = booking.status == BookingStatus.awaitingPayment;
+      final isHeld = booking.status == BookingStatus.held &&
+          (booking.lockedUntil == null || booking.lockedUntil!.isAfter(now));
+
+      // Phân loại theo người dùng
+      if (booking.userId == _currentUserId) {
+        if (isHeld) {
           for (final slot in booking.splitToSlots(widget.slotDuration)) {
             final canonical = _canonicalizeSlot(slot);
             newSelected.add(canonical);
             newHeld[canonical] = booking;
+          }
+        }
+      } else {
+        // Đây là booking của người dùng khác
+        if (isConfirmed || isAwaitingPayment || isHeld) {
+          for (final slot in booking.splitToSlots(widget.slotDuration)) {
+            newOtherBooked.add(_canonicalizeSlot(slot));
           }
         }
       }
@@ -124,12 +140,12 @@ class _BookingPageState extends State<BookingPage> {
 
     setState(() {
       _bookings = bookings;
-      _selectedSlots
-        ..clear()
-        ..addAll(newSelected);
-      _heldBookings
-        ..clear()
-        ..addAll(newHeld);
+      _selectedSlots.clear();
+      _selectedSlots.addAll(newSelected);
+      _heldBookings.clear();
+      _heldBookings.addAll(newHeld);
+      _otherBookedSlots.clear();
+      _otherBookedSlots.addAll(newOtherBooked);
       _isLoading = false;
       if (clearError) {
         _errorMessage = null;
@@ -203,6 +219,16 @@ class _BookingPageState extends State<BookingPage> {
 
   void _handleSlotTap(SelectedSlot slot, bool shouldSelect) {
     final canonical = _canonicalizeSlot(slot);
+
+    // Thêm điều kiện kiểm tra slot đã bị đặt bởi người khác
+    if (_otherBookedSlots.contains(canonical)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Khung giờ này đã có người khác giữ hoặc đặt.')),
+      );
+      return;
+    }
+
     if (_processingSlots.contains(canonical)) {
       return;
     }
@@ -461,8 +487,10 @@ class _BookingPageState extends State<BookingPage> {
                           date: _selectedDate,
                           startHour: _startHour,
                           endHour: _endHour,
-                          bookings: _bookings,
-                          selectedSlots: _selectedSlots,
+                          bookings: _bookings, // Giữ nguyên bookings
+                          selectedSlots:
+                              _selectedSlots, // Giữ nguyên selectedSlots
+                          otherBookedSlots: _otherBookedSlots, // THÊM DÒNG NÀY
                           currentUserId: _currentUserId,
                           onSlotTap: _handleSlotTap,
                         ),

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -391,6 +391,56 @@ class _BookingPageState extends State<BookingPage> {
         booking.status == BookingStatus.awaitingPayment);
   }
 
+  Iterable<CourtBooking> get _blockingBookingsFromOthers {
+    final now = DateTime.now().toUtc();
+    return _bookings.where((booking) {
+      if (booking.userId == _currentUserId) {
+        return false;
+      }
+
+      switch (booking.status) {
+        case BookingStatus.confirmed:
+        case BookingStatus.awaitingPayment:
+          return true;
+        case BookingStatus.held:
+          return booking.lockedUntil == null ||
+              booking.lockedUntil!.isAfter(now);
+        case BookingStatus.cancelled:
+        case BookingStatus.expired:
+          return false;
+      }
+    });
+  }
+
+  String _labelForCourtUnit(String unitId) {
+    for (final unit in widget.detailData.units) {
+      if (unit.id == unitId) {
+        return unit.label.isEmpty ? 'Sân' : unit.label;
+      }
+    }
+    return 'Sân';
+  }
+
+  String _formatBookingTimeRange(CourtBooking booking) {
+    final start = DateFormat('HH:mm').format(booking.startTime.toLocal());
+    final end = DateFormat('HH:mm').format(booking.endTime.toLocal());
+    return '$start - $end';
+  }
+
+  String _describeOtherBookingStatus(CourtBooking booking) {
+    switch (booking.status) {
+      case BookingStatus.confirmed:
+        return 'Đã xác nhận';
+      case BookingStatus.awaitingPayment:
+        return 'Chờ thanh toán';
+      case BookingStatus.held:
+        return 'Đang giữ chỗ';
+      case BookingStatus.cancelled:
+      case BookingStatus.expired:
+        return '';
+    }
+  }
+
   int get _startHour {
     final minutes = widget.detailData.openingHours
         .map((item) => parseTimeToMinutes(item.openTime))
@@ -475,6 +525,8 @@ class _BookingPageState extends State<BookingPage> {
         children: [
           _buildHeader(cs, holdExpires),
           _buildLegend(cs),
+          if (_blockingBookingsFromOthers.isNotEmpty)
+            _buildOtherBookingsNotice(cs),
           Expanded(
             child: _isLoading
                 ? const Center(child: CircularProgressIndicator())
@@ -602,6 +654,59 @@ class _BookingPageState extends State<BookingPage> {
               'Chờ thanh toán'), // CHANGED
           _legendItem(
               cs.primaryContainer.withOpacity(0.9), 'Đã xác nhận'), // CHANGED
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOtherBookingsNotice(ColorScheme cs) {
+    final bookings = _blockingBookingsFromOthers.toList()
+      ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: cs.surfaceVariant.withOpacity(0.35),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.6)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.lock_clock, color: cs.primary),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Các khung giờ đã có người đặt',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: cs.onSurface,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ...bookings.map(
+            (booking) {
+              final statusLabel = _describeOtherBookingStatus(booking);
+              final parts = [
+                _formatBookingTimeRange(booking),
+                _labelForCourtUnit(booking.courtUnitId),
+                if (statusLabel.isNotEmpty) statusLabel,
+              ];
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 6),
+                child: Text(
+                  parts.join(' • '),
+                  style: TextStyle(color: cs.onSurfaceVariant),
+                ),
+              );
+            },
+          ),
         ],
       ),
     );

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -33,12 +33,15 @@ class _BookingPageState extends State<BookingPage> {
   final Map<SelectedSlot, CourtBooking> _heldBookings = {};
   final Set<SelectedSlot> _processingSlots = {};
 
+  BookingRealtimeSubscription? _realtimeSubscription;
+
   List<CourtBooking> _bookings = <CourtBooking>[];
 
   bool _isLoading = false;
   String? _errorMessage;
   bool _submittingRequest = false;
   String? _currentUserId;
+  bool _hasRealtimeInitialized = false;
 
   @override
   void initState() {
@@ -51,14 +54,33 @@ class _BookingPageState extends State<BookingPage> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final auth = Provider.of<AuthManager>(context);
+    final previousUserId = _currentUserId;
     final newUserId = auth.user?.id;
-    if (newUserId != _currentUserId) {
+    final shouldRestart =
+        !_hasRealtimeInitialized || newUserId != previousUserId;
+    if (shouldRestart) {
       _currentUserId = newUserId;
-      _loadBookings();
+      _hasRealtimeInitialized = true;
+      if (previousUserId != newUserId) {
+        _selectedSlots.clear();
+        _heldBookings.clear();
+      }
+      _restartRealtime();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant BookingPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.detailData.court.id != widget.detailData.court.id) {
+      _restartRealtime();
+    } else if (oldWidget.slotDuration != widget.slotDuration) {
+      _applyBookings(_bookings, clearError: false);
     }
   }
 
   Future<void> _loadBookings() async {
+    if (!mounted) return;
     setState(() {
       _isLoading = true;
       _errorMessage = null;
@@ -69,36 +91,88 @@ class _BookingPageState extends State<BookingPage> {
         courtId: widget.detailData.court.id,
         date: _selectedDate,
       );
+      if (!mounted) return;
+      _applyBookings(bookings);
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = _describeError(error);
+        _isLoading = false;
+      });
+    }
+  }
 
-      final newSelected = <SelectedSlot>{};
-      final newHeld = <SelectedSlot, CourtBooking>{};
+  void _applyBookings(List<CourtBooking> bookings, {bool clearError = true}) {
+    if (!mounted) return;
+    final newSelected = <SelectedSlot>{};
+    final newHeld = <SelectedSlot, CourtBooking>{};
 
-      if (_currentUserId != null) {
-        for (final booking in bookings) {
-          // CHANGED: dùng BookingStatus.held thay cho locked
-          if (booking.userId == _currentUserId &&
-              booking.status == BookingStatus.held &&
-              booking.isActiveLock) {
-            for (final slot in booking.splitToSlots(widget.slotDuration)) {
-              final canonical = _canonicalizeSlot(slot);
-              newSelected.add(canonical);
-              newHeld[canonical] = booking;
-            }
+    if (_currentUserId != null) {
+      for (final booking in bookings) {
+        // CHANGED: dùng BookingStatus.held thay cho locked
+        if (booking.userId == _currentUserId &&
+            booking.status == BookingStatus.held &&
+            booking.isActiveLock) {
+          for (final slot in booking.splitToSlots(widget.slotDuration)) {
+            final canonical = _canonicalizeSlot(slot);
+            newSelected.add(canonical);
+            newHeld[canonical] = booking;
           }
         }
       }
+    }
 
-      if (!mounted) return;
+    setState(() {
+      _bookings = bookings;
+      _selectedSlots
+        ..clear()
+        ..addAll(newSelected);
+      _heldBookings
+        ..clear()
+        ..addAll(newHeld);
+      _isLoading = false;
+      if (clearError) {
+        _errorMessage = null;
+      }
+    });
+  }
+
+  Future<void> _restartRealtime({bool emitInitial = true}) async {
+    final previous = _realtimeSubscription;
+    _realtimeSubscription = null;
+    if (previous != null) {
+      await previous.cancel();
+    }
+
+    if (!mounted) {
+      return;
+    }
+
+    if (emitInitial) {
       setState(() {
-        _bookings = bookings;
-        _selectedSlots
-          ..clear()
-          ..addAll(newSelected);
-        _heldBookings
-          ..clear()
-          ..addAll(newHeld);
-        _isLoading = false;
+        _isLoading = true;
+        _errorMessage = null;
       });
+    }
+
+    try {
+      final subscription = await _bookingService.subscribeToBookings(
+        courtId: widget.detailData.court.id,
+        date: _selectedDate,
+        emitInitial: emitInitial,
+        onData: (bookings) {
+          if (!mounted) return;
+          _applyBookings(bookings);
+        },
+        onError: (error) {
+          if (!mounted) return;
+          setState(() {
+            _errorMessage = _describeError(error);
+            _isLoading = false;
+          });
+        },
+      );
+      _realtimeSubscription = subscription;
     } catch (error) {
       if (!mounted) return;
       setState(() {
@@ -123,7 +197,7 @@ class _BookingPageState extends State<BookingPage> {
       setState(() {
         _selectedDate = picked;
       });
-      await _loadBookings();
+      await _restartRealtime();
     }
   }
 
@@ -338,6 +412,14 @@ class _BookingPageState extends State<BookingPage> {
     );
   }
 
+  @override
+  void dispose() {
+    final subscription = _realtimeSubscription;
+    _realtimeSubscription = null;
+    subscription?.cancel();
+    super.dispose();
+  }
+
   String _describeError(Object error) {
     if (error is BookingServiceException) {
       return error.message;
@@ -357,7 +439,7 @@ class _BookingPageState extends State<BookingPage> {
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            onPressed: _isLoading ? null : _loadBookings,
+            onPressed: _isLoading ? null : () => _restartRealtime(),
             tooltip: 'Tải lại trạng thái đặt sân',
           ),
         ],
@@ -648,7 +730,7 @@ class _BookingPageState extends State<BookingPage> {
           ),
           const SizedBox(height: 12),
           FilledButton(
-            onPressed: _loadBookings,
+            onPressed: () => _restartRealtime(),
             child: const Text('Thử lại'),
           ),
         ],

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -83,12 +83,12 @@ class BookingService {
     }
 
     final subscription = await pb.collection(collection).subscribe(
-          '*',
-          (_) async {
-            await loadLatest();
-          },
-          filter: filter,
-        );
+      '*',
+      (_) async {
+        await loadLatest();
+      },
+      filter: filter,
+    );
 
     return BookingRealtimeSubscription(() async {
       try {

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -94,23 +94,38 @@ class BookingService {
       try {
         final dynamic sub = subscription;
         final collectionApi = pb.collection(collection);
-        if (sub is RealtimeSubscription) {
-          try {
-            await (sub as dynamic).unsubscribe();
-            return;
-          } catch (_) {
-            await collectionApi.unsubscribe(sub.id);
+
+        try {
+          final dynamic maybeUnsubscribe = sub.unsubscribe;
+          if (maybeUnsubscribe is Future<void> Function()) {
+            await maybeUnsubscribe();
             return;
           }
-        } else if (sub is Future<void> Function()) {
+        } catch (_) {
+          // ignore and try other strategies
+        }
+
+        if (sub is Future<void> Function()) {
           await sub();
           return;
-        } else if (sub is String) {
+        }
+
+        try {
+          final dynamic maybeId = sub.id;
+          if (maybeId is String && maybeId.isNotEmpty) {
+            await collectionApi.unsubscribe(maybeId);
+            return;
+          }
+        } catch (_) {
+          // ignore and try other strategies
+        }
+
+        if (sub is String) {
           await collectionApi.unsubscribe(sub);
           return;
-        } else {
-          await collectionApi.unsubscribe('*');
         }
+
+        await collectionApi.unsubscribe('*');
       } catch (_) {
         try {
           await pb.collection(collection).unsubscribe('*');

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -12,6 +12,20 @@ class BookingServiceException implements Exception {
   String toString() => message;
 }
 
+class BookingRealtimeSubscription {
+  BookingRealtimeSubscription(this._cancel);
+
+  final Future<void> Function() _cancel;
+
+  Future<void> cancel() async {
+    try {
+      await _cancel();
+    } catch (_) {
+      // Ignore cancellation errors to keep the UI stable.
+    }
+  }
+}
+
 class BookingService {
   static const collection = 'court_bookings';
 
@@ -20,13 +34,7 @@ class BookingService {
     required DateTime date,
   }) async {
     final pb = await getPocketbaseInstance();
-
-    final dayStart = DateTime(date.year, date.month, date.day).toUtc();
-    final dayEnd = dayStart.add(const Duration(days: 1));
-
-    final escapedCourt = _escapeFilterValue(courtId);
-    final filter =
-        "court_id='$escapedCourt' && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'";
+    final filter = _buildDailyCourtFilter(courtId: courtId, date: date);
 
     try {
       final result = await pb.collection(collection).getList(
@@ -43,6 +51,72 @@ class BookingService {
       throw BookingServiceException(
           'Không thể tải lịch đặt sân. Vui lòng thử lại sau.');
     }
+  }
+
+  Future<BookingRealtimeSubscription> subscribeToBookings({
+    required String courtId,
+    required DateTime date,
+    required void Function(List<CourtBooking> bookings) onData,
+    void Function(Object error)? onError,
+    bool emitInitial = true,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final filter = _buildDailyCourtFilter(courtId: courtId, date: date);
+
+    var isFetching = false;
+
+    Future<void> loadLatest() async {
+      if (isFetching) return;
+      isFetching = true;
+      try {
+        final bookings = await listBookings(courtId: courtId, date: date);
+        onData(bookings);
+      } catch (error) {
+        onError?.call(error);
+      } finally {
+        isFetching = false;
+      }
+    }
+
+    if (emitInitial) {
+      await loadLatest();
+    }
+
+    final subscription = await pb.collection(collection).subscribe(
+          '*',
+          (_) async {
+            await loadLatest();
+          },
+          filter: filter,
+        );
+
+    return BookingRealtimeSubscription(() async {
+      try {
+        final dynamic sub = subscription;
+        final collectionApi = pb.collection(collection);
+        if (sub is RealtimeSubscription) {
+          try {
+            await (sub as dynamic).unsubscribe();
+            return;
+          } catch (_) {
+            await collectionApi.unsubscribe(sub.id);
+            return;
+          }
+        } else if (sub is Future<void> Function()) {
+          await sub();
+          return;
+        } else if (sub is String) {
+          await collectionApi.unsubscribe(sub);
+          return;
+        } else {
+          await collectionApi.unsubscribe('*');
+        }
+      } catch (_) {
+        try {
+          await pb.collection(collection).unsubscribe('*');
+        } catch (_) {}
+      }
+    });
   }
 
   Future<CourtBooking> lockSlot({
@@ -185,6 +259,16 @@ class BookingService {
 
   String _escapeFilterValue(String value) {
     return value.replaceAll("'", "\\'");
+  }
+
+  String _buildDailyCourtFilter({
+    required String courtId,
+    required DateTime date,
+  }) {
+    final dayStart = DateTime(date.year, date.month, date.day).toUtc();
+    final dayEnd = dayStart.add(const Duration(days: 1));
+    final escapedCourt = _escapeFilterValue(courtId);
+    return "court_id='$escapedCourt' && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'";
   }
 
   String _mapClientException(ClientException error) {


### PR DESCRIPTION
## Summary
- add a reusable booking realtime subscription helper to the booking service
- hook the booking page into PocketBase realtime updates so the timeline stays in sync automatically
- update manual refresh and retry actions to restart the realtime stream instead of only fetching once
