### PR TITLE
Refactor booking flow into BookingManager provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:badminton_booking_app/pages/court/booking_manager.dart';
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
@@ -32,6 +33,9 @@ class MyApp extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create: (ctx) => CourtManager(),
+        ),
+        ChangeNotifierProvider(
+          create: (ctx) => BookingManager(),
         ),
       ],
       child: Consumer<AuthManager>(

--- a/lib/models/booking.dart
+++ b/lib/models/booking.dart
@@ -111,6 +111,13 @@ class SelectedSlot {
   final DateTime startTime;
   final DateTime endTime;
 
+  /// Unique key for identifying a slot regardless of timezone representation.
+  String get key {
+    final startUtc = startTime.toUtc();
+    final endUtc = endTime.toUtc();
+    return '${courtUnitId}_${startUtc.millisecondsSinceEpoch}_${endUtc.millisecondsSinceEpoch}';
+  }
+
   SelectedSlot copyWith({
     DateTime? startTime,
     DateTime? endTime,

--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -28,8 +28,7 @@ class BookingManager with ChangeNotifier {
   final Map<String, CourtBooking> _heldByMe = <String, CourtBooking>{};
   final Map<String, SelectedSlot> _heldSlots = <String, SelectedSlot>{};
 
-  RealtimeSubscription? _realtimeSubscription;
-  StreamSubscription<RecordSubscriptionEvent>? _rtSub;
+  bool _isRealtimeSubscribed = false;
 
   String? get courtId => _courtId;
   DateTime get date => _date;
@@ -418,39 +417,40 @@ class BookingManager with ChangeNotifier {
   Future<void> _setupRealtime(String courtId) async {
     try {
       final pb = await getPocketbaseInstance();
-      _realtimeSubscription =
-          await pb.collection(BookingService.collection).subscribe('*');
-      _rtSub = _realtimeSubscription?.stream.listen((event) {
-        final record = event.record;
-        if (record != null) {
-          final recordCourtId = (record.data['court_id'] as String?) ?? '';
-          if (recordCourtId != _courtId) {
-            return;
+      await pb.collection(BookingService.collection).subscribe(
+        '*',
+        (RecordSubscriptionEvent event) {
+          final record = event.record;
+          if (record != null) {
+            final recordCourtId = (record.data['court_id'] as String?) ?? '';
+            final activeCourtId = _courtId ?? courtId;
+            if (recordCourtId != activeCourtId) {
+              return;
+            }
           }
-        }
-        // ignore errors – background refresh only
-        _refreshBookingsInternal().then((_) {
-          notifyListeners();
-        }).catchError((_) {});
-      });
+          // ignore errors – background refresh only
+          _refreshBookingsInternal().then((_) {
+            notifyListeners();
+          }).catchError((_) {});
+        },
+      );
+      _isRealtimeSubscribed = true;
     } catch (_) {
       // Realtime not critical; ignore errors silently.
     }
   }
 
   Future<void> _teardownRealtime() async {
-    await _rtSub?.cancel();
-    _rtSub = null;
-    if (_realtimeSubscription != null) {
-      try {
-        final pb = await getPocketbaseInstance();
-        await pb
-            .collection(BookingService.collection)
-            .unsubscribe(_realtimeSubscription!);
-      } catch (_) {
-        // ignore
-      }
-      _realtimeSubscription = null;
+    if (!_isRealtimeSubscribed) {
+      return;
+    }
+    try {
+      final pb = await getPocketbaseInstance();
+      await pb.collection(BookingService.collection).unsubscribe('*');
+    } catch (_) {
+      // ignore
+    } finally {
+      _isRealtimeSubscribed = false;
     }
   }
 

--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -1,0 +1,463 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../../models/booking.dart';
+import '../../services/booking_service.dart';
+import '../../services/pocketbase_client.dart';
+
+class BookingManager with ChangeNotifier {
+  BookingManager({BookingService? bookingService})
+      : _bookingService = bookingService ?? BookingService();
+
+  final BookingService _bookingService;
+
+  String? _courtId;
+  DateTime _date = DateTime.now();
+  String? _currentUserId;
+  Duration _slotDuration = const Duration(hours: 1);
+
+  bool _isInitialized = false;
+  bool _isLoading = false;
+  bool _isMutating = false;
+  String? _error;
+
+  List<CourtBooking> _bookings = <CourtBooking>[];
+  final Set<SelectedSlot> _selectedSlots = <SelectedSlot>{};
+  final Map<String, CourtBooking> _heldByMe = <String, CourtBooking>{};
+  final Map<String, SelectedSlot> _heldSlots = <String, SelectedSlot>{};
+
+  RealtimeSubscription? _realtimeSubscription;
+  StreamSubscription<RecordSubscriptionEvent>? _rtSub;
+
+  String? get courtId => _courtId;
+  DateTime get date => _date;
+  String? get currentUserId => _currentUserId;
+  Duration get slotDuration => _slotDuration;
+  bool get isInitialized => _isInitialized;
+  bool get isLoading => _isLoading;
+  bool get isMutating => _isMutating;
+  String? get error => _error;
+
+  List<CourtBooking> get bookings => List.unmodifiable(_bookings);
+  Set<SelectedSlot> get selectedSlots => Set.unmodifiable(_selectedSlots);
+  Map<String, CourtBooking> get heldByMe => Map.unmodifiable(_heldByMe);
+  List<SelectedSlot> get heldSlots {
+    final items = _heldSlots.values.toList(growable: false);
+    items.sort((a, b) => a.startTime.compareTo(b.startTime));
+    return items;
+  }
+
+  List<CourtBooking> get heldBookings {
+    final map = <String, CourtBooking>{};
+    for (final booking in _heldByMe.values) {
+      map[booking.id] = booking;
+    }
+    final items = map.values.toList(growable: false)
+      ..sort((a, b) => a.startTime.compareTo(b.startTime));
+    return items;
+  }
+
+  Iterable<CourtBooking> get awaitingPaymentBookings {
+    if (_currentUserId == null) {
+      return const Iterable<CourtBooking>.empty();
+    }
+    return _bookings.where((booking) =>
+        booking.userId == _currentUserId &&
+        booking.status == BookingStatus.awaitingPayment);
+  }
+
+  DateTime? get holdExpiresAt {
+    DateTime? result;
+    for (final booking in heldBookings) {
+      final locked = booking.lockedUntil;
+      if (locked == null) continue;
+      if (result == null || locked.isBefore(result)) {
+        result = locked;
+      }
+    }
+    return result;
+  }
+
+  Future<void> init({
+    required String courtId,
+    required DateTime date,
+    String? userId,
+    Duration? slotDuration,
+  }) async {
+    _courtId = courtId;
+    _date = DateTime(date.year, date.month, date.day);
+    _currentUserId = userId;
+    if (slotDuration != null) {
+      _slotDuration = slotDuration;
+    }
+
+    _selectedSlots.clear();
+    _heldByMe.clear();
+    _heldSlots.clear();
+    _error = null;
+    _isLoading = true;
+    _isInitialized = true;
+    notifyListeners();
+
+    await _teardownRealtime();
+
+    try {
+      await _refreshBookingsInternal();
+      await _setupRealtime(courtId);
+    } catch (error) {
+      _error = _describeError(error);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> changeDate(DateTime newDate) async {
+    if (_courtId == null) return;
+    await init(
+      courtId: _courtId!,
+      date: newDate,
+      userId: _currentUserId,
+      slotDuration: _slotDuration,
+    );
+  }
+
+  Future<void> refetch({bool showLoading = false}) async {
+    if (_courtId == null) return;
+    if (showLoading) {
+      _isLoading = true;
+      notifyListeners();
+    }
+    try {
+      await _refreshBookingsInternal();
+    } catch (error) {
+      _error = _describeError(error);
+      rethrow;
+    } finally {
+      if (showLoading) {
+        _isLoading = false;
+      }
+      notifyListeners();
+    }
+  }
+
+  void updateSlotDuration(Duration duration) {
+    if (duration == _slotDuration) return;
+    _slotDuration = duration;
+    _rebuildHeldSlots();
+    notifyListeners();
+  }
+
+  bool isSlotUnavailable(SelectedSlot slot, {String? myUserId}) {
+    final canonical = _canonicalize(slot);
+    final key = canonical.key;
+    if (_heldByMe.containsKey(key)) {
+      return true;
+    }
+
+    final requesterId = myUserId ?? _currentUserId;
+    for (final booking in _bookings) {
+      if (booking.courtUnitId != canonical.courtUnitId) continue;
+      if (!_isBlockingBooking(booking)) continue;
+      if (_overlapsBooking(booking, canonical)) {
+        if (requesterId == null) {
+          return true;
+        }
+        if (booking.userId == requesterId) {
+          return true;
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void toggleSelect(SelectedSlot slot) {
+    final canonical = _canonicalize(slot);
+    if (_selectedSlots.remove(canonical)) {
+      notifyListeners();
+      return;
+    }
+
+    if (isSlotUnavailable(canonical, myUserId: _currentUserId)) {
+      return;
+    }
+
+    for (final existing in _selectedSlots) {
+      if (existing.courtUnitId != canonical.courtUnitId) continue;
+      if (_slotsOverlap(existing, canonical)) {
+        return;
+      }
+    }
+
+    _selectedSlots.add(canonical);
+    notifyListeners();
+  }
+
+  Future<void> holdSelected({required String userId}) async {
+    if (_courtId == null) return;
+    if (_selectedSlots.isEmpty) return;
+
+    final slots = _selectedSlots.toList(growable: false)
+      ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+    _isMutating = true;
+    notifyListeners();
+
+    try {
+      for (final slot in slots) {
+        final booking = await _bookingService.lockSlot(
+          courtId: _courtId!,
+          courtUnitId: slot.courtUnitId,
+          userId: userId,
+          startTime: slot.startTime.toUtc(),
+          endTime: slot.endTime.toUtc(),
+        );
+        _replaceBooking(booking);
+        final key = slot.key;
+        _heldByMe[key] = booking;
+        _heldSlots[key] = slot;
+      }
+      _selectedSlots.clear();
+    } on BookingServiceException {
+      rethrow;
+    } catch (error) {
+      rethrow;
+    } finally {
+      _isMutating = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> cancelHold(SelectedSlot slot) async {
+    final canonical = _canonicalize(slot);
+    final key = canonical.key;
+    final booking = _heldByMe[key];
+
+    if (booking == null) {
+      if (_selectedSlots.remove(canonical)) {
+        notifyListeners();
+      }
+      return;
+    }
+
+    _isMutating = true;
+    notifyListeners();
+
+    try {
+      await _bookingService.releaseBooking(booking.id);
+      _removeHeldBookingById(booking.id);
+      _bookings.removeWhere((element) => element.id == booking.id);
+    } on BookingServiceException {
+      rethrow;
+    } catch (error) {
+      rethrow;
+    } finally {
+      _isMutating = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> proceedToPayment() async {
+    final toUpdate = heldBookings;
+    if (toUpdate.isEmpty) return;
+
+    _isMutating = true;
+    notifyListeners();
+
+    try {
+      for (final booking in toUpdate) {
+        final updated = await _bookingService.submitForApproval(booking.id);
+        _replaceBooking(updated);
+        _removeHeldBookingById(updated.id);
+      }
+    } on BookingServiceException {
+      rethrow;
+    } catch (error) {
+      rethrow;
+    } finally {
+      _isMutating = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> confirmAllAfterPayment() async {
+    if (_currentUserId == null) return;
+    final awaiting = _bookings
+        .where((booking) =>
+            booking.userId == _currentUserId &&
+            booking.status == BookingStatus.awaitingPayment)
+        .toList(growable: false);
+    if (awaiting.isEmpty) return;
+
+    _isMutating = true;
+    notifyListeners();
+
+    try {
+      for (final booking in awaiting) {
+        final updated = await _bookingService.markAsConfirmed(booking.id);
+        _replaceBooking(updated);
+      }
+    } on BookingServiceException {
+      rethrow;
+    } catch (error) {
+      rethrow;
+    } finally {
+      _isMutating = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    unawaited(_teardownRealtime());
+    super.dispose();
+  }
+
+  Future<void> _refreshBookingsInternal() async {
+    if (_courtId == null) return;
+    final bookings = await _bookingService.listBookings(
+      courtId: _courtId!,
+      date: _date,
+    );
+    bookings.sort((a, b) => a.startTime.compareTo(b.startTime));
+    _bookings = bookings;
+    _rebuildHeldSlots();
+  }
+
+  void _replaceBooking(CourtBooking booking) {
+    final index = _bookings.indexWhere((item) => item.id == booking.id);
+    if (index >= 0) {
+      _bookings[index] = booking;
+    } else {
+      _bookings.add(booking);
+    }
+    _bookings.sort((a, b) => a.startTime.compareTo(b.startTime));
+  }
+
+  void _rebuildHeldSlots() {
+    _heldByMe.clear();
+    _heldSlots.clear();
+    if (_currentUserId == null) return;
+    for (final booking in _bookings) {
+      if (booking.userId != _currentUserId) continue;
+      if (booking.status != BookingStatus.held) continue;
+      if (!booking.isActiveLock) continue;
+      for (final slot in booking.splitToSlots(_slotDuration)) {
+        final canonical = _canonicalize(slot);
+        final key = canonical.key;
+        _heldByMe[key] = booking;
+        _heldSlots[key] = canonical;
+      }
+    }
+  }
+
+  bool _isBlockingBooking(CourtBooking booking) {
+    switch (booking.status) {
+      case BookingStatus.held:
+        return booking.isActiveLock;
+      case BookingStatus.awaitingPayment:
+      case BookingStatus.confirmed:
+        return true;
+      case BookingStatus.cancelled:
+      case BookingStatus.expired:
+        return false;
+    }
+  }
+
+  bool _overlapsBooking(CourtBooking booking, SelectedSlot slot) {
+    final bookingStart = booking.startTime.toUtc();
+    final bookingEnd = booking.endTime.toUtc();
+    return _intervalsOverlap(
+      bookingStart,
+      bookingEnd,
+      slot.startTime.toUtc(),
+      slot.endTime.toUtc(),
+    );
+  }
+
+  bool _slotsOverlap(SelectedSlot a, SelectedSlot b) {
+    return _intervalsOverlap(
+      a.startTime.toUtc(),
+      a.endTime.toUtc(),
+      b.startTime.toUtc(),
+      b.endTime.toUtc(),
+    );
+  }
+
+  bool _intervalsOverlap(
+    DateTime startA,
+    DateTime endA,
+    DateTime startB,
+    DateTime endB,
+  ) {
+    return startA.isBefore(endB) && startB.isBefore(endA);
+  }
+
+  SelectedSlot _canonicalize(SelectedSlot slot) {
+    return SelectedSlot(
+      courtUnitId: slot.courtUnitId,
+      startTime: slot.startTime.toUtc(),
+      endTime: slot.endTime.toUtc(),
+    );
+  }
+
+  void _removeHeldBookingById(String bookingId) {
+    final keysToRemove = _heldByMe.entries
+        .where((entry) => entry.value.id == bookingId)
+        .map((entry) => entry.key)
+        .toList(growable: false);
+    for (final key in keysToRemove) {
+      _heldByMe.remove(key);
+      _heldSlots.remove(key);
+    }
+  }
+
+  Future<void> _setupRealtime(String courtId) async {
+    try {
+      final pb = await getPocketbaseInstance();
+      _realtimeSubscription =
+          await pb.collection(BookingService.collection).subscribe('*');
+      _rtSub = _realtimeSubscription?.stream.listen((event) {
+        final record = event.record;
+        if (record != null) {
+          final recordCourtId = (record.data['court_id'] as String?) ?? '';
+          if (recordCourtId != _courtId) {
+            return;
+          }
+        }
+        // ignore errors – background refresh only
+        _refreshBookingsInternal().then((_) {
+          notifyListeners();
+        }).catchError((_) {});
+      });
+    } catch (_) {
+      // Realtime not critical; ignore errors silently.
+    }
+  }
+
+  Future<void> _teardownRealtime() async {
+    await _rtSub?.cancel();
+    _rtSub = null;
+    if (_realtimeSubscription != null) {
+      try {
+        final pb = await getPocketbaseInstance();
+        await pb
+            .collection(BookingService.collection)
+            .unsubscribe(_realtimeSubscription!);
+      } catch (_) {
+        // ignore
+      }
+      _realtimeSubscription = null;
+    }
+  }
+
+  String _describeError(Object error) {
+    if (error is BookingServiceException) {
+      return error.message;
+    }
+    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
+  }
+}

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -1,8 +1,9 @@
 import 'package:badminton_booking_app/components/my_court_time.dart';
 import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court_detail.dart';
-import 'package:badminton_booking_app/pages/court/payment_page.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
+import 'package:badminton_booking_app/pages/court/booking_manager.dart';
+import 'package:badminton_booking_app/pages/court/payment_page.dart';
 import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
 import 'package:flutter/material.dart';
@@ -13,12 +14,10 @@ class BookingPage extends StatefulWidget {
   const BookingPage({
     super.key,
     required this.detailData,
-    this.bookingService,
     this.slotDuration = const Duration(hours: 1),
   });
 
   final CourtDetailData detailData;
-  final BookingService? bookingService;
   final Duration slotDuration;
 
   @override
@@ -26,330 +25,55 @@ class BookingPage extends StatefulWidget {
 }
 
 class _BookingPageState extends State<BookingPage> {
-  late DateTime _selectedDate;
-  late BookingService _bookingService;
-
-  final Set<SelectedSlot> _selectedSlots = <SelectedSlot>{};
-  final Map<SelectedSlot, CourtBooking> _heldBookings = {};
-  final Set<SelectedSlot> _processingSlots = {};
-
-  List<CourtBooking> _bookings = <CourtBooking>[];
-
-  bool _isLoading = false;
-  String? _errorMessage;
-  bool _submittingRequest = false;
-  String? _currentUserId;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedDate = DateTime.now();
-    _bookingService = widget.bookingService ?? BookingService();
-  }
+  String? _lastUserId;
+  String? _lastCourtId;
+  bool _initRequested = false;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final auth = Provider.of<AuthManager>(context);
-    final newUserId = auth.user?.id;
-    if (newUserId != _currentUserId) {
-      _currentUserId = newUserId;
-      _loadBookings();
-    }
-  }
+    final userId = auth.user?.id;
+    final manager = Provider.of<BookingManager>(context, listen: false);
 
-  Future<void> _loadBookings() async {
-    setState(() {
-      _isLoading = true;
-      _errorMessage = null;
-    });
+    final shouldInit = !_initRequested ||
+        _lastCourtId != widget.detailData.court.id ||
+        manager.courtId != widget.detailData.court.id ||
+        _lastUserId != userId;
 
-    try {
-      final bookings = await _bookingService.listBookings(
+    if (shouldInit) {
+      final initialDate = manager.isInitialized &&
+              manager.courtId == widget.detailData.court.id
+          ? manager.date
+          : DateTime.now();
+      manager.init(
         courtId: widget.detailData.court.id,
-        date: _selectedDate,
+        date: initialDate,
+        userId: userId,
+        slotDuration: widget.slotDuration,
       );
-
-      final newSelected = <SelectedSlot>{};
-      final newHeld = <SelectedSlot, CourtBooking>{};
-
-      if (_currentUserId != null) {
-        for (final booking in bookings) {
-          // CHANGED: dùng BookingStatus.held thay cho locked
-          if (booking.userId == _currentUserId &&
-              booking.status == BookingStatus.held &&
-              booking.isActiveLock) {
-            for (final slot in booking.splitToSlots(widget.slotDuration)) {
-              final canonical = _canonicalizeSlot(slot);
-              newSelected.add(canonical);
-              newHeld[canonical] = booking;
-            }
-          }
-        }
-      }
-
-      if (!mounted) return;
-      setState(() {
-        _bookings = bookings;
-        _selectedSlots
-          ..clear()
-          ..addAll(newSelected);
-        _heldBookings
-          ..clear()
-          ..addAll(newHeld);
-        _isLoading = false;
-      });
-    } catch (error) {
-      if (!mounted) return;
-      setState(() {
-        _errorMessage = _describeError(error);
-        _isLoading = false;
-      });
+      _initRequested = true;
+      _lastCourtId = widget.detailData.court.id;
+      _lastUserId = userId;
+    } else if (manager.slotDuration != widget.slotDuration) {
+      manager.updateSlotDuration(widget.slotDuration);
     }
-  }
-
-  Future<void> _selectDate() async {
-    final first = DateTime.now().subtract(const Duration(days: 1));
-    final last = DateTime.now().add(const Duration(days: 365));
-
-    final picked = await showDatePicker(
-      context: context,
-      initialDate: _selectedDate,
-      firstDate: first,
-      lastDate: last,
-    );
-
-    if (picked != null && picked != _selectedDate) {
-      setState(() {
-        _selectedDate = picked;
-      });
-      await _loadBookings();
-    }
-  }
-
-  void _handleSlotTap(SelectedSlot slot, bool shouldSelect) {
-    final canonical = _canonicalizeSlot(slot);
-    if (_processingSlots.contains(canonical)) {
-      return;
-    }
-
-    if (shouldSelect) {
-      if (_currentUserId == null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Vui lòng đăng nhập để giữ chỗ.')),
-        );
-        return;
-      }
-      _lockSlot(canonical);
-    } else {
-      _releaseSlot(canonical);
-    }
-  }
-
-  Future<void> _lockSlot(SelectedSlot slot) async {
-    setState(() => _processingSlots.add(slot));
-
-    try {
-      final booking = await _bookingService.lockSlot(
-        courtId: widget.detailData.court.id,
-        courtUnitId: slot.courtUnitId,
-        userId: _currentUserId!,
-        startTime: slot.startTime.toUtc(),
-        endTime: slot.endTime.toUtc(),
-      );
-
-      final bookingSlots = booking.splitToSlots(widget.slotDuration);
-      if (!mounted) return;
-      setState(() {
-        _bookings = [..._bookings, booking];
-        for (final item in bookingSlots) {
-          final canonical = _canonicalizeSlot(item);
-          _selectedSlots.add(canonical);
-          _heldBookings[canonical] = booking;
-        }
-      });
-    } catch (error) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_describeError(error))),
-      );
-    } finally {
-      if (!mounted) return;
-      setState(() => _processingSlots.remove(slot));
-    }
-  }
-
-  Future<void> _releaseSlot(SelectedSlot slot) async {
-    final booking = _heldBookings.remove(slot);
-    if (booking == null) {
-      setState(() => _selectedSlots.remove(slot));
-      return;
-    }
-
-    setState(() {
-      _processingSlots.add(slot);
-    });
-
-    try {
-      await _bookingService.releaseBooking(booking.id);
-      if (!mounted) return;
-      setState(() {
-        _selectedSlots.remove(slot);
-        _bookings.removeWhere((item) => item.id == booking.id);
-      });
-    } catch (error) {
-      if (!mounted) return;
-      _heldBookings[slot] = booking;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_describeError(error))),
-      );
-    } finally {
-      if (!mounted) return;
-      setState(() => _processingSlots.remove(slot));
-    }
-  }
-
-  // CHANGED: đổi tên hàm và text sang "chuyển sang chờ thanh toán"
-  Future<void> _proceedToAwaitingPayment() async {
-    if (_heldBookings.isEmpty) return;
-    setState(() => _submittingRequest = true);
-
-    try {
-      final updates = <CourtBooking>[];
-      for (final booking in _heldBookings.values) {
-        // vẫn gọi service cũ, nhưng service nên update status = 'awaiting_payment'
-        final updated = await _bookingService.submitForApproval(booking.id);
-        updates.add(updated);
-      }
-
-      if (!mounted) return;
-      setState(() {
-        for (final updated in updates) {
-          _bookings.removeWhere((item) => item.id == updated.id);
-          _bookings.add(updated);
-        }
-        _selectedSlots.clear();
-        _heldBookings.clear();
-        _submittingRequest = false;
-      });
-
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Đã chuyển sang trạng thái chờ thanh toán.'),
-        ),
-      );
-      await _loadBookings();
-    } catch (error) {
-      if (!mounted) return;
-      setState(() => _submittingRequest = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_describeError(error))),
-      );
-    }
-  }
-
-  List<CourtTimelineRow> get _rows {
-    final units = widget.detailData.units;
-    if (units.isEmpty) {
-      return [const CourtTimelineRow(id: 'default', label: 'Sân 1')];
-    }
-    return units
-        .where((unit) => unit.isActive)
-        .map((unit) => CourtTimelineRow(
-              id: unit.id,
-              label: unit.label.isEmpty ? 'Sân' : unit.label,
-            ))
-        .toList();
-  }
-
-  Duration get _totalDuration {
-    var minutes = 0;
-    for (final slot in _selectedSlots) {
-      minutes += slot.endTime.difference(slot.startTime).inMinutes;
-    }
-    return Duration(minutes: minutes);
-  }
-
-  double get _totalPrice {
-    var total = 0.0;
-    for (final slot in _selectedSlots) {
-      total += calculateSlotPrice(
-        widget.detailData,
-        slot,
-        widget.slotDuration,
-      );
-    }
-    return total;
-  }
-
-  // CHANGED: dùng awaitingPayment thay cho confirmed
-  Iterable<CourtBooking> get _awaitingPaymentForUser {
-    if (_currentUserId == null) return const Iterable.empty();
-    return _bookings.where((booking) =>
-        booking.userId == _currentUserId &&
-        booking.status == BookingStatus.awaitingPayment);
-  }
-
-  int get _startHour {
-    final minutes = widget.detailData.openingHours
-        .map((item) => parseTimeToMinutes(item.openTime))
-        .whereType<int>();
-    if (minutes.isEmpty) return 6;
-    final minMinute = minutes.reduce((a, b) => a < b ? a : b);
-    final base = (minMinute / 60).floor();
-    if (base < 0) return 0;
-    if (base > 23) return 23;
-    return base;
-  }
-
-  int get _endHour {
-    final minutes = widget.detailData.openingHours
-        .map((item) => parseTimeToMinutes(item.closeTime))
-        .whereType<int>();
-    if (minutes.isEmpty) return 22;
-    final maxMinute = minutes.reduce((a, b) => a > b ? a : b);
-    var endHour = (maxMinute / 60).ceil();
-    if (endHour < 1) {
-      endHour = 1;
-    } else if (endHour > 24) {
-      endHour = 24;
-    }
-    return endHour <= _startHour ? _startHour + 1 : endHour;
-  }
-
-  DateTime? get _holdExpiresAt {
-    DateTime? result;
-    for (final booking in _heldBookings.values) {
-      final locked = booking.lockedUntil?.toLocal();
-      if (locked == null) continue;
-      if (result == null || locked.isBefore(result)) {
-        result = locked;
-      }
-    }
-    return result;
-  }
-
-  SelectedSlot _canonicalizeSlot(SelectedSlot slot) {
-    return SelectedSlot(
-      courtUnitId: slot.courtUnitId,
-      startTime: slot.startTime.toUtc(),
-      endTime: slot.endTime.toUtc(),
-    );
-  }
-
-  String _describeError(Object error) {
-    if (error is BookingServiceException) {
-      return error.message;
-    }
-    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
   }
 
   @override
   Widget build(BuildContext context) {
+    final manager = context.watch<BookingManager>();
+    final userId = context.select<AuthManager, String?>(
+      (auth) => auth.user?.id,
+    );
+
     final cs = Theme.of(context).colorScheme;
     final rows = _rows;
-    final holdExpires = _holdExpiresAt;
+    final bookings = manager.bookings;
+    final selectedSlots = manager.selectedSlots;
+    final awaitingPayment = manager.awaitingPaymentBookings.toList(growable: false);
+    final heldSlots = manager.heldSlots;
+    final holdExpires = manager.holdExpiresAt?.toLocal();
 
     return Scaffold(
       appBar: AppBar(
@@ -357,45 +81,143 @@ class _BookingPageState extends State<BookingPage> {
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            onPressed: _isLoading ? null : _loadBookings,
             tooltip: 'Tải lại trạng thái đặt sân',
+            onPressed: manager.isLoading
+                ? null
+                : () async {
+                    try {
+                      await manager.refetch(showLoading: true);
+                    } catch (error) {
+                      if (!mounted) return;
+                      _showError(error);
+                    }
+                  },
           ),
         ],
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          _buildHeader(cs, holdExpires),
+          _buildHeader(cs, manager.date, holdExpires, selectedSlots, manager),
           _buildLegend(cs),
           Expanded(
-            child: _isLoading
+            child: manager.isLoading
                 ? const Center(child: CircularProgressIndicator())
-                : _errorMessage != null
-                    ? _buildErrorState(cs)
+                : manager.error != null
+                    ? _buildErrorState(cs, manager)
                     : Padding(
                         padding: const EdgeInsets.only(bottom: 12),
                         child: CourtTimeline(
                           rows: rows,
-                          date: _selectedDate,
+                          date: manager.date,
                           startHour: _startHour,
                           endHour: _endHour,
-                          bookings: _bookings,
-                          selectedSlots: _selectedSlots,
-                          currentUserId: _currentUserId,
-                          onSlotTap: _handleSlotTap,
+                          bookings: bookings,
+                          selectedSlots: selectedSlots,
+                          currentUserId: userId,
+                          onSlotTap: (slot, shouldSelect) =>
+                              _handleSlotTap(slot, shouldSelect, userId, manager),
                         ),
                       ),
           ),
-          _buildSummary(cs, holdExpires),
+          _buildSummary(
+            cs,
+            selectedSlots,
+            awaitingPayment,
+            holdExpires,
+            heldSlots,
+            manager,
+          ),
         ],
       ),
-      bottomNavigationBar: _buildActions(cs),
+      bottomNavigationBar: _buildActions(
+        cs,
+        userId,
+        manager,
+        awaitingPayment,
+      ),
     );
   }
 
-  Widget _buildHeader(ColorScheme cs, DateTime? holdExpires) {
-    final dateLabel = DateFormat('dd/MM/yyyy').format(_selectedDate);
-    final totalDuration = _totalDuration;
+  Future<void> _selectDate(BookingManager manager) async {
+    final now = DateTime.now();
+    final first = now.subtract(const Duration(days: 1));
+    final last = now.add(const Duration(days: 365));
+
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: manager.date,
+      firstDate: first,
+      lastDate: last,
+    );
+
+    if (picked != null && !_isSameDay(picked, manager.date)) {
+      try {
+        await manager.changeDate(picked);
+      } catch (error) {
+        if (!mounted) return;
+        _showError(error);
+      }
+    }
+  }
+
+  void _handleSlotTap(
+    SelectedSlot slot,
+    bool shouldSelect,
+    String? userId,
+    BookingManager manager,
+  ) {
+    if (!shouldSelect && manager.heldByMe.containsKey(slot.key)) {
+      _cancelHold(slot, manager);
+      return;
+    }
+
+    if (shouldSelect) {
+      if (userId == null) {
+        _showLoginRequired();
+        return;
+      }
+      if (manager.isSlotUnavailable(slot, myUserId: userId)) {
+        return;
+      }
+      manager.toggleSelect(slot);
+    } else {
+      manager.toggleSelect(slot);
+    }
+  }
+
+  Future<void> _cancelHold(SelectedSlot slot, BookingManager manager) async {
+    try {
+      await manager.cancelHold(slot);
+    } catch (error) {
+      if (!mounted) return;
+      _showError(error);
+    }
+  }
+
+  void _showLoginRequired() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Vui lòng đăng nhập để giữ chỗ.')),
+    );
+  }
+
+  void _showError(Object error) {
+    final message =
+        error is BookingServiceException ? error.message : 'Đã xảy ra lỗi. Vui lòng thử lại.';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  Widget _buildHeader(
+    ColorScheme cs,
+    DateTime selectedDate,
+    DateTime? holdExpires,
+    Set<SelectedSlot> selectedSlots,
+    BookingManager manager,
+  ) {
+    final dateLabel = DateFormat('dd/MM/yyyy').format(selectedDate);
+    final totalDuration = _totalDuration(selectedSlots);
     final durationLabel = totalDuration.inMinutes == 0
         ? 'Chưa chọn thời gian'
         : '${totalDuration.inMinutes ~/ 60}h ${totalDuration.inMinutes % 60}p';
@@ -421,7 +243,7 @@ class _BookingPageState extends State<BookingPage> {
                 style: FilledButton.styleFrom(
                   backgroundColor: cs.surface,
                 ),
-                onPressed: _selectDate,
+                onPressed: () => _selectDate(manager),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -457,8 +279,11 @@ class _BookingPageState extends State<BookingPage> {
             const SizedBox(height: 4),
             Row(
               children: [
-                Icon(Icons.hourglass_bottom,
-                    size: 18, color: cs.onPrimary.withOpacity(0.9)),
+                Icon(
+                  Icons.hourglass_bottom,
+                  size: 18,
+                  color: cs.onPrimary.withOpacity(0.9),
+                ),
                 const SizedBox(width: 6),
                 Text(
                   'Giữ chỗ đến ${DateFormat('HH:mm').format(holdExpires)}',
@@ -486,19 +311,26 @@ class _BookingPageState extends State<BookingPage> {
         runSpacing: 8,
         children: [
           _legendItem(
-              cs.secondaryContainer.withOpacity(0.7), 'Đang giữ chỗ'), // held
+              cs.secondaryContainer.withOpacity(0.7), 'Đang giữ chỗ'),
           _legendItem(cs.errorContainer.withOpacity(0.9), 'Người khác giữ'),
-          _legendItem(cs.tertiaryContainer.withOpacity(0.9),
-              'Chờ thanh toán'), // CHANGED
           _legendItem(
-              cs.primaryContainer.withOpacity(0.9), 'Đã xác nhận'), // CHANGED
+              cs.tertiaryContainer.withOpacity(0.9), 'Chờ thanh toán'),
+          _legendItem(
+              cs.primaryContainer.withOpacity(0.9), 'Đã xác nhận'),
         ],
       ),
     );
   }
 
-  Widget _buildSummary(ColorScheme cs, DateTime? holdExpires) {
-    final totalPrice = _totalPrice;
+  Widget _buildSummary(
+    ColorScheme cs,
+    Set<SelectedSlot> selectedSlots,
+    List<CourtBooking> awaitingPayment,
+    DateTime? holdExpires,
+    List<SelectedSlot> heldSlots,
+    BookingManager manager,
+  ) {
+    final totalPrice = _totalPrice(selectedSlots);
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -521,17 +353,13 @@ class _BookingPageState extends State<BookingPage> {
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  _selectedSlots.isEmpty
-                      ? 'Chọn khung giờ để giữ chỗ tối đa 15 phút.'
-                      : 'Đã chọn ${_selectedSlots.length} khung giờ.',
+                  'Tổng cộng',
+                  style: TextStyle(
+                    color: cs.onSurface,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Icon(Icons.payments_outlined, size: 20, color: cs.primary),
               const SizedBox(width: 8),
               Text(
                 formatCurrency(totalPrice),
@@ -543,17 +371,40 @@ class _BookingPageState extends State<BookingPage> {
               ),
             ],
           ),
-          // CHANGED: thông báo số booking chờ thanh toán thay vì đã duyệt
-          if (_awaitingPaymentForUser.isNotEmpty) ...[
+          if (awaitingPayment.isNotEmpty) ...[
             const SizedBox(height: 8),
             Row(
               children: [
                 Icon(Icons.pending_actions, size: 20, color: cs.primary),
                 const SizedBox(width: 6),
                 Text(
-                  'Có ${_awaitingPaymentForUser.length} lượt chờ thanh toán.',
+                  'Có ${awaitingPayment.length} lượt chờ thanh toán.',
                   style: TextStyle(color: cs.primary),
                 ),
+              ],
+            ),
+          ],
+          if (heldSlots.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              'Đang giữ (${heldSlots.length})',
+              style: TextStyle(
+                fontWeight: FontWeight.w600,
+                color: cs.onSurface,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final slot in heldSlots)
+                  InputChip(
+                    label: Text(_formatSlotLabel(slot)),
+                    onDeleted: manager.isMutating
+                        ? null
+                        : () => _cancelHold(slot, manager),
+                  ),
               ],
             ),
           ],
@@ -562,9 +413,14 @@ class _BookingPageState extends State<BookingPage> {
     );
   }
 
-  Widget _buildActions(ColorScheme cs) {
-    // CHANGED: bật thanh toán khi có booking awaiting_payment
-    final hasAwaitingPayment = _awaitingPaymentForUser.isNotEmpty;
+  Widget _buildActions(
+    ColorScheme cs,
+    String? userId,
+    BookingManager manager,
+    List<CourtBooking> awaitingPayment,
+  ) {
+    final hasSelection = manager.selectedSlots.isNotEmpty;
+    final hasAwaitingPayment = awaitingPayment.isNotEmpty;
 
     return SafeArea(
       minimum: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -574,42 +430,76 @@ class _BookingPageState extends State<BookingPage> {
           SizedBox(
             width: double.infinity,
             child: FilledButton(
-              onPressed: _heldBookings.isEmpty || _submittingRequest
+              onPressed: !hasSelection || manager.isMutating
                   ? null
-                  : _proceedToAwaitingPayment, // CHANGED
-              child: _submittingRequest
+                  : () async {
+                      if (userId == null) {
+                        _showLoginRequired();
+                        return;
+                      }
+                      try {
+                        await manager.holdSelected(userId: userId);
+                        if (!mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Đã giữ chỗ thành công.')),
+                        );
+                      } catch (error) {
+                        if (!mounted) return;
+                        _showError(error);
+                      }
+                    },
+              child: manager.isMutating && hasSelection
                   ? const SizedBox(
                       height: 22,
                       width: 22,
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
-                  : const Text('Chuyển sang thanh toán'), // CHANGED
+                  : Text('Giữ chỗ (${manager.selectedSlots.length})'),
+            ),
+          ),
+          const SizedBox(height: 10),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.tonal(
+              onPressed: manager.heldBookings.isEmpty || manager.isMutating
+                  ? null
+                  : () async {
+                      try {
+                        await manager.proceedToPayment();
+                        if (!mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                              content: Text('Đã chuyển sang trạng thái chờ thanh toán.')),
+                        );
+                        await manager.refetch(showLoading: true);
+                      } catch (error) {
+                        if (!mounted) return;
+                        _showError(error);
+                      }
+                    },
+              child: const Text('Chuyển sang thanh toán'),
             ),
           ),
           const SizedBox(height: 10),
           SizedBox(
             width: double.infinity,
             child: OutlinedButton(
-              onPressed: hasAwaitingPayment
-                  ? () async {
+              onPressed: !hasAwaitingPayment || manager.isMutating
+                  ? null
+                  : () async {
                       final result = await Navigator.push<bool>(
                         context,
                         MaterialPageRoute(
                           builder: (context) => PaymentPage(
                             detailData: widget.detailData,
-                            bookings:
-                                _awaitingPaymentForUser.toList(), // CHANGED
                             slotDuration: widget.slotDuration,
-                            bookingService: _bookingService,
                           ),
                         ),
                       );
-
                       if (result == true && mounted) {
-                        await _loadBookings();
+                        await manager.refetch(showLoading: true);
                       }
-                    }
-                  : null,
+                    },
               child: const Text('Thanh toán'),
             ),
           ),
@@ -637,22 +527,111 @@ class _BookingPageState extends State<BookingPage> {
     );
   }
 
-  Widget _buildErrorState(ColorScheme cs) {
+  Widget _buildErrorState(ColorScheme cs, BookingManager manager) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
-            _errorMessage ?? 'Không thể tải dữ liệu.',
+            manager.error ?? 'Không thể tải dữ liệu.',
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 12),
           FilledButton(
-            onPressed: _loadBookings,
+            onPressed: () async {
+              try {
+                await manager.refetch(showLoading: true);
+              } catch (error) {
+                if (!mounted) return;
+                _showError(error);
+              }
+            },
             child: const Text('Thử lại'),
           ),
         ],
       ),
     );
+  }
+
+  List<CourtTimelineRow> get _rows {
+    final units = widget.detailData.units;
+    if (units.isEmpty) {
+      return [const CourtTimelineRow(id: 'default', label: 'Sân 1')];
+    }
+    return units
+        .where((unit) => unit.isActive)
+        .map((unit) => CourtTimelineRow(
+              id: unit.id,
+              label: unit.label.isEmpty ? 'Sân' : unit.label,
+            ))
+        .toList();
+  }
+
+  Duration _totalDuration(Set<SelectedSlot> slots) {
+    var minutes = 0;
+    for (final slot in slots) {
+      minutes += slot.endTime.difference(slot.startTime).inMinutes;
+    }
+    return Duration(minutes: minutes);
+  }
+
+  double _totalPrice(Set<SelectedSlot> slots) {
+    var total = 0.0;
+    for (final slot in slots) {
+      total += calculateSlotPrice(
+        widget.detailData,
+        slot,
+        widget.slotDuration,
+      );
+    }
+    return total;
+  }
+
+  int get _startHour {
+    final minutes = widget.detailData.openingHours
+        .map((item) => parseTimeToMinutes(item.openTime))
+        .whereType<int>();
+    if (minutes.isEmpty) return 6;
+    final minMinute = minutes.reduce((a, b) => a < b ? a : b);
+    final base = (minMinute / 60).floor();
+    if (base < 0) return 0;
+    if (base > 23) return 23;
+    return base;
+  }
+
+  int get _endHour {
+    final minutes = widget.detailData.openingHours
+        .map((item) => parseTimeToMinutes(item.closeTime))
+        .whereType<int>();
+    if (minutes.isEmpty) return 22;
+    final maxMinute = minutes.reduce((a, b) => a > b ? a : b);
+    var endHour = (maxMinute / 60).ceil();
+    if (endHour < 1) {
+      endHour = 1;
+    } else if (endHour > 24) {
+      endHour = 24;
+    }
+    return endHour <= _startHour ? _startHour + 1 : endHour;
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  String _formatSlotLabel(SelectedSlot slot) {
+    final formatter = DateFormat('HH:mm');
+    final start = formatter.format(slot.startTime.toLocal());
+    final end = formatter.format(slot.endTime.toLocal());
+    final courtLabel = _resolveCourtLabel(slot.courtUnitId);
+    return '$courtLabel $start-$end';
+  }
+
+  String _resolveCourtLabel(String courtUnitId) {
+    if (widget.detailData.units.isEmpty) return 'Sân';
+    final unit = widget.detailData.units.firstWhere(
+      (unit) => unit.id == courtUnitId,
+      orElse: () => widget.detailData.units.first,
+    );
+    return unit.label.isEmpty ? 'Sân' : unit.label;
   }
 }

--- a/lib/pages/court/payment_page.dart
+++ b/lib/pages/court/payment_page.dart
@@ -1,72 +1,37 @@
 import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court_detail.dart';
+import 'package:badminton_booking_app/pages/court/booking_manager.dart';
 import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
 class PaymentPage extends StatefulWidget {
   const PaymentPage({
     super.key,
     required this.detailData,
-    required this.bookings,
     this.slotDuration = const Duration(hours: 1),
-    this.bookingService,
   });
 
   final CourtDetailData detailData;
-  final List<CourtBooking> bookings;
   final Duration slotDuration;
-  final BookingService? bookingService;
 
   @override
   State<PaymentPage> createState() => _PaymentPageState();
 }
 
 class _PaymentPageState extends State<PaymentPage> {
-  late BookingService _bookingService;
-  bool _processing = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _bookingService = widget.bookingService ?? BookingService();
-  }
-
-  List<SelectedSlot> get _slots {
-    return widget.bookings
-        .expand((booking) => booking.splitToSlots(widget.slotDuration))
-        .map((slot) => SelectedSlot(
-              courtUnitId: slot.courtUnitId,
-              startTime: slot.startTime.toUtc(),
-              endTime: slot.endTime.toUtc(),
-            ))
-        .toList();
-  }
-
-  Duration get _totalDuration {
-    var minutes = 0;
-    for (final slot in _slots) {
-      minutes += slot.endTime.difference(slot.startTime).inMinutes;
-    }
-    return Duration(minutes: minutes);
-  }
-
-  double get _totalPrice {
-    var total = 0.0;
-    for (final slot in _slots) {
-      total += calculateSlotPrice(widget.detailData, slot, widget.slotDuration);
-    }
-    return total;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final totalDuration = _totalDuration;
+    final manager = context.watch<BookingManager>();
+    final bookings = manager.awaitingPaymentBookings.toList(growable: false);
+    final slots = _collectSlots(bookings);
+    final totalDuration = _totalDuration(slots);
     final durationLabel = totalDuration.inMinutes == 0
         ? '0 phút'
         : '${totalDuration.inMinutes ~/ 60}h ${totalDuration.inMinutes % 60}p';
+    final cs = Theme.of(context).colorScheme;
 
     return Scaffold(
       appBar: AppBar(
@@ -79,27 +44,41 @@ class _PaymentPageState extends State<PaymentPage> {
             _buildCourtInfoCard(cs),
             const SizedBox(height: 16),
             Expanded(
-              child: widget.bookings.isEmpty
+              child: bookings.isEmpty
                   ? _buildEmptyState()
                   : ListView.builder(
-                      itemCount: widget.bookings.length,
+                      itemCount: bookings.length,
                       itemBuilder: (context, index) {
-                        final booking = widget.bookings[index];
-                        final slots = booking.splitToSlots(widget.slotDuration);
-                        return _buildBookingCard(cs, booking, slots);
+                        final booking = bookings[index];
+                        final bookingSlots = booking.splitToSlots(widget.slotDuration);
+                        return _buildBookingCard(cs, booking, bookingSlots);
                       },
                     ),
             ),
             const SizedBox(height: 12),
-            _buildTotalRow(cs, durationLabel),
+            _buildTotalRow(cs, durationLabel, slots),
             const SizedBox(height: 12),
             SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: widget.bookings.isEmpty || _processing
+                onPressed: bookings.isEmpty || manager.isMutating
                     ? null
-                    : _handlePayment,
-                child: _processing
+                    : () async {
+                        final bookingManager = context.read<BookingManager>();
+                        try {
+                          await bookingManager.confirmAllAfterPayment();
+                          if (!mounted) return;
+                          await bookingManager.refetch(showLoading: true);
+                          if (!mounted) return;
+                          await _showPaymentSuccess();
+                          if (!mounted) return;
+                          Navigator.of(context).pop(true);
+                        } catch (error) {
+                          if (!mounted) return;
+                          _showError(error);
+                        }
+                      },
+                child: manager.isMutating
                     ? const SizedBox(
                         height: 22,
                         width: 22,
@@ -195,8 +174,7 @@ class _PaymentPageState extends State<PaymentPage> {
   Widget _buildSlotRow(ColorScheme cs, SelectedSlot slot) {
     final timeLabel =
         '${DateFormat.Hm().format(slot.startTime.toLocal())} - ${DateFormat.Hm().format(slot.endTime.toLocal())}';
-    final price =
-        calculateSlotPrice(widget.detailData, slot, widget.slotDuration);
+    final price = calculateSlotPrice(widget.detailData, slot, widget.slotDuration);
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -220,7 +198,13 @@ class _PaymentPageState extends State<PaymentPage> {
     );
   }
 
-  Widget _buildTotalRow(ColorScheme cs, String durationLabel) {
+  Widget _buildTotalRow(
+    ColorScheme cs,
+    String durationLabel,
+    List<SelectedSlot> slots,
+  ) {
+    final totalPrice = _totalPrice(slots);
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
       decoration: BoxDecoration(
@@ -248,7 +232,7 @@ class _PaymentPageState extends State<PaymentPage> {
             children: [
               const Text('Tổng cộng'),
               Text(
-                formatCurrency(_totalPrice),
+                formatCurrency(totalPrice),
                 style: TextStyle(
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
@@ -275,30 +259,36 @@ class _PaymentPageState extends State<PaymentPage> {
     );
   }
 
-  Future<void> _handlePayment() async {
-    setState(() => _processing = true);
-
-    try {
-      for (final booking in widget.bookings) {
-        await _bookingService.markAsConfirmed(booking.id);
-      }
-
-      if (!mounted) return;
-      await _showPaymentSuccess(context);
-      if (!mounted) return;
-      Navigator.of(context).pop(true);
-    } catch (error) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_describeError(error))),
-      );
-    } finally {
-      if (!mounted) return;
-      setState(() => _processing = false);
-    }
+  List<SelectedSlot> _collectSlots(List<CourtBooking> bookings) {
+    return bookings
+        .expand((booking) => booking.splitToSlots(widget.slotDuration))
+        .map(
+          (slot) => SelectedSlot(
+            courtUnitId: slot.courtUnitId,
+            startTime: slot.startTime.toUtc(),
+            endTime: slot.endTime.toUtc(),
+          ),
+        )
+        .toList(growable: false);
   }
 
-  Future<void> _showPaymentSuccess(BuildContext context) {
+  Duration _totalDuration(List<SelectedSlot> slots) {
+    var minutes = 0;
+    for (final slot in slots) {
+      minutes += slot.endTime.difference(slot.startTime).inMinutes;
+    }
+    return Duration(minutes: minutes);
+  }
+
+  double _totalPrice(List<SelectedSlot> slots) {
+    var total = 0.0;
+    for (final slot in slots) {
+      total += calculateSlotPrice(widget.detailData, slot, widget.slotDuration);
+    }
+    return total;
+  }
+
+  Future<void> _showPaymentSuccess() {
     return showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
@@ -315,11 +305,12 @@ class _PaymentPageState extends State<PaymentPage> {
     );
   }
 
-  String _describeError(Object error) {
-    if (error is BookingServiceException) {
-      return error.message;
-    }
-    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
+  void _showError(Object error) {
+    final message =
+        error is BookingServiceException ? error.message : 'Đã xảy ra lỗi. Vui lòng thử lại.';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
   }
 
   String _resolveCourtLabel(String courtUnitId) {


### PR DESCRIPTION
## Summary
- add a BookingManager ChangeNotifier that owns booking state, slot validation, realtime updates, and mutations
- refactor the booking timeline and payment pages to consume BookingManager instead of managing local state
- register the new provider at the app root and extend SelectedSlot with a stable key for slot bookkeeping
