### PR TITLE
Group court selection by clusters

### DIFF
--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
@@ -13,19 +14,21 @@ class BookingManager extends ChangeNotifier {
     required this.detailData,
     BookingService? bookingService,
     this.slotDuration = const Duration(hours: 1),
-  }) : _bookingService = bookingService ?? BookingService() {
+    this.unitGroupSize = 5,
+  })  : assert(unitGroupSize > 0, 'unitGroupSize must be positive'),
+        _bookingService = bookingService ?? BookingService() {
     _selectedDate = _normalizeDate(DateTime.now());
-    _selectedCourtUnitId = _resolveInitialCourtUnitId();
 
     Future.microtask(() => loadBookings());
   }
 
   final CourtDetailData detailData;
   final Duration slotDuration;
+  final int unitGroupSize;
   final BookingService _bookingService;
 
   DateTime _selectedDate = DateTime.now();
-  String? _selectedCourtUnitId;
+  int _selectedUnitGroupIndex = 0;
   String? _currentUserId;
 
   bool _isLoading = false;
@@ -44,19 +47,46 @@ class BookingManager extends ChangeNotifier {
       <String, _BookingCacheEntry>{};
 
   DateTime get selectedDate => _selectedDate;
-  String? get selectedCourtUnitId => _selectedCourtUnitId;
+  int get selectedUnitGroupIndex => _selectedUnitGroupIndex;
   bool get isLoading => _isLoading;
   bool get isSubmittingHeldBookings => _isSubmittingHeldBookings;
   bool get isConfirmingAwaitingPayment => _isConfirmingAwaitingPaymentBookings;
   String? get friendlyErrorMessage => _friendlyErrorMessage;
   List<CourtBooking> get bookings => List.unmodifiable(_loadedBookings);
-  List<CourtBooking> get bookingsForSelectedUnit {
-    final unitId = _selectedCourtUnitId;
-    if (unitId == null) {
+  List<CourtUnit> get activeCourtUnits =>
+      detailData.units.where((unit) => unit.isActive).toList(growable: false);
+  List<CourtUnit> get visibleCourtUnits {
+    final units = activeCourtUnits;
+    if (units.isEmpty) {
+      return const [];
+    }
+    final totalGroups = totalCourtUnitGroups;
+    if (totalGroups == 0) {
+      return const [];
+    }
+    final safeIndex =
+        _selectedUnitGroupIndex.clamp(0, totalGroups - 1).toInt();
+    final start = safeIndex * unitGroupSize;
+    final end = math.min(start + unitGroupSize, units.length);
+    return units.sublist(start, end);
+  }
+
+  int get totalCourtUnitGroups {
+    final units = activeCourtUnits;
+    if (units.isEmpty) {
+      return 0;
+    }
+    return (units.length / unitGroupSize).ceil();
+  }
+
+  List<CourtBooking> get bookingsForVisibleUnits {
+    final visibleUnits = visibleCourtUnits;
+    if (visibleUnits.isEmpty) {
       return List.unmodifiable(_loadedBookings);
     }
+    final visibleIds = visibleUnits.map((unit) => unit.id).toSet();
     return List.unmodifiable(
-      _loadedBookings.where((booking) => booking.courtUnitId == unitId),
+      _loadedBookings.where((booking) => visibleIds.contains(booking.courtUnitId)),
     );
   }
 
@@ -119,18 +149,21 @@ class BookingManager extends ChangeNotifier {
     await loadBookings();
   }
 
-  Future<void> changeCourtUnit(String? unitId) async {
-    if (unitId == _selectedCourtUnitId) {
+  Future<void> changeCourtUnitGroup(int groupIndex) async {
+    final totalGroups = totalCourtUnitGroups;
+    if (totalGroups == 0) {
       return;
     }
-    _friendlyErrorMessage = null;
-    _selectedCourtUnitId = unitId;
+    final clampedIndex = groupIndex.clamp(0, totalGroups - 1).toInt();
+    if (clampedIndex == _selectedUnitGroupIndex) {
+      return;
+    }
+    _selectedUnitGroupIndex = clampedIndex;
     notifyListeners();
-    await loadBookings(forceRefresh: true);
   }
 
   Future<void> loadBookings({bool forceRefresh = false}) async {
-    final cacheKey = _cacheKeyFor(_selectedDate, _selectedCourtUnitId);
+    final cacheKey = _cacheKeyFor(_selectedDate, null);
 
     if (!forceRefresh) {
       final cached = _bookingCacheByKey[cacheKey];
@@ -140,18 +173,6 @@ class BookingManager extends ChangeNotifier {
         _syncSelectedSlotsWithBookings();
         notifyListeners();
         return;
-      }
-
-      if (_selectedCourtUnitId != null) {
-        final fallbackCache =
-            _bookingCacheByKey[_cacheKeyFor(_selectedDate, null)];
-        if (fallbackCache != null) {
-          _loadedBookings = List<CourtBooking>.from(fallbackCache.bookings);
-          _friendlyErrorMessage = null;
-          _syncSelectedSlotsWithBookings();
-          notifyListeners();
-          return;
-        }
       }
     }
 
@@ -448,17 +469,6 @@ class BookingManager extends ChangeNotifier {
 
   DateTime _normalizeDate(DateTime date) {
     return DateTime(date.year, date.month, date.day);
-  }
-
-  String? _resolveInitialCourtUnitId() {
-    if (detailData.units.isEmpty) {
-      return null;
-    }
-    final activeUnit = detailData.units.firstWhere(
-      (unit) => unit.isActive,
-      orElse: () => detailData.units.first,
-    );
-    return activeUnit.id;
   }
 
   String _describeFriendlyError(Object error) {

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -103,7 +103,7 @@ class _BookingPageViewState extends State<_BookingPageView> {
                           date: provider.selectedDate,
                           startHour: _resolveStartHour(),
                           endHour: _resolveEndHour(),
-                          bookings: provider.bookingsForSelectedUnit,
+                          bookings: provider.bookingsForVisibleUnits,
                           selectedSlots: provider.selectedSlots,
                           currentUserId: _lastUserId,
                           onSlotTap: (slot, shouldSelect) => _handleSlotTap(
@@ -119,30 +119,45 @@ class _BookingPageViewState extends State<_BookingPageView> {
   }
 
   List<CourtTimelineRow> _buildTimelineRows(BookingManager provider) {
-    final units =
+    final activeUnits =
         widget.detailData.units.where((unit) => unit.isActive).toList();
-    if (units.isEmpty) {
+    if (activeUnits.isEmpty) {
       return const [CourtTimelineRow(id: 'default', label: 'Sân 1')];
     }
-    final selectedId = provider.selectedCourtUnitId;
-    if (selectedId == null) {
-      return units
-          .map((unit) => CourtTimelineRow(
-                id: unit.id,
-                label: unit.label.isEmpty ? 'Sân' : unit.label,
-              ))
+    final orderMap = <String, int>{};
+    for (var i = 0; i < activeUnits.length; i++) {
+      orderMap[activeUnits[i].id] = i + 1;
+    }
+    final visibleUnits = provider.visibleCourtUnits;
+    if (visibleUnits.isEmpty) {
+      return activeUnits
+          .map(
+            (unit) => CourtTimelineRow(
+              id: unit.id,
+              label: _unitLabel(unit, orderMap),
+            ),
+          )
           .toList();
     }
-    final unit = units.firstWhere(
-      (item) => item.id == selectedId,
-      orElse: () => units.first,
-    );
-    return [
-      CourtTimelineRow(
-        id: unit.id,
-        label: unit.label.isEmpty ? 'Sân' : unit.label,
-      ),
-    ];
+    return visibleUnits
+        .map(
+          (unit) => CourtTimelineRow(
+            id: unit.id,
+            label: _unitLabel(unit, orderMap),
+          ),
+        )
+        .toList();
+  }
+
+  String _unitLabel(CourtUnit unit, Map<String, int> orderMap) {
+    if (unit.label.trim().isNotEmpty) {
+      return unit.label.trim();
+    }
+    final index = orderMap[unit.id];
+    if (index != null) {
+      return 'Sân $index';
+    }
+    return 'Sân';
   }
 
   Future<void> _handleSlotTap(
@@ -241,7 +256,7 @@ class _BookingPageViewState extends State<_BookingPageView> {
               ),
             ],
           ),
-          if (widget.detailData.units.length > 1)
+          if (widget.detailData.units.where((unit) => unit.isActive).length > 1)
             Padding(
               padding: const EdgeInsets.only(top: 12),
               child: _buildCourtUnitSelector(provider, colorScheme),
@@ -253,10 +268,22 @@ class _BookingPageViewState extends State<_BookingPageView> {
 
   Widget _buildCourtUnitSelector(
       BookingManager provider, ColorScheme colorScheme) {
-    final units =
+    final activeUnits =
         widget.detailData.units.where((unit) => unit.isActive).toList();
-    final selectedId = provider.selectedCourtUnitId ??
-        (units.isNotEmpty ? units.first.id : null);
+    if (activeUnits.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final orderMap = <String, int>{};
+    for (var i = 0; i < activeUnits.length; i++) {
+      orderMap[activeUnits[i].id] = i + 1;
+    }
+    final groups = _chunkUnits(activeUnits, provider.unitGroupSize);
+    if (groups.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final selectedGroupIndex = provider.selectedUnitGroupIndex
+        .clamp(0, groups.length - 1)
+        .toInt();
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -270,18 +297,23 @@ class _BookingPageViewState extends State<_BookingPageView> {
           const SizedBox(width: 8),
           Expanded(
             child: DropdownButtonHideUnderline(
-              child: DropdownButton<String>(
-                value: selectedId,
+              child: DropdownButton<int>(
+                value: selectedGroupIndex,
                 onChanged: (value) {
                   if (value != null) {
-                    provider.changeCourtUnit(value);
+                    provider.changeCourtUnitGroup(value);
                   }
                 },
-                items: units
+                items: groups
+                    .asMap()
+                    .entries
                     .map(
-                      (unit) => DropdownMenuItem<String>(
-                        value: unit.id,
-                        child: Text(unit.label.isEmpty ? 'Sân' : unit.label),
+                      (entry) => DropdownMenuItem<int>(
+                        value: entry.key,
+                        child: Text(
+                          _groupLabel(entry.value, orderMap),
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
                     )
                     .toList(),
@@ -291,6 +323,30 @@ class _BookingPageViewState extends State<_BookingPageView> {
         ],
       ),
     );
+  }
+
+  List<List<CourtUnit>> _chunkUnits(List<CourtUnit> units, int groupSize) {
+    final chunks = <List<CourtUnit>>[];
+    if (units.isEmpty) {
+      return chunks;
+    }
+    for (var i = 0; i < units.length; i += groupSize) {
+      final end = i + groupSize;
+      chunks.add(units.sublist(i, end > units.length ? units.length : end));
+    }
+    return chunks;
+  }
+
+  String _groupLabel(List<CourtUnit> group, Map<String, int> orderMap) {
+    if (group.isEmpty) {
+      return 'Sân';
+    }
+    final startLabel = _unitLabel(group.first, orderMap);
+    if (group.length == 1) {
+      return startLabel;
+    }
+    final endLabel = _unitLabel(group.last, orderMap);
+    return '$startLabel đến $endLabel';
   }
 
   Widget _buildLegend(ColorScheme colorScheme) {


### PR DESCRIPTION
## Summary
- update the booking manager to expose active court units in configurable clusters and filter bookings by the visible group
- refresh the booking page timeline to show only the current cluster and update the dropdown to select labelled unit ranges
