### PR TITLE
Rename booking provider to booking manager

### DIFF
--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -1,0 +1,493 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:intl/intl.dart';
+
+import 'package:badminton_booking_app/models/booking.dart';
+import 'package:badminton_booking_app/models/court_detail.dart';
+import 'package:badminton_booking_app/services/booking_service.dart';
+import 'package:badminton_booking_app/utils/booking_helpers.dart';
+
+class BookingManager extends ChangeNotifier {
+  BookingManager({
+    required this.detailData,
+    BookingService? bookingService,
+    this.slotDuration = const Duration(hours: 1),
+  }) : _bookingService = bookingService ?? BookingService() {
+    _selectedDate = _normalizeDate(DateTime.now());
+    _selectedCourtUnitId = _resolveInitialCourtUnitId();
+
+    Future.microtask(() => loadBookings());
+  }
+
+  final CourtDetailData detailData;
+  final Duration slotDuration;
+  final BookingService _bookingService;
+
+  DateTime _selectedDate = DateTime.now();
+  String? _selectedCourtUnitId;
+  String? _currentUserId;
+
+  bool _isLoading = false;
+  bool _isSubmittingHeldBookings = false;
+  bool _isConfirmingAwaitingPaymentBookings = false;
+
+  String? _friendlyErrorMessage;
+
+  List<CourtBooking> _loadedBookings = <CourtBooking>[];
+  final Set<SelectedSlot> _selectedSlots = <SelectedSlot>{};
+  final Map<SelectedSlot, CourtBooking> _heldBookingsBySlot = <SelectedSlot, CourtBooking>{};
+  final Set<SelectedSlot> _slotsInProgress = <SelectedSlot>{};
+
+  final Map<String, _BookingCacheEntry> _bookingCacheByKey = <String, _BookingCacheEntry>{};
+
+  DateTime get selectedDate => _selectedDate;
+  String? get selectedCourtUnitId => _selectedCourtUnitId;
+  bool get isLoading => _isLoading;
+  bool get isSubmittingHeldBookings => _isSubmittingHeldBookings;
+  bool get isConfirmingAwaitingPayment =>
+      _isConfirmingAwaitingPaymentBookings;
+  String? get friendlyErrorMessage => _friendlyErrorMessage;
+  List<CourtBooking> get bookings => List.unmodifiable(_loadedBookings);
+  List<CourtBooking> get bookingsForSelectedUnit {
+    final unitId = _selectedCourtUnitId;
+    if (unitId == null) {
+      return List.unmodifiable(_loadedBookings);
+    }
+    return List.unmodifiable(
+      _loadedBookings.where((booking) => booking.courtUnitId == unitId),
+    );
+  }
+
+  Set<SelectedSlot> get selectedSlots => Set.unmodifiable(_selectedSlots);
+  Iterable<CourtBooking> get heldBookings => _heldBookingsBySlot.values;
+  Iterable<CourtBooking> get awaitingPaymentBookings =>
+      _loadedBookings.where(_isAwaitingPaymentAndMine);
+
+  bool get hasHeldBookings => _heldBookingsBySlot.isNotEmpty;
+  bool get hasAwaitingPaymentBookings => awaitingPaymentBookings.isNotEmpty;
+
+  Duration get totalSelectedDuration {
+    var totalMinutes = 0;
+    for (final slot in _selectedSlots) {
+      totalMinutes += slot.endTime.difference(slot.startTime).inMinutes;
+    }
+    return Duration(minutes: totalMinutes);
+  }
+
+  double get totalSelectedPrice {
+    var totalPrice = 0.0;
+    for (final slot in _selectedSlots) {
+      totalPrice += calculateSlotPrice(detailData, slot, slotDuration);
+    }
+    return totalPrice;
+  }
+
+  DateTime? get holdExpiresAt {
+    DateTime? result;
+    for (final booking in _heldBookingsBySlot.values) {
+      final locked = booking.lockedUntil?.toLocal();
+      if (locked == null) {
+        continue;
+      }
+      if (result == null || locked.isBefore(result)) {
+        result = locked;
+      }
+    }
+    return result;
+  }
+
+  void updateCurrentUser(String? userId) {
+    if (userId == _currentUserId) {
+      return;
+    }
+    _currentUserId = userId;
+    _syncSelectedSlotsWithBookings();
+    notifyListeners();
+    unawaited(loadBookings(forceRefresh: true));
+  }
+
+  Future<void> changeDate(DateTime date) async {
+    final normalized = _normalizeDate(date);
+    if (normalized.isAtSameMomentAs(_selectedDate)) {
+      return;
+    }
+    _selectedDate = normalized;
+    _friendlyErrorMessage = null;
+    notifyListeners();
+    await loadBookings();
+  }
+
+  Future<void> changeCourtUnit(String? unitId) async {
+    if (unitId == _selectedCourtUnitId) {
+      return;
+    }
+    _selectedCourtUnitId = unitId;
+    notifyListeners();
+    await loadBookings();
+  }
+
+  Future<void> loadBookings({bool forceRefresh = false}) async {
+    final cacheKey = _cacheKeyFor(_selectedDate, _selectedCourtUnitId);
+
+    if (!forceRefresh) {
+      final cached = _bookingCacheByKey[cacheKey];
+      if (cached != null) {
+        _loadedBookings = List<CourtBooking>.from(cached.bookings);
+        _friendlyErrorMessage = null;
+        _syncSelectedSlotsWithBookings();
+        notifyListeners();
+        return;
+      }
+
+      if (_selectedCourtUnitId != null) {
+        final fallbackCache = _bookingCacheByKey[_cacheKeyFor(_selectedDate, null)];
+        if (fallbackCache != null) {
+          _loadedBookings = List<CourtBooking>.from(fallbackCache.bookings);
+          _friendlyErrorMessage = null;
+          _syncSelectedSlotsWithBookings();
+          notifyListeners();
+          return;
+        }
+      }
+    }
+
+    _isLoading = true;
+    _friendlyErrorMessage = null;
+    notifyListeners();
+
+    try {
+      final bookings = await _bookingService.listBookings(
+        courtId: detailData.court.id,
+        date: _selectedDate,
+      );
+      _loadedBookings = bookings;
+      _updateCache(bookings, _selectedDate);
+      _syncSelectedSlotsWithBookings();
+      _isLoading = false;
+      notifyListeners();
+    } catch (error) {
+      _isLoading = false;
+      _friendlyErrorMessage = _describeFriendlyError(error);
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshBookings() => loadBookings(forceRefresh: true);
+
+  Future<void> holdSlot(SelectedSlot slot) async {
+    if (_currentUserId == null || _currentUserId!.isEmpty) {
+      throw BookingManagerException('Vui lòng đăng nhập để giữ chỗ.');
+    }
+
+    final normalized = _normalizeSlot(slot);
+    if (_slotsInProgress.contains(normalized)) {
+      return;
+    }
+    _slotsInProgress.add(normalized);
+    notifyListeners();
+
+    try {
+      final booking = await _bookingService.lockSlot(
+        courtId: detailData.court.id,
+        courtUnitId: normalized.courtUnitId,
+        userId: _currentUserId!,
+        startTime: normalized.startTime,
+        endTime: normalized.endTime,
+      );
+
+      _loadedBookings = List<CourtBooking>.from(_loadedBookings)..add(booking);
+      _updateCache(_loadedBookings, _selectedDate);
+      _selectedSlots.add(normalized);
+      _heldBookingsBySlot[normalized] = booking;
+      notifyListeners();
+    } catch (error) {
+      _slotsInProgress.remove(normalized);
+      notifyListeners();
+      throw BookingManagerException(_describeHoldError(error));
+    } finally {
+      _slotsInProgress.remove(normalized);
+      notifyListeners();
+    }
+  }
+
+  Future<void> releaseSlot(SelectedSlot slot) async {
+    final normalized = _normalizeSlot(slot);
+    if (_slotsInProgress.contains(normalized)) {
+      return;
+    }
+
+    final heldBooking = _heldBookingsBySlot.remove(normalized);
+    _selectedSlots.remove(normalized);
+    if (heldBooking == null) {
+      notifyListeners();
+      return;
+    }
+
+    _slotsInProgress.add(normalized);
+    notifyListeners();
+
+    try {
+      await _bookingService.releaseBooking(heldBooking.id);
+      _loadedBookings = List<CourtBooking>.from(_loadedBookings)
+        ..removeWhere((item) => item.id == heldBooking.id);
+      _updateCache(_loadedBookings, _selectedDate);
+      notifyListeners();
+    } catch (error) {
+      _selectedSlots.add(normalized);
+      _heldBookingsBySlot[normalized] = heldBooking;
+      _slotsInProgress.remove(normalized);
+      notifyListeners();
+      throw BookingManagerException(_describeFriendlyError(error));
+    } finally {
+      _slotsInProgress.remove(normalized);
+      notifyListeners();
+    }
+  }
+
+  bool isSlotInProgress(SelectedSlot slot) {
+    final normalized = _normalizeSlot(slot);
+    return _slotsInProgress.contains(normalized);
+  }
+
+  Future<void> submitHeldBookingsForPayment() async {
+    if (_heldBookingsBySlot.isEmpty) {
+      return;
+    }
+
+    _isSubmittingHeldBookings = true;
+    notifyListeners();
+
+    try {
+      final updatedBookings = <CourtBooking>[];
+      final processedBookingIds = <String>{};
+      for (final booking in _heldBookingsBySlot.values) {
+        if (processedBookingIds.contains(booking.id)) {
+          continue;
+        }
+        final updated = await _bookingService.submitForApproval(booking.id);
+        processedBookingIds.add(booking.id);
+        updatedBookings.add(updated);
+      }
+
+      final updatedList = List<CourtBooking>.from(_loadedBookings);
+      for (final updated in updatedBookings) {
+        final index = updatedList.indexWhere((item) => item.id == updated.id);
+        if (index >= 0) {
+          updatedList[index] = updated;
+        }
+      }
+
+      _loadedBookings = updatedList;
+      _updateCache(_loadedBookings, _selectedDate);
+      _heldBookingsBySlot.clear();
+      _selectedSlots.clear();
+      notifyListeners();
+      await loadBookings(forceRefresh: true);
+    } catch (error) {
+      _isSubmittingHeldBookings = false;
+      notifyListeners();
+      throw BookingManagerException(_describeFriendlyError(error));
+    } finally {
+      _isSubmittingHeldBookings = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> confirmAwaitingPaymentBookings() async {
+    final bookingsToConfirm = awaitingPaymentBookings.toList();
+    if (bookingsToConfirm.isEmpty) {
+      return;
+    }
+
+    _isConfirmingAwaitingPaymentBookings = true;
+    notifyListeners();
+
+    final confirmedBookings = <CourtBooking>[];
+    final failedBookings = <CourtBooking>[];
+
+    try {
+      for (final booking in bookingsToConfirm) {
+        try {
+          final updated = await _bookingService.markAsConfirmed(booking.id);
+          confirmedBookings.add(updated);
+        } catch (_) {
+          failedBookings.add(booking);
+        }
+      }
+
+      if (failedBookings.isNotEmpty) {
+        await loadBookings(forceRefresh: true);
+        throw BookingManagerException(
+          'Một số lượt đặt đã không thể xác nhận. Vui lòng tải lại và thử lại.',
+        );
+      }
+
+      final updatedList = List<CourtBooking>.from(_loadedBookings);
+      for (final updated in confirmedBookings) {
+        final index = updatedList.indexWhere((item) => item.id == updated.id);
+        if (index >= 0) {
+          updatedList[index] = updated;
+        }
+      }
+
+      _loadedBookings = updatedList;
+      _updateCache(_loadedBookings, _selectedDate);
+      notifyListeners();
+      await loadBookings(forceRefresh: true);
+    } finally {
+      _isConfirmingAwaitingPaymentBookings = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> cancelHeldBookings() async {
+    if (_heldBookingsBySlot.isEmpty) {
+      _selectedSlots.clear();
+      notifyListeners();
+      return;
+    }
+
+    final bookingsToCancel = _heldBookingsBySlot.values.toList();
+    _heldBookingsBySlot.clear();
+    _selectedSlots.clear();
+    notifyListeners();
+
+    for (final booking in bookingsToCancel) {
+      try {
+        await _bookingService.releaseBooking(booking.id);
+      } catch (_) {
+        // swallow errors to avoid blocking cancellation
+      }
+    }
+
+    await loadBookings(forceRefresh: true);
+  }
+
+  bool _isAwaitingPaymentAndMine(CourtBooking booking) {
+    if (booking.status != BookingStatus.awaitingPayment) {
+      return false;
+    }
+    if (_currentUserId == null || _currentUserId!.isEmpty) {
+      return false;
+    }
+    return booking.userId == _currentUserId;
+  }
+
+  SelectedSlot _normalizeSlot(SelectedSlot slot) {
+    return SelectedSlot(
+      courtUnitId: slot.courtUnitId,
+      startTime: slot.startTime.toUtc(),
+      endTime: slot.endTime.toUtc(),
+    );
+  }
+
+  void _syncSelectedSlotsWithBookings() {
+    if (_currentUserId == null) {
+      _selectedSlots.clear();
+      _heldBookingsBySlot.clear();
+      return;
+    }
+
+    final updatedSelected = <SelectedSlot>{};
+    final updatedHeld = <SelectedSlot, CourtBooking>{};
+    for (final booking in _loadedBookings) {
+      if (booking.userId != _currentUserId) {
+        continue;
+      }
+      if (booking.status == BookingStatus.held && booking.isActiveLock) {
+        final slots = booking.splitToSlots(slotDuration);
+        for (final slot in slots) {
+          final normalized = _normalizeSlot(slot);
+          updatedSelected.add(normalized);
+          updatedHeld[normalized] = booking;
+        }
+      }
+    }
+
+    _selectedSlots
+      ..clear()
+      ..addAll(updatedSelected);
+    _heldBookingsBySlot
+      ..clear()
+      ..addAll(updatedHeld);
+  }
+
+  void _updateCache(List<CourtBooking> bookings, DateTime date) {
+    final normalizedDate = _normalizeDate(date);
+    final baseKey = _cacheKeyFor(normalizedDate, null);
+    _bookingCacheByKey[baseKey] = _BookingCacheEntry(
+      bookings: List<CourtBooking>.from(bookings),
+      fetchedAt: DateTime.now(),
+    );
+
+    final grouped = <String, List<CourtBooking>>{};
+    for (final booking in bookings) {
+      grouped.putIfAbsent(booking.courtUnitId, () => <CourtBooking>[]).add(booking);
+    }
+
+    for (final entry in grouped.entries) {
+      final unitKey = _cacheKeyFor(normalizedDate, entry.key);
+      _bookingCacheByKey[unitKey] = _BookingCacheEntry(
+        bookings: List<CourtBooking>.from(entry.value),
+        fetchedAt: DateTime.now(),
+      );
+    }
+  }
+
+  String _cacheKeyFor(DateTime date, String? unitId) {
+    final formatter = DateFormat('yyyy-MM-dd');
+    final dayLabel = formatter.format(date);
+    return '${detailData.court.id}__$dayLabel__${unitId ?? 'all'}';
+  }
+
+  DateTime _normalizeDate(DateTime date) {
+    return DateTime(date.year, date.month, date.day);
+  }
+
+  String? _resolveInitialCourtUnitId() {
+    if (detailData.units.isEmpty) {
+      return null;
+    }
+    final activeUnit = detailData.units.firstWhere(
+      (unit) => unit.isActive,
+      orElse: () => detailData.units.first,
+    );
+    return activeUnit.id;
+  }
+
+  String _describeFriendlyError(Object error) {
+    if (error is BookingServiceException) {
+      return error.message;
+    }
+    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
+  }
+
+  String _describeHoldError(Object error) {
+    if (error is BookingServiceException) {
+      if (error.message.contains('đã có lượt đặt')) {
+        return 'Khung giờ vừa chọn đã có người giữ/đặt, vui lòng chọn khung khác.';
+      }
+      return error.message;
+    }
+    return 'Không thể giữ chỗ. Vui lòng thử lại.';
+  }
+}
+
+class _BookingCacheEntry {
+  _BookingCacheEntry({
+    required this.bookings,
+    required this.fetchedAt,
+  });
+
+  final List<CourtBooking> bookings;
+  final DateTime fetchedAt;
+}
+
+class BookingManagerException implements Exception {
+  BookingManagerException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -36,17 +36,18 @@ class BookingManager extends ChangeNotifier {
 
   List<CourtBooking> _loadedBookings = <CourtBooking>[];
   final Set<SelectedSlot> _selectedSlots = <SelectedSlot>{};
-  final Map<SelectedSlot, CourtBooking> _heldBookingsBySlot = <SelectedSlot, CourtBooking>{};
+  final Map<SelectedSlot, CourtBooking> _heldBookingsBySlot =
+      <SelectedSlot, CourtBooking>{};
   final Set<SelectedSlot> _slotsInProgress = <SelectedSlot>{};
 
-  final Map<String, _BookingCacheEntry> _bookingCacheByKey = <String, _BookingCacheEntry>{};
+  final Map<String, _BookingCacheEntry> _bookingCacheByKey =
+      <String, _BookingCacheEntry>{};
 
   DateTime get selectedDate => _selectedDate;
   String? get selectedCourtUnitId => _selectedCourtUnitId;
   bool get isLoading => _isLoading;
   bool get isSubmittingHeldBookings => _isSubmittingHeldBookings;
-  bool get isConfirmingAwaitingPayment =>
-      _isConfirmingAwaitingPaymentBookings;
+  bool get isConfirmingAwaitingPayment => _isConfirmingAwaitingPaymentBookings;
   String? get friendlyErrorMessage => _friendlyErrorMessage;
   List<CourtBooking> get bookings => List.unmodifiable(_loadedBookings);
   List<CourtBooking> get bookingsForSelectedUnit {
@@ -122,9 +123,10 @@ class BookingManager extends ChangeNotifier {
     if (unitId == _selectedCourtUnitId) {
       return;
     }
+    _friendlyErrorMessage = null;
     _selectedCourtUnitId = unitId;
     notifyListeners();
-    await loadBookings();
+    await loadBookings(forceRefresh: true);
   }
 
   Future<void> loadBookings({bool forceRefresh = false}) async {
@@ -141,7 +143,8 @@ class BookingManager extends ChangeNotifier {
       }
 
       if (_selectedCourtUnitId != null) {
-        final fallbackCache = _bookingCacheByKey[_cacheKeyFor(_selectedDate, null)];
+        final fallbackCache =
+            _bookingCacheByKey[_cacheKeyFor(_selectedDate, null)];
         if (fallbackCache != null) {
           _loadedBookings = List<CourtBooking>.from(fallbackCache.bookings);
           _friendlyErrorMessage = null;
@@ -423,7 +426,9 @@ class BookingManager extends ChangeNotifier {
 
     final grouped = <String, List<CourtBooking>>{};
     for (final booking in bookings) {
-      grouped.putIfAbsent(booking.courtUnitId, () => <CourtBooking>[]).add(booking);
+      grouped
+          .putIfAbsent(booking.courtUnitId, () => <CourtBooking>[])
+          .add(booking);
     }
 
     for (final entry in grouped.entries) {
@@ -438,7 +443,7 @@ class BookingManager extends ChangeNotifier {
   String _cacheKeyFor(DateTime date, String? unitId) {
     final formatter = DateFormat('yyyy-MM-dd');
     final dayLabel = formatter.format(date);
-    return '${detailData.court.id}__$dayLabel__${unitId ?? 'all'}';
+    return '${detailData.court.id}__${dayLabel}__${unitId ?? 'all'}';
   }
 
   DateTime _normalizeDate(DateTime date) {

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -55,7 +55,13 @@ class _BookingPageViewState extends State<_BookingPageView> {
     final userId = auth.user?.id;
     if (userId != _lastUserId) {
       _lastUserId = userId;
-      provider.updateCurrentUser(userId);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          provider.updateCurrentUser(userId);
+        });
+      });
     }
   }
 
@@ -97,11 +103,11 @@ class _BookingPageViewState extends State<_BookingPageView> {
                           date: provider.selectedDate,
                           startHour: _resolveStartHour(),
                           endHour: _resolveEndHour(),
-                          bookings: provider.bookings,
+                          bookings: provider.bookingsForSelectedUnit,
                           selectedSlots: provider.selectedSlots,
                           currentUserId: _lastUserId,
-                          onSlotTap: (slot, shouldSelect) =>
-                              _handleSlotTap(context, provider, slot, shouldSelect),
+                          onSlotTap: (slot, shouldSelect) => _handleSlotTap(
+                              context, provider, slot, shouldSelect),
                         ),
                       ),
           ),
@@ -113,7 +119,8 @@ class _BookingPageViewState extends State<_BookingPageView> {
   }
 
   List<CourtTimelineRow> _buildTimelineRows(BookingManager provider) {
-    final units = widget.detailData.units.where((unit) => unit.isActive).toList();
+    final units =
+        widget.detailData.units.where((unit) => unit.isActive).toList();
     if (units.isEmpty) {
       return const [CourtTimelineRow(id: 'default', label: 'Sân 1')];
     }
@@ -200,7 +207,8 @@ class _BookingPageViewState extends State<_BookingPageView> {
                 ),
               ),
               FilledButton.tonal(
-                style: FilledButton.styleFrom(backgroundColor: colorScheme.surface),
+                style: FilledButton.styleFrom(
+                    backgroundColor: colorScheme.surface),
                 onPressed: () => _selectDate(context, provider),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
@@ -243,8 +251,10 @@ class _BookingPageViewState extends State<_BookingPageView> {
     );
   }
 
-  Widget _buildCourtUnitSelector(BookingManager provider, ColorScheme colorScheme) {
-    final units = widget.detailData.units.where((unit) => unit.isActive).toList();
+  Widget _buildCourtUnitSelector(
+      BookingManager provider, ColorScheme colorScheme) {
+    final units =
+        widget.detailData.units.where((unit) => unit.isActive).toList();
     final selectedId = provider.selectedCourtUnitId ??
         (units.isNotEmpty ? units.first.id : null);
 
@@ -332,7 +342,8 @@ class _BookingPageViewState extends State<_BookingPageView> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.warning_amber_rounded, color: colorScheme.error, size: 40),
+            Icon(Icons.warning_amber_rounded,
+                color: colorScheme.error, size: 40),
             const SizedBox(height: 12),
             Text(
               provider.friendlyErrorMessage ?? 'Không thể tải dữ liệu.',
@@ -380,7 +391,8 @@ class _BookingPageViewState extends State<_BookingPageView> {
           const SizedBox(height: 8),
           Row(
             children: [
-              Icon(Icons.payments_outlined, size: 20, color: colorScheme.primary),
+              Icon(Icons.payments_outlined,
+                  size: 20, color: colorScheme.primary),
               const SizedBox(width: 8),
               Text(
                 formatCurrency(totalPrice),
@@ -411,7 +423,8 @@ class _BookingPageViewState extends State<_BookingPageView> {
             const SizedBox(height: 8),
             Row(
               children: [
-                Icon(Icons.pending_actions, size: 20, color: colorScheme.primary),
+                Icon(Icons.pending_actions,
+                    size: 20, color: colorScheme.primary),
                 const SizedBox(width: 6),
                 Text(
                   'Có ${provider.awaitingPaymentBookings.length} lượt chờ thanh toán.',
@@ -438,11 +451,12 @@ class _BookingPageViewState extends State<_BookingPageView> {
           SizedBox(
             width: double.infinity,
             child: FilledButton(
-              onPressed: provider.hasHeldBookings && !provider.isSubmittingHeldBookings
-                  ? () async {
-                      await _handleSubmitForPayment(context, provider);
-                    }
-                  : null,
+              onPressed:
+                  provider.hasHeldBookings && !provider.isSubmittingHeldBookings
+                      ? () async {
+                          await _handleSubmitForPayment(context, provider);
+                        }
+                      : null,
               child: provider.isSubmittingHeldBookings
                   ? const SizedBox(
                       height: 22,
@@ -484,7 +498,8 @@ class _BookingPageViewState extends State<_BookingPageView> {
                       await provider.cancelHeldBookings();
                       if (!mounted) return;
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Đã huỷ giữ chỗ hiện tại.')),
+                        const SnackBar(
+                            content: Text('Đã huỷ giữ chỗ hiện tại.')),
                       );
                     }
                   : null,
@@ -504,7 +519,8 @@ class _BookingPageViewState extends State<_BookingPageView> {
       await provider.submitHeldBookingsForPayment();
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Đã chuyển sang trạng thái chờ thanh toán.')),
+        const SnackBar(
+            content: Text('Đã chuyển sang trạng thái chờ thanh toán.')),
       );
     } on BookingManagerException catch (error) {
       if (!mounted) return;
@@ -522,7 +538,8 @@ class _BookingPageViewState extends State<_BookingPageView> {
     }
   }
 
-  Future<void> _selectDate(BuildContext context, BookingManager provider) async {
+  Future<void> _selectDate(
+      BuildContext context, BookingManager provider) async {
     final today = DateTime.now();
     final first = today.subtract(const Duration(days: 1));
     final last = today.add(const Duration(days: 365));

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -1,15 +1,16 @@
 import 'package:badminton_booking_app/components/my_court_time.dart';
 import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court_detail.dart';
-import 'package:badminton_booking_app/pages/court/payment_page.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
+import 'package:badminton_booking_app/pages/court/booking_manager.dart';
+import 'package:badminton_booking_app/pages/court/payment_page.dart';
 import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-class BookingPage extends StatefulWidget {
+class BookingPage extends StatelessWidget {
   const BookingPage({
     super.key,
     required this.detailData,
@@ -22,334 +23,47 @@ class BookingPage extends StatefulWidget {
   final Duration slotDuration;
 
   @override
-  State<BookingPage> createState() => _BookingPageState();
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<BookingManager>(
+      create: (_) => BookingManager(
+        detailData: detailData,
+        bookingService: bookingService,
+        slotDuration: slotDuration,
+      ),
+      child: _BookingPageView(detailData: detailData),
+    );
+  }
 }
 
-class _BookingPageState extends State<BookingPage> {
-  late DateTime _selectedDate;
-  late BookingService _bookingService;
+class _BookingPageView extends StatefulWidget {
+  const _BookingPageView({required this.detailData});
 
-  final Set<SelectedSlot> _selectedSlots = <SelectedSlot>{};
-  final Map<SelectedSlot, CourtBooking> _heldBookings = {};
-  final Set<SelectedSlot> _processingSlots = {};
-
-  List<CourtBooking> _bookings = <CourtBooking>[];
-
-  bool _isLoading = false;
-  String? _errorMessage;
-  bool _submittingRequest = false;
-  String? _currentUserId;
+  final CourtDetailData detailData;
 
   @override
-  void initState() {
-    super.initState();
-    _selectedDate = DateTime.now();
-    _bookingService = widget.bookingService ?? BookingService();
-  }
+  State<_BookingPageView> createState() => _BookingPageViewState();
+}
+
+class _BookingPageViewState extends State<_BookingPageView> {
+  String? _lastUserId;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final auth = Provider.of<AuthManager>(context);
-    final newUserId = auth.user?.id;
-    if (newUserId != _currentUserId) {
-      _currentUserId = newUserId;
-      _loadBookings();
+    final provider = Provider.of<BookingManager>(context, listen: false);
+    final userId = auth.user?.id;
+    if (userId != _lastUserId) {
+      _lastUserId = userId;
+      provider.updateCurrentUser(userId);
     }
-  }
-
-  Future<void> _loadBookings() async {
-    setState(() {
-      _isLoading = true;
-      _errorMessage = null;
-    });
-
-    try {
-      final bookings = await _bookingService.listBookings(
-        courtId: widget.detailData.court.id,
-        date: _selectedDate,
-      );
-
-      final newSelected = <SelectedSlot>{};
-      final newHeld = <SelectedSlot, CourtBooking>{};
-
-      if (_currentUserId != null) {
-        for (final booking in bookings) {
-          // CHANGED: dùng BookingStatus.held thay cho locked
-          if (booking.userId == _currentUserId &&
-              booking.status == BookingStatus.held &&
-              booking.isActiveLock) {
-            for (final slot in booking.splitToSlots(widget.slotDuration)) {
-              final canonical = _canonicalizeSlot(slot);
-              newSelected.add(canonical);
-              newHeld[canonical] = booking;
-            }
-          }
-        }
-      }
-
-      if (!mounted) return;
-      setState(() {
-        _bookings = bookings;
-        _selectedSlots
-          ..clear()
-          ..addAll(newSelected);
-        _heldBookings
-          ..clear()
-          ..addAll(newHeld);
-        _isLoading = false;
-      });
-    } catch (error) {
-      if (!mounted) return;
-      setState(() {
-        _errorMessage = _describeError(error);
-        _isLoading = false;
-      });
-    }
-  }
-
-  Future<void> _selectDate() async {
-    final first = DateTime.now().subtract(const Duration(days: 1));
-    final last = DateTime.now().add(const Duration(days: 365));
-
-    final picked = await showDatePicker(
-      context: context,
-      initialDate: _selectedDate,
-      firstDate: first,
-      lastDate: last,
-    );
-
-    if (picked != null && picked != _selectedDate) {
-      setState(() {
-        _selectedDate = picked;
-      });
-      await _loadBookings();
-    }
-  }
-
-  void _handleSlotTap(SelectedSlot slot, bool shouldSelect) {
-    final canonical = _canonicalizeSlot(slot);
-    if (_processingSlots.contains(canonical)) {
-      return;
-    }
-
-    if (shouldSelect) {
-      if (_currentUserId == null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Vui lòng đăng nhập để giữ chỗ.')),
-        );
-        return;
-      }
-      _lockSlot(canonical);
-    } else {
-      _releaseSlot(canonical);
-    }
-  }
-
-  Future<void> _lockSlot(SelectedSlot slot) async {
-    setState(() => _processingSlots.add(slot));
-
-    try {
-      final booking = await _bookingService.lockSlot(
-        courtId: widget.detailData.court.id,
-        courtUnitId: slot.courtUnitId,
-        userId: _currentUserId!,
-        startTime: slot.startTime.toUtc(),
-        endTime: slot.endTime.toUtc(),
-      );
-
-      final bookingSlots = booking.splitToSlots(widget.slotDuration);
-      if (!mounted) return;
-      setState(() {
-        _bookings = [..._bookings, booking];
-        for (final item in bookingSlots) {
-          final canonical = _canonicalizeSlot(item);
-          _selectedSlots.add(canonical);
-          _heldBookings[canonical] = booking;
-        }
-      });
-    } catch (error) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_describeError(error))),
-      );
-    } finally {
-      if (!mounted) return;
-      setState(() => _processingSlots.remove(slot));
-    }
-  }
-
-  Future<void> _releaseSlot(SelectedSlot slot) async {
-    final booking = _heldBookings.remove(slot);
-    if (booking == null) {
-      setState(() => _selectedSlots.remove(slot));
-      return;
-    }
-
-    setState(() {
-      _processingSlots.add(slot);
-    });
-
-    try {
-      await _bookingService.releaseBooking(booking.id);
-      if (!mounted) return;
-      setState(() {
-        _selectedSlots.remove(slot);
-        _bookings.removeWhere((item) => item.id == booking.id);
-      });
-    } catch (error) {
-      if (!mounted) return;
-      _heldBookings[slot] = booking;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_describeError(error))),
-      );
-    } finally {
-      if (!mounted) return;
-      setState(() => _processingSlots.remove(slot));
-    }
-  }
-
-  // CHANGED: đổi tên hàm và text sang "chuyển sang chờ thanh toán"
-  Future<void> _proceedToAwaitingPayment() async {
-    if (_heldBookings.isEmpty) return;
-    setState(() => _submittingRequest = true);
-
-    try {
-      final updates = <CourtBooking>[];
-      for (final booking in _heldBookings.values) {
-        // vẫn gọi service cũ, nhưng service nên update status = 'awaiting_payment'
-        final updated = await _bookingService.submitForApproval(booking.id);
-        updates.add(updated);
-      }
-
-      if (!mounted) return;
-      setState(() {
-        for (final updated in updates) {
-          _bookings.removeWhere((item) => item.id == updated.id);
-          _bookings.add(updated);
-        }
-        _selectedSlots.clear();
-        _heldBookings.clear();
-        _submittingRequest = false;
-      });
-
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Đã chuyển sang trạng thái chờ thanh toán.'),
-        ),
-      );
-      await _loadBookings();
-    } catch (error) {
-      if (!mounted) return;
-      setState(() => _submittingRequest = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_describeError(error))),
-      );
-    }
-  }
-
-  List<CourtTimelineRow> get _rows {
-    final units = widget.detailData.units;
-    if (units.isEmpty) {
-      return [const CourtTimelineRow(id: 'default', label: 'Sân 1')];
-    }
-    return units
-        .where((unit) => unit.isActive)
-        .map((unit) => CourtTimelineRow(
-              id: unit.id,
-              label: unit.label.isEmpty ? 'Sân' : unit.label,
-            ))
-        .toList();
-  }
-
-  Duration get _totalDuration {
-    var minutes = 0;
-    for (final slot in _selectedSlots) {
-      minutes += slot.endTime.difference(slot.startTime).inMinutes;
-    }
-    return Duration(minutes: minutes);
-  }
-
-  double get _totalPrice {
-    var total = 0.0;
-    for (final slot in _selectedSlots) {
-      total += calculateSlotPrice(
-        widget.detailData,
-        slot,
-        widget.slotDuration,
-      );
-    }
-    return total;
-  }
-
-  // CHANGED: dùng awaitingPayment thay cho confirmed
-  Iterable<CourtBooking> get _awaitingPaymentForUser {
-    if (_currentUserId == null) return const Iterable.empty();
-    return _bookings.where((booking) =>
-        booking.userId == _currentUserId &&
-        booking.status == BookingStatus.awaitingPayment);
-  }
-
-  int get _startHour {
-    final minutes = widget.detailData.openingHours
-        .map((item) => parseTimeToMinutes(item.openTime))
-        .whereType<int>();
-    if (minutes.isEmpty) return 6;
-    final minMinute = minutes.reduce((a, b) => a < b ? a : b);
-    final base = (minMinute / 60).floor();
-    if (base < 0) return 0;
-    if (base > 23) return 23;
-    return base;
-  }
-
-  int get _endHour {
-    final minutes = widget.detailData.openingHours
-        .map((item) => parseTimeToMinutes(item.closeTime))
-        .whereType<int>();
-    if (minutes.isEmpty) return 22;
-    final maxMinute = minutes.reduce((a, b) => a > b ? a : b);
-    var endHour = (maxMinute / 60).ceil();
-    if (endHour < 1) {
-      endHour = 1;
-    } else if (endHour > 24) {
-      endHour = 24;
-    }
-    return endHour <= _startHour ? _startHour + 1 : endHour;
-  }
-
-  DateTime? get _holdExpiresAt {
-    DateTime? result;
-    for (final booking in _heldBookings.values) {
-      final locked = booking.lockedUntil?.toLocal();
-      if (locked == null) continue;
-      if (result == null || locked.isBefore(result)) {
-        result = locked;
-      }
-    }
-    return result;
-  }
-
-  SelectedSlot _canonicalizeSlot(SelectedSlot slot) {
-    return SelectedSlot(
-      courtUnitId: slot.courtUnitId,
-      startTime: slot.startTime.toUtc(),
-      endTime: slot.endTime.toUtc(),
-    );
-  }
-
-  String _describeError(Object error) {
-    if (error is BookingServiceException) {
-      return error.message;
-    }
-    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
   }
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final rows = _rows;
-    final holdExpires = _holdExpiresAt;
+    final provider = context.watch<BookingManager>();
+    final colorScheme = Theme.of(context).colorScheme;
+    final timelineRows = _buildTimelineRows(provider);
 
     return Scaffold(
       appBar: AppBar(
@@ -357,83 +71,149 @@ class _BookingPageState extends State<BookingPage> {
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            onPressed: _isLoading ? null : _loadBookings,
             tooltip: 'Tải lại trạng thái đặt sân',
+            onPressed: provider.isLoading
+                ? null
+                : () {
+                    provider.refreshBookings();
+                  },
           ),
         ],
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          _buildHeader(cs, holdExpires),
-          _buildLegend(cs),
+          _buildHeader(context, provider, colorScheme),
+          _buildLegend(colorScheme),
           Expanded(
-            child: _isLoading
+            child: provider.isLoading
                 ? const Center(child: CircularProgressIndicator())
-                : _errorMessage != null
-                    ? _buildErrorState(cs)
+                : provider.friendlyErrorMessage != null
+                    ? _buildErrorState(context, provider, colorScheme)
                     : Padding(
                         padding: const EdgeInsets.only(bottom: 12),
                         child: CourtTimeline(
-                          rows: rows,
-                          date: _selectedDate,
-                          startHour: _startHour,
-                          endHour: _endHour,
-                          bookings: _bookings,
-                          selectedSlots: _selectedSlots,
-                          currentUserId: _currentUserId,
-                          onSlotTap: _handleSlotTap,
+                          rows: timelineRows,
+                          date: provider.selectedDate,
+                          startHour: _resolveStartHour(),
+                          endHour: _resolveEndHour(),
+                          bookings: provider.bookings,
+                          selectedSlots: provider.selectedSlots,
+                          currentUserId: _lastUserId,
+                          onSlotTap: (slot, shouldSelect) =>
+                              _handleSlotTap(context, provider, slot, shouldSelect),
                         ),
                       ),
           ),
-          _buildSummary(cs, holdExpires),
+          _buildSummary(provider, colorScheme),
         ],
       ),
-      bottomNavigationBar: _buildActions(cs),
+      bottomNavigationBar: _buildActions(context, provider, colorScheme),
     );
   }
 
-  Widget _buildHeader(ColorScheme cs, DateTime? holdExpires) {
-    final dateLabel = DateFormat('dd/MM/yyyy').format(_selectedDate);
-    final totalDuration = _totalDuration;
+  List<CourtTimelineRow> _buildTimelineRows(BookingManager provider) {
+    final units = widget.detailData.units.where((unit) => unit.isActive).toList();
+    if (units.isEmpty) {
+      return const [CourtTimelineRow(id: 'default', label: 'Sân 1')];
+    }
+    final selectedId = provider.selectedCourtUnitId;
+    if (selectedId == null) {
+      return units
+          .map((unit) => CourtTimelineRow(
+                id: unit.id,
+                label: unit.label.isEmpty ? 'Sân' : unit.label,
+              ))
+          .toList();
+    }
+    final unit = units.firstWhere(
+      (item) => item.id == selectedId,
+      orElse: () => units.first,
+    );
+    return [
+      CourtTimelineRow(
+        id: unit.id,
+        label: unit.label.isEmpty ? 'Sân' : unit.label,
+      ),
+    ];
+  }
+
+  Future<void> _handleSlotTap(
+    BuildContext context,
+    BookingManager provider,
+    SelectedSlot slot,
+    bool shouldSelect,
+  ) async {
+    if (provider.isSlotInProgress(slot)) {
+      return;
+    }
+
+    try {
+      if (shouldSelect) {
+        await provider.holdSlot(slot);
+      } else {
+        await provider.releaseSlot(slot);
+      }
+    } on BookingManagerException catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(error.message),
+          action: SnackBarAction(
+            label: 'Tải lại',
+            onPressed: () {
+              provider.refreshBookings();
+            },
+          ),
+        ),
+      );
+    }
+  }
+
+  Widget _buildHeader(
+    BuildContext context,
+    BookingManager provider,
+    ColorScheme colorScheme,
+  ) {
+    final dateLabel = DateFormat('dd/MM/yyyy').format(provider.selectedDate);
+    final totalDuration = provider.totalSelectedDuration;
     final durationLabel = totalDuration.inMinutes == 0
         ? 'Chưa chọn thời gian'
         : '${totalDuration.inMinutes ~/ 60}h ${totalDuration.inMinutes % 60}p';
 
     return Container(
-      color: cs.primary,
+      color: colorScheme.primary,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Row(
             children: [
-              Text(
-                widget.detailData.court.name,
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: cs.onPrimary,
+              Expanded(
+                child: Text(
+                  widget.detailData.court.name,
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.onPrimary,
+                  ),
                 ),
               ),
-              const Spacer(),
               FilledButton.tonal(
-                style: FilledButton.styleFrom(
-                  backgroundColor: cs.surface,
-                ),
-                onPressed: _selectDate,
+                style: FilledButton.styleFrom(backgroundColor: colorScheme.surface),
+                onPressed: () => _selectDate(context, provider),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
                       dateLabel,
                       style: TextStyle(
-                        color: cs.onSurface,
+                        color: colorScheme.onSurface,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
                     const SizedBox(width: 8),
-                    Icon(Icons.calendar_month, color: cs.onSurface),
+                    Icon(Icons.calendar_month, color: colorScheme.onSurface),
                   ],
                 ),
               ),
@@ -441,178 +221,82 @@ class _BookingPageState extends State<BookingPage> {
           ),
           const SizedBox(height: 8),
           Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Icon(Icons.schedule, color: cs.onPrimary.withOpacity(0.9)),
-              const SizedBox(width: 6),
-              Text(
-                durationLabel,
-                style: TextStyle(
-                  color: cs.onPrimary,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-          if (holdExpires != null) ...[
-            const SizedBox(height: 4),
-            Row(
-              children: [
-                Icon(Icons.hourglass_bottom,
-                    size: 18, color: cs.onPrimary.withOpacity(0.9)),
-                const SizedBox(width: 6),
-                Text(
-                  'Giữ chỗ đến ${DateFormat('HH:mm').format(holdExpires)}',
-                  style: TextStyle(color: cs.onPrimary),
-                ),
-              ],
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildLegend(ColorScheme cs) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-      decoration: BoxDecoration(
-        color: cs.surface,
-        border: Border(
-          bottom: BorderSide(color: cs.outlineVariant.withOpacity(0.4)),
-        ),
-      ),
-      child: Wrap(
-        spacing: 12,
-        runSpacing: 8,
-        children: [
-          _legendItem(
-              cs.secondaryContainer.withOpacity(0.7), 'Đang giữ chỗ'), // held
-          _legendItem(cs.errorContainer.withOpacity(0.9), 'Người khác giữ'),
-          _legendItem(cs.tertiaryContainer.withOpacity(0.9),
-              'Chờ thanh toán'), // CHANGED
-          _legendItem(
-              cs.primaryContainer.withOpacity(0.9), 'Đã xác nhận'), // CHANGED
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSummary(ColorScheme cs, DateTime? holdExpires) {
-    final totalPrice = _totalPrice;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      decoration: BoxDecoration(
-        color: cs.surface,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 4,
-            offset: const Offset(0, -2),
-          )
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const Icon(Icons.sticky_note_2_outlined, size: 20),
+              Icon(Icons.schedule, color: colorScheme.onPrimary),
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  _selectedSlots.isEmpty
-                      ? 'Chọn khung giờ để giữ chỗ tối đa 15 phút.'
-                      : 'Đã chọn ${_selectedSlots.length} khung giờ.',
+                  durationLabel,
+                  style: TextStyle(color: colorScheme.onPrimary),
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Icon(Icons.payments_outlined, size: 20, color: cs.primary),
-              const SizedBox(width: 8),
-              Text(
-                formatCurrency(totalPrice),
-                style: TextStyle(
-                  color: cs.primary,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 18,
-                ),
-              ),
-            ],
-          ),
-          // CHANGED: thông báo số booking chờ thanh toán thay vì đã duyệt
-          if (_awaitingPaymentForUser.isNotEmpty) ...[
-            const SizedBox(height: 8),
-            Row(
-              children: [
-                Icon(Icons.pending_actions, size: 20, color: cs.primary),
-                const SizedBox(width: 6),
-                Text(
-                  'Có ${_awaitingPaymentForUser.length} lượt chờ thanh toán.',
-                  style: TextStyle(color: cs.primary),
-                ),
-              ],
+          if (widget.detailData.units.length > 1)
+            Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: _buildCourtUnitSelector(provider, colorScheme),
             ),
-          ],
         ],
       ),
     );
   }
 
-  Widget _buildActions(ColorScheme cs) {
-    // CHANGED: bật thanh toán khi có booking awaiting_payment
-    final hasAwaitingPayment = _awaitingPaymentForUser.isNotEmpty;
+  Widget _buildCourtUnitSelector(BookingManager provider, ColorScheme colorScheme) {
+    final units = widget.detailData.units.where((unit) => unit.isActive).toList();
+    final selectedId = provider.selectedCourtUnitId ??
+        (units.isNotEmpty ? units.first.id : null);
 
-    return SafeArea(
-      minimum: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: colorScheme.surface.withOpacity(0.9),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
         children: [
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
-              onPressed: _heldBookings.isEmpty || _submittingRequest
-                  ? null
-                  : _proceedToAwaitingPayment, // CHANGED
-              child: _submittingRequest
-                  ? const SizedBox(
-                      height: 22,
-                      width: 22,
-                      child: CircularProgressIndicator(strokeWidth: 2),
+          Icon(Icons.sports_tennis, color: colorScheme.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+                value: selectedId,
+                onChanged: (value) {
+                  if (value != null) {
+                    provider.changeCourtUnit(value);
+                  }
+                },
+                items: units
+                    .map(
+                      (unit) => DropdownMenuItem<String>(
+                        value: unit.id,
+                        child: Text(unit.label.isEmpty ? 'Sân' : unit.label),
+                      ),
                     )
-                  : const Text('Chuyển sang thanh toán'), // CHANGED
+                    .toList(),
+              ),
             ),
           ),
-          const SizedBox(height: 10),
-          SizedBox(
-            width: double.infinity,
-            child: OutlinedButton(
-              onPressed: hasAwaitingPayment
-                  ? () async {
-                      final result = await Navigator.push<bool>(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => PaymentPage(
-                            detailData: widget.detailData,
-                            bookings:
-                                _awaitingPaymentForUser.toList(), // CHANGED
-                            slotDuration: widget.slotDuration,
-                            bookingService: _bookingService,
-                          ),
-                        ),
-                      );
+        ],
+      ),
+    );
+  }
 
-                      if (result == true && mounted) {
-                        await _loadBookings();
-                      }
-                    }
-                  : null,
-              child: const Text('Thanh toán'),
-            ),
-          ),
+  Widget _buildLegend(ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      color: colorScheme.surface,
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          _legendItem(colorScheme.primary.withOpacity(0.2), 'Có thể đặt'),
+          _legendItem(colorScheme.primary, 'Bạn đang giữ chỗ'),
+          _legendItem(colorScheme.secondary, 'Người khác giữ chỗ'),
+          _legendItem(colorScheme.tertiary, 'Chờ thanh toán'),
+          _legendItem(colorScheme.error, 'Đã xác nhận'),
         ],
       ),
     );
@@ -637,22 +321,249 @@ class _BookingPageState extends State<BookingPage> {
     );
   }
 
-  Widget _buildErrorState(ColorScheme cs) {
+  Widget _buildErrorState(
+    BuildContext context,
+    BookingManager provider,
+    ColorScheme colorScheme,
+  ) {
     return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.warning_amber_rounded, color: colorScheme.error, size: 40),
+            const SizedBox(height: 12),
+            Text(
+              provider.friendlyErrorMessage ?? 'Không thể tải dữ liệu.',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () {
+                provider.refreshBookings();
+              },
+              child: const Text('Tải lại'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSummary(BookingManager provider, ColorScheme colorScheme) {
+    final holdExpires = provider.holdExpiresAt;
+    final totalPrice = provider.totalSelectedPrice;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        border: Border(top: BorderSide(color: colorScheme.outlineVariant)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.sticky_note_2_outlined, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  provider.selectedSlots.isEmpty
+                      ? 'Chọn khung giờ để giữ chỗ tối đa 15 phút.'
+                      : 'Đã chọn ${provider.selectedSlots.length} khung giờ.',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Icon(Icons.payments_outlined, size: 20, color: colorScheme.primary),
+              const SizedBox(width: 8),
+              Text(
+                formatCurrency(totalPrice),
+                style: TextStyle(
+                  color: colorScheme.primary,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+            ],
+          ),
+          if (holdExpires != null) ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(Icons.timer_outlined, size: 20, color: colorScheme.error),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    'Giữ chỗ hết hạn lúc ${DateFormat('HH:mm').format(holdExpires)}.',
+                    style: TextStyle(color: colorScheme.error),
+                  ),
+                ),
+              ],
+            ),
+          ],
+          if (provider.hasAwaitingPaymentBookings) ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(Icons.pending_actions, size: 20, color: colorScheme.primary),
+                const SizedBox(width: 6),
+                Text(
+                  'Có ${provider.awaitingPaymentBookings.length} lượt chờ thanh toán.',
+                  style: TextStyle(color: colorScheme.primary),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActions(
+    BuildContext context,
+    BookingManager provider,
+    ColorScheme colorScheme,
+  ) {
+    return SafeArea(
+      minimum: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(
-            _errorMessage ?? 'Không thể tải dữ liệu.',
-            textAlign: TextAlign.center,
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: provider.hasHeldBookings && !provider.isSubmittingHeldBookings
+                  ? () async {
+                      await _handleSubmitForPayment(context, provider);
+                    }
+                  : null,
+              child: provider.isSubmittingHeldBookings
+                  ? const SizedBox(
+                      height: 22,
+                      width: 22,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Chuyển sang thanh toán'),
+            ),
           ),
-          const SizedBox(height: 12),
-          FilledButton(
-            onPressed: _loadBookings,
-            child: const Text('Thử lại'),
+          const SizedBox(height: 10),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton(
+              onPressed: provider.hasAwaitingPaymentBookings
+                  ? () async {
+                      final providerInstance = context.read<BookingManager>();
+                      final result = await Navigator.of(context).push<bool>(
+                        MaterialPageRoute(
+                          builder: (context) => ChangeNotifierProvider.value(
+                            value: providerInstance,
+                            child: const PaymentPage(),
+                          ),
+                        ),
+                      );
+                      if (result == true && mounted) {
+                        await provider.refreshBookings();
+                      }
+                    }
+                  : null,
+              child: const Text('Thanh toán'),
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: TextButton(
+              onPressed: provider.hasHeldBookings
+                  ? () async {
+                      await provider.cancelHeldBookings();
+                      if (!mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Đã huỷ giữ chỗ hiện tại.')),
+                      );
+                    }
+                  : null,
+              child: const Text('Huỷ giữ chỗ'),
+            ),
           ),
         ],
       ),
     );
+  }
+
+  Future<void> _handleSubmitForPayment(
+    BuildContext context,
+    BookingManager provider,
+  ) async {
+    try {
+      await provider.submitHeldBookingsForPayment();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Đã chuyển sang trạng thái chờ thanh toán.')),
+      );
+    } on BookingManagerException catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(error.message),
+          action: SnackBarAction(
+            label: 'Tải lại',
+            onPressed: () {
+              provider.refreshBookings();
+            },
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _selectDate(BuildContext context, BookingManager provider) async {
+    final today = DateTime.now();
+    final first = today.subtract(const Duration(days: 1));
+    final last = today.add(const Duration(days: 365));
+
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: provider.selectedDate,
+      firstDate: first,
+      lastDate: last,
+    );
+
+    if (picked != null) {
+      await provider.changeDate(picked);
+    }
+  }
+
+  int _resolveStartHour() {
+    final minutes = widget.detailData.openingHours
+        .map((item) => parseTimeToMinutes(item.openTime))
+        .whereType<int>();
+    if (minutes.isEmpty) return 6;
+    final minMinute = minutes.reduce((a, b) => a < b ? a : b);
+    final base = (minMinute / 60).floor();
+    if (base < 0) return 0;
+    if (base > 23) return 23;
+    return base;
+  }
+
+  int _resolveEndHour() {
+    final minutes = widget.detailData.openingHours
+        .map((item) => parseTimeToMinutes(item.closeTime))
+        .whereType<int>();
+    if (minutes.isEmpty) return 22;
+    final maxMinute = minutes.reduce((a, b) => a > b ? a : b);
+    var endHour = (maxMinute / 60).ceil();
+    if (endHour < 1) {
+      endHour = 1;
+    } else if (endHour > 24) {
+      endHour = 24;
+    }
+    final start = _resolveStartHour();
+    return endHour <= start ? start + 1 : endHour;
   }
 }

--- a/lib/pages/court/payment_page.dart
+++ b/lib/pages/court/payment_page.dart
@@ -1,72 +1,34 @@
 import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court_detail.dart';
-import 'package:badminton_booking_app/services/booking_service.dart';
+import 'package:badminton_booking_app/pages/court/booking_manager.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
 class PaymentPage extends StatefulWidget {
-  const PaymentPage({
-    super.key,
-    required this.detailData,
-    required this.bookings,
-    this.slotDuration = const Duration(hours: 1),
-    this.bookingService,
-  });
-
-  final CourtDetailData detailData;
-  final List<CourtBooking> bookings;
-  final Duration slotDuration;
-  final BookingService? bookingService;
+  const PaymentPage({super.key});
 
   @override
   State<PaymentPage> createState() => _PaymentPageState();
 }
 
 class _PaymentPageState extends State<PaymentPage> {
-  late BookingService _bookingService;
-  bool _processing = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _bookingService = widget.bookingService ?? BookingService();
-  }
-
-  List<SelectedSlot> get _slots {
-    return widget.bookings
-        .expand((booking) => booking.splitToSlots(widget.slotDuration))
-        .map((slot) => SelectedSlot(
-              courtUnitId: slot.courtUnitId,
-              startTime: slot.startTime.toUtc(),
-              endTime: slot.endTime.toUtc(),
-            ))
-        .toList();
-  }
-
-  Duration get _totalDuration {
-    var minutes = 0;
-    for (final slot in _slots) {
-      minutes += slot.endTime.difference(slot.startTime).inMinutes;
-    }
-    return Duration(minutes: minutes);
-  }
-
-  double get _totalPrice {
-    var total = 0.0;
-    for (final slot in _slots) {
-      total += calculateSlotPrice(widget.detailData, slot, widget.slotDuration);
-    }
-    return total;
-  }
+  bool _isProcessingPayment = false;
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final totalDuration = _totalDuration;
+    final provider = context.watch<BookingManager>();
+    final bookings = provider.awaitingPaymentBookings.toList();
+    final slots = _buildSlots(provider, bookings);
+    final detail = provider.detailData;
+
+    final totalDuration = _totalDuration(slots);
     final durationLabel = totalDuration.inMinutes == 0
         ? '0 phút'
         : '${totalDuration.inMinutes ~/ 60}h ${totalDuration.inMinutes % 60}p';
+    final totalPrice = _totalPrice(provider, slots);
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
       appBar: AppBar(
@@ -76,30 +38,30 @@ class _PaymentPageState extends State<PaymentPage> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
-            _buildCourtInfoCard(cs),
+            _buildCourtInfoCard(detail, colorScheme),
             const SizedBox(height: 16),
             Expanded(
-              child: widget.bookings.isEmpty
+              child: bookings.isEmpty
                   ? _buildEmptyState()
                   : ListView.builder(
-                      itemCount: widget.bookings.length,
+                      itemCount: bookings.length,
                       itemBuilder: (context, index) {
-                        final booking = widget.bookings[index];
-                        final slots = booking.splitToSlots(widget.slotDuration);
-                        return _buildBookingCard(cs, booking, slots);
+                        final booking = bookings[index];
+                        final bookingSlots = booking.splitToSlots(provider.slotDuration);
+                        return _buildBookingCard(colorScheme, provider, booking, bookingSlots);
                       },
                     ),
             ),
             const SizedBox(height: 12),
-            _buildTotalRow(cs, durationLabel),
+            _buildTotalRow(colorScheme, durationLabel, totalPrice),
             const SizedBox(height: 12),
             SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: widget.bookings.isEmpty || _processing
+                onPressed: bookings.isEmpty || _isProcessingPayment
                     ? null
-                    : _handlePayment,
-                child: _processing
+                    : () async => _handlePayment(context),
+                child: _isProcessingPayment
                     ? const SizedBox(
                         height: 22,
                         width: 22,
@@ -115,7 +77,37 @@ class _PaymentPageState extends State<PaymentPage> {
     );
   }
 
-  Widget _buildCourtInfoCard(ColorScheme cs) {
+  List<SelectedSlot> _buildSlots(
+    BookingManager provider,
+    List<CourtBooking> bookings,
+  ) {
+    return bookings
+        .expand((booking) => booking.splitToSlots(provider.slotDuration))
+        .map((slot) => SelectedSlot(
+              courtUnitId: slot.courtUnitId,
+              startTime: slot.startTime.toUtc(),
+              endTime: slot.endTime.toUtc(),
+            ))
+        .toList();
+  }
+
+  Duration _totalDuration(List<SelectedSlot> slots) {
+    var minutes = 0;
+    for (final slot in slots) {
+      minutes += slot.endTime.difference(slot.startTime).inMinutes;
+    }
+    return Duration(minutes: minutes);
+  }
+
+  double _totalPrice(BookingManager provider, List<SelectedSlot> slots) {
+    var total = 0.0;
+    for (final slot in slots) {
+      total += calculateSlotPrice(provider.detailData, slot, provider.slotDuration);
+    }
+    return total;
+  }
+
+  Widget _buildCourtInfoCard(CourtDetailData detail, ColorScheme colorScheme) {
     return Material(
       elevation: 2,
       borderRadius: BorderRadius.circular(12),
@@ -123,19 +115,19 @@ class _PaymentPageState extends State<PaymentPage> {
         width: double.infinity,
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: cs.surface,
+          color: colorScheme.surface,
           borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: cs.outline.withOpacity(0.2)),
+          border: Border.all(color: colorScheme.outline.withOpacity(0.2)),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              widget.detailData.court.name,
+              detail.court.name,
               style: TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.bold,
-                color: cs.onSurface,
+                color: colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 6),
@@ -143,7 +135,7 @@ class _PaymentPageState extends State<PaymentPage> {
               children: [
                 const Icon(Icons.place, size: 18),
                 const SizedBox(width: 6),
-                Expanded(child: Text(widget.detailData.court.location)),
+                Expanded(child: Text(detail.court.location)),
               ],
             ),
             const SizedBox(height: 6),
@@ -151,7 +143,7 @@ class _PaymentPageState extends State<PaymentPage> {
               children: [
                 const Icon(Icons.phone, size: 18),
                 const SizedBox(width: 6),
-                Text(widget.detailData.court.phone),
+                Text(detail.court.phone),
               ],
             ),
           ],
@@ -161,98 +153,71 @@ class _PaymentPageState extends State<PaymentPage> {
   }
 
   Widget _buildBookingCard(
-    ColorScheme cs,
+    ColorScheme colorScheme,
+    BookingManager provider,
     CourtBooking booking,
     List<SelectedSlot> slots,
   ) {
-    final formatter = DateFormat('dd/MM/yyyy');
-    final dayLabel = formatter.format(booking.startTime.toLocal());
-
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: cs.surfaceVariant.withOpacity(0.5),
+        color: colorScheme.surface,
         borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outline.withOpacity(0.2)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Ngày $dayLabel',
-            style: TextStyle(
-              fontWeight: FontWeight.w700,
-              color: cs.onSurface,
-            ),
-          ),
-          const SizedBox(height: 8),
-          ...slots.map((slot) => _buildSlotRow(cs, slot)).toList(),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSlotRow(ColorScheme cs, SelectedSlot slot) {
-    final timeLabel =
-        '${DateFormat.Hm().format(slot.startTime.toLocal())} - ${DateFormat.Hm().format(slot.endTime.toLocal())}';
-    final price =
-        calculateSlotPrice(widget.detailData, slot, widget.slotDuration);
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              '${_resolveCourtLabel(slot.courtUnitId)}  $timeLabel',
-              style: TextStyle(color: cs.onSurface),
-            ),
-          ),
-          Text(
-            formatCurrency(price),
-            style: TextStyle(
-              fontWeight: FontWeight.w600,
-              color: cs.primary,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTotalRow(ColorScheme cs, String durationLabel) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-      decoration: BoxDecoration(
-        color: cs.surfaceVariant.withOpacity(0.6),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          Row(
             children: [
-              const Text('Tổng thời gian'),
-              Text(
-                durationLabel,
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  color: cs.onSurface,
-                ),
-              ),
+              const Icon(Icons.access_time, size: 18),
+              const SizedBox(width: 6),
+              Text(DateFormat('dd/MM/yyyy HH:mm').format(booking.startTime.toLocal())),
             ],
           ),
-          const Spacer(),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
+          const SizedBox(height: 8),
+          ...slots.map((slot) {
+            final timeLabel =
+                '${DateFormat('HH:mm').format(slot.startTime.toLocal())} - ${DateFormat('HH:mm').format(slot.endTime.toLocal())}';
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Text('${_resolveCourtLabel(provider, slot.courtUnitId)}  $timeLabel'),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTotalRow(ColorScheme colorScheme, String durationLabel, double totalPrice) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outline.withOpacity(0.2)),
+      ),
+      child: Column(
+        children: [
+          Row(
             children: [
-              const Text('Tổng cộng'),
+              const Icon(Icons.timer_outlined),
+              const SizedBox(width: 8),
+              Text('Tổng thời lượng: $durationLabel'),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Icon(Icons.payments_outlined, color: colorScheme.primary),
+              const SizedBox(width: 8),
               Text(
-                formatCurrency(_totalPrice),
+                formatCurrency(totalPrice),
                 style: TextStyle(
-                  fontSize: 20,
+                  color: colorScheme.primary,
                   fontWeight: FontWeight.bold,
-                  color: cs.primary,
+                  fontSize: 18,
                 ),
               ),
             ],
@@ -275,26 +240,23 @@ class _PaymentPageState extends State<PaymentPage> {
     );
   }
 
-  Future<void> _handlePayment() async {
-    setState(() => _processing = true);
+  Future<void> _handlePayment(BuildContext context) async {
+    setState(() => _isProcessingPayment = true);
 
     try {
-      for (final booking in widget.bookings) {
-        await _bookingService.markAsConfirmed(booking.id);
-      }
-
+      await context.read<BookingManager>().confirmAwaitingPaymentBookings();
       if (!mounted) return;
       await _showPaymentSuccess(context);
       if (!mounted) return;
       Navigator.of(context).pop(true);
-    } catch (error) {
+    } on BookingManagerException catch (error) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_describeError(error))),
+        SnackBar(content: Text(error.message)),
       );
     } finally {
       if (!mounted) return;
-      setState(() => _processing = false);
+      setState(() => _isProcessingPayment = false);
     }
   }
 
@@ -304,7 +266,8 @@ class _PaymentPageState extends State<PaymentPage> {
       builder: (context) => AlertDialog(
         title: const Text('Thanh toán thành công'),
         content: const Text(
-            'Chúng tôi đã ghi nhận giao dịch của bạn. Chúc bạn có buổi chơi vui vẻ!'),
+          'Chúng tôi đã ghi nhận giao dịch của bạn. Chúc bạn có buổi chơi vui vẻ!',
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
@@ -315,18 +278,14 @@ class _PaymentPageState extends State<PaymentPage> {
     );
   }
 
-  String _describeError(Object error) {
-    if (error is BookingServiceException) {
-      return error.message;
+  String _resolveCourtLabel(BookingManager provider, String courtUnitId) {
+    final units = provider.detailData.units;
+    if (units.isEmpty) {
+      return 'Sân';
     }
-    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
-  }
-
-  String _resolveCourtLabel(String courtUnitId) {
-    if (widget.detailData.units.isEmpty) return 'Sân';
-    final unit = widget.detailData.units.firstWhere(
-      (unit) => unit.id == courtUnitId,
-      orElse: () => widget.detailData.units.first,
+    final unit = units.firstWhere(
+      (item) => item.id == courtUnitId,
+      orElse: () => units.first,
     );
     return unit.label.isEmpty ? 'Sân' : unit.label;
   }


### PR DESCRIPTION
## Summary
- rename the booking provider to a centralized BookingManager with clearer, descriptive state fields and cache naming
- update the booking page to consume the new manager, using the renamed actions and friendlier error accessors across the UI
- adjust the payment page to read from BookingManager with explicit naming for payment submission state and confirmation flow

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f8a0fcb678832b98920a5003acd6d5