### PR TITLE
Add user booking history and today's bookings pages

### DIFF
--- a/lib/components/user_booking_tile.dart
+++ b/lib/components/user_booking_tile.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/booking.dart';
+import '../models/user_booking_view.dart';
+
+class UserBookingTile extends StatelessWidget {
+  const UserBookingTile({
+    super.key,
+    required this.bookingView,
+  });
+
+  final UserBookingView bookingView;
+
+  @override
+  Widget build(BuildContext context) {
+    final booking = bookingView.booking;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final courtName = bookingView.courtName ?? 'Sân chưa xác định';
+    final courtLocation = bookingView.courtLocation ?? 'Đang cập nhật địa điểm';
+    final courtUnitLabel =
+        bookingView.courtUnitLabel != null && bookingView.courtUnitLabel!.isNotEmpty
+            ? bookingView.courtUnitLabel!
+            : booking.courtUnitId;
+
+    final dateText = _formatDate(booking.startTime.toLocal());
+    final timeRangeText = _formatTimeRange(
+      booking.startTime.toLocal(),
+      booking.endTime.toLocal(),
+    );
+
+    final statusLabel = _mapStatusToLabel(booking.status);
+    final statusColor = _mapStatusToColor(booking.status, colorScheme);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                _buildCourtThumbnail(context),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        courtName,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        courtLocation,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          color: Colors.black54,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Icon(Icons.calendar_today, size: 18),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        dateText,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        timeRangeText,
+                        style: const TextStyle(fontSize: 13),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const Icon(Icons.sports_tennis, size: 18),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Sân: $courtUnitLabel',
+                    style: const TextStyle(fontSize: 13),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                decoration: BoxDecoration(
+                  color: statusColor.withOpacity(0.12),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(
+                  statusLabel,
+                  style: TextStyle(
+                    color: statusColor,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCourtThumbnail(BuildContext context) {
+    final placeholder = Container(
+      width: 64,
+      height: 64,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primary.withOpacity(0.08),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Icon(
+        Icons.sports_tennis,
+        color: Theme.of(context).colorScheme.primary,
+      ),
+    );
+
+    final imageUrl = bookingView.courtCoverImageUrl;
+    if (imageUrl == null || imageUrl.isEmpty) {
+      return placeholder;
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: Image.network(
+        imageUrl,
+        width: 64,
+        height: 64,
+        fit: BoxFit.cover,
+        errorBuilder: (_, __, ___) => placeholder,
+        loadingBuilder: (context, child, loadingProgress) {
+          if (loadingProgress == null) {
+            return child;
+          }
+          return SizedBox(
+            width: 64,
+            height: 64,
+            child: Center(
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  value: loadingProgress.expectedTotalBytes != null
+                      ? loadingProgress.cumulativeBytesLoaded /
+                          loadingProgress.expectedTotalBytes!
+                      : null,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+String _formatDate(DateTime date) {
+  return DateFormat('EEEE, dd/MM/yyyy', 'vi_VN').format(date);
+}
+
+String _formatTimeRange(DateTime start, DateTime end) {
+  final formatter = DateFormat('HH:mm', 'vi_VN');
+  return '${formatter.format(start)} - ${formatter.format(end)}';
+}
+
+String _mapStatusToLabel(BookingStatus status) {
+  switch (status) {
+    case BookingStatus.held:
+      return 'Đang giữ chỗ';
+    case BookingStatus.awaitingPayment:
+      return 'Chờ thanh toán';
+    case BookingStatus.confirmed:
+      return 'Đã xác nhận';
+    case BookingStatus.cancelled:
+      return 'Đã hủy';
+    case BookingStatus.expired:
+      return 'Hết hạn';
+  }
+}
+
+Color _mapStatusToColor(BookingStatus status, ColorScheme colorScheme) {
+  switch (status) {
+    case BookingStatus.held:
+      return colorScheme.tertiary;
+    case BookingStatus.awaitingPayment:
+      return colorScheme.secondary;
+    case BookingStatus.confirmed:
+      return const Color(0xFF2E7D32);
+    case BookingStatus.cancelled:
+      return const Color(0xFFC62828);
+    case BookingStatus.expired:
+      return Colors.grey.shade700;
+  }
+}

--- a/lib/components/user_booking_tile.dart
+++ b/lib/components/user_booking_tile.dart
@@ -19,10 +19,10 @@ class UserBookingTile extends StatelessWidget {
 
     final courtName = bookingView.courtName ?? 'Sân chưa xác định';
     final courtLocation = bookingView.courtLocation ?? 'Đang cập nhật địa điểm';
-    final courtUnitLabel =
-        bookingView.courtUnitLabel != null && bookingView.courtUnitLabel!.isNotEmpty
-            ? bookingView.courtUnitLabel!
-            : booking.courtUnitId;
+    final courtUnitLabel = bookingView.courtUnitLabel != null &&
+            bookingView.courtUnitLabel!.isNotEmpty
+        ? bookingView.courtUnitLabel!
+        : booking.courtUnitId;
 
     final dateText = _formatDate(booking.startTime.toLocal());
     final timeRangeText = _formatTimeRange(
@@ -35,104 +35,110 @@ class UserBookingTile extends StatelessWidget {
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      elevation: 2,
+      elevation: 4,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                _buildCourtThumbnail(context),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        courtName,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w700,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: colorScheme.outline),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _buildCourtThumbnail(context),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          courtName,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w700,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        courtLocation,
-                        style: const TextStyle(
-                          fontSize: 13,
-                          color: Colors.black54,
+                        const SizedBox(height: 4),
+                        Text(
+                          courtLocation,
+                          style: const TextStyle(
+                            fontSize: 13,
+                            color: Colors.black54,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Icon(Icons.calendar_today, size: 18),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        dateText,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.w600,
+                ],
+              ),
+              const SizedBox(height: 16),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.calendar_today, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          dateText,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.w600,
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        timeRangeText,
-                        style: const TextStyle(fontSize: 13),
-                      ),
-                    ],
+                        const SizedBox(height: 4),
+                        Text(
+                          timeRangeText,
+                          style: const TextStyle(fontSize: 13),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                const Icon(Icons.sports_tennis, size: 18),
-                const SizedBox(width: 8),
-                Expanded(
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const Icon(Icons.sports_tennis, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Sân: $courtUnitLabel',
+                      style: const TextStyle(fontSize: 13),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: statusColor.withOpacity(0.12),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
                   child: Text(
-                    'Sân: $courtUnitLabel',
-                    style: const TextStyle(fontSize: 13),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                decoration: BoxDecoration(
-                  color: statusColor.withOpacity(0.12),
-                  borderRadius: BorderRadius.circular(20),
-                ),
-                child: Text(
-                  statusLabel,
-                  style: TextStyle(
-                    color: statusColor,
-                    fontWeight: FontWeight.w600,
+                    statusLabel,
+                    style: TextStyle(
+                      color: statusColor,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
 import 'package:badminton_booking_app/pages/auth/login_page.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
@@ -13,7 +14,7 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await dotenv.load(fileName: ".env");
-
+  await initializeDateFormatting('vi_VN');
   runApp(const MyApp());
 }
 

--- a/lib/models/user_booking_view.dart
+++ b/lib/models/user_booking_view.dart
@@ -1,0 +1,104 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import 'booking.dart';
+
+class UserBookingView {
+  const UserBookingView({
+    required this.booking,
+    this.courtName,
+    this.courtLocation,
+    this.courtCoverImageUrl,
+    this.courtUnitLabel,
+  });
+
+  factory UserBookingView.fromRecord(
+    RecordModel record,
+    PocketBase pocketBase,
+  ) {
+    final booking = CourtBooking.fromRecord(record);
+
+    String? resolvedCourtName;
+    String? resolvedCourtLocation;
+    String? resolvedCourtCoverImageUrl;
+    String? resolvedCourtUnitLabel;
+
+    final expand = record.expand;
+    if (expand != null && expand.isNotEmpty) {
+      final courtRecord = _resolveExpandedRecord(expand['court_id']);
+      if (courtRecord != null) {
+        final data = courtRecord.data;
+        final rawName = data['name'] as String?;
+        final rawLocation = data['location'] as String?;
+        resolvedCourtName = rawName?.trim().isNotEmpty == true
+            ? rawName!.trim()
+            : null;
+        resolvedCourtLocation = rawLocation?.trim().isNotEmpty == true
+            ? rawLocation!.trim()
+            : null;
+
+        final coverField = data['cover_image'];
+        final coverFileName = _extractFirstFileName(coverField);
+        if (coverFileName != null && coverFileName.isNotEmpty) {
+          resolvedCourtCoverImageUrl =
+              pocketBase.files.getUrl(courtRecord, coverFileName).toString();
+        }
+      }
+
+      final courtUnitRecord = _resolveExpandedRecord(expand['court_unit_id']);
+      if (courtUnitRecord != null) {
+        final data = courtUnitRecord.data;
+        final rawLabel =
+            (data['court_label'] ?? data['label']) as String? ?? '';
+        final trimmedLabel = rawLabel.trim();
+        if (trimmedLabel.isNotEmpty) {
+          resolvedCourtUnitLabel = trimmedLabel;
+        }
+      }
+    }
+
+    return UserBookingView(
+      booking: booking,
+      courtName: resolvedCourtName,
+      courtLocation: resolvedCourtLocation,
+      courtCoverImageUrl: resolvedCourtCoverImageUrl,
+      courtUnitLabel: resolvedCourtUnitLabel,
+    );
+  }
+
+  final CourtBooking booking;
+  final String? courtName;
+  final String? courtLocation;
+  final String? courtCoverImageUrl;
+  final String? courtUnitLabel;
+}
+
+RecordModel? _resolveExpandedRecord(dynamic expanded) {
+  if (expanded is RecordModel) {
+    return expanded;
+  }
+
+  if (expanded is List) {
+    for (final item in expanded) {
+      if (item is RecordModel) {
+        return item;
+      }
+    }
+  }
+
+  return null;
+}
+
+String? _extractFirstFileName(dynamic value) {
+  if (value is String && value.trim().isNotEmpty) {
+    return value.trim();
+  }
+
+  if (value is List && value.isNotEmpty) {
+    final first = value.first;
+    if (first is String && first.trim().isNotEmpty) {
+      return first.trim();
+    }
+  }
+
+  return null;
+}

--- a/lib/pages/court/payment_page.dart
+++ b/lib/pages/court/payment_page.dart
@@ -167,7 +167,7 @@ class _PaymentPageState extends State<PaymentPage> {
       decoration: BoxDecoration(
         color: colorScheme.surface,
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: colorScheme.outline.withOpacity(0.2)),
+        border: Border.all(color: colorScheme.outline),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/pages/user/profile_page.dart
+++ b/lib/pages/user/profile_page.dart
@@ -5,8 +5,10 @@ import 'package:badminton_booking_app/components/my_icon_button.dart';
 import 'package:badminton_booking_app/models/user_details.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
 import 'package:badminton_booking_app/pages/auth/login_page.dart';
+import 'package:badminton_booking_app/pages/user/user_booking_history_page.dart';
 import 'package:badminton_booking_app/pages/user/user_detail.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
+import 'package:badminton_booking_app/pages/user/user_today_bookings_page.dart';
 import 'package:badminton_booking_app/utils/dialog_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
@@ -262,7 +264,32 @@ class _ProfilePageState extends State<ProfilePage> {
                           ),
                           SizedBox(height: 5),
                           _buildListItem(
-                              context, Icons.calendar_month, "Booking History"),
+                            context,
+                            Icons.calendar_month,
+                            "Booking History",
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) => const UserBookingHistoryPage(),
+                                ),
+                              );
+                            },
+                          ),
+                          const SizedBox(height: 10),
+                          _buildListItem(
+                            context,
+                            Icons.event_note,
+                            "Today's Bookings",
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) => const UserTodayBookingsPage(),
+                                ),
+                              );
+                            },
+                          ),
                           SizedBox(height: 15),
                           Text(
                             "Systems",
@@ -366,6 +393,14 @@ class _ProfilePageState extends State<ProfilePage> {
                           icon: Icons.calendar_today,
                           title: "",
                           color: const Color.fromARGB(255, 207, 162, 48),
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => const UserTodayBookingsPage(),
+                              ),
+                            );
+                          },
                         ),
                         SizedBox(width: 5),
                       ],

--- a/lib/pages/user/user_booking_history_page.dart
+++ b/lib/pages/user/user_booking_history_page.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../components/user_booking_tile.dart';
+import '../../models/user_booking_view.dart';
+import '../../services/booking_service.dart';
+import 'user_manager.dart';
+
+class UserBookingHistoryPage extends StatefulWidget {
+  const UserBookingHistoryPage({super.key});
+
+  @override
+  State<UserBookingHistoryPage> createState() =>
+      _UserBookingHistoryPageState();
+}
+
+class _UserBookingHistoryPageState extends State<UserBookingHistoryPage> {
+  final BookingService _bookingService = BookingService();
+  Future<List<UserBookingView>>? _historyFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _historyFuture = _loadHistory();
+  }
+
+  Future<List<UserBookingView>> _loadHistory() async {
+    final userManager = context.read<UserManager>();
+    final userId = await userManager.getCurrentUserId();
+    if (userId == null || userId.isEmpty) {
+      throw BookingServiceException('Không tìm thấy thông tin người dùng.');
+    }
+    return _bookingService.listUserBookings(userId: userId);
+  }
+
+  Future<void> _refreshHistory() async {
+    final future = _loadHistory();
+    setState(() {
+      _historyFuture = future;
+    });
+    await future;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Lịch sử đặt sân'),
+      ),
+      body: FutureBuilder<List<UserBookingView>>(
+        future: _historyFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return _buildError(snapshot.error.toString());
+          }
+
+          final bookings = snapshot.data ?? const <UserBookingView>[];
+          if (bookings.isEmpty) {
+            return _buildEmptyState();
+          }
+
+          return RefreshIndicator(
+            onRefresh: _refreshHistory,
+            child: ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemCount: bookings.length,
+              itemBuilder: (context, index) {
+                final bookingView = bookings[index];
+                return UserBookingTile(bookingView: bookingView);
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return RefreshIndicator(
+      onRefresh: _refreshHistory,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: const [
+          SizedBox(height: 120),
+          Icon(Icons.calendar_month, size: 72, color: Colors.grey),
+          SizedBox(height: 12),
+          Center(
+            child: Text(
+              'Bạn chưa có lịch sử đặt sân.',
+              style: TextStyle(fontSize: 16, color: Colors.black54),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildError(String message) {
+    return RefreshIndicator(
+      onRefresh: _refreshHistory,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 120),
+          const Icon(Icons.error_outline, size: 72, color: Colors.redAccent),
+          const SizedBox(height: 12),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 16, color: Colors.black87),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Center(
+            child: Text(
+              'Kéo xuống để thử tải lại.',
+              style: TextStyle(color: Colors.black45),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/user/user_today_bookings_page.dart
+++ b/lib/pages/user/user_today_bookings_page.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../components/user_booking_tile.dart';
+import '../../models/user_booking_view.dart';
+import '../../services/booking_service.dart';
+import 'user_manager.dart';
+
+class UserTodayBookingsPage extends StatefulWidget {
+  const UserTodayBookingsPage({super.key});
+
+  @override
+  State<UserTodayBookingsPage> createState() => _UserTodayBookingsPageState();
+}
+
+class _UserTodayBookingsPageState extends State<UserTodayBookingsPage> {
+  final BookingService _bookingService = BookingService();
+  Future<List<UserBookingView>>? _todayFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _todayFuture = _loadTodayBookings();
+  }
+
+  Future<List<UserBookingView>> _loadTodayBookings() async {
+    final userManager = context.read<UserManager>();
+    final userId = await userManager.getCurrentUserId();
+    if (userId == null || userId.isEmpty) {
+      throw BookingServiceException('Không tìm thấy thông tin người dùng.');
+    }
+
+    final now = DateTime.now();
+    final startOfDay = DateTime(now.year, now.month, now.day);
+    final endOfDay = startOfDay.add(const Duration(days: 1));
+
+    return _bookingService.listUserBookings(
+      userId: userId,
+      startTimeInclusive: startOfDay,
+      endTimeExclusive: endOfDay,
+    );
+  }
+
+  Future<void> _refreshTodayBookings() async {
+    final future = _loadTodayBookings();
+    setState(() {
+      _todayFuture = future;
+    });
+    await future;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Lịch hôm nay'),
+      ),
+      body: FutureBuilder<List<UserBookingView>>(
+        future: _todayFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return _buildError(snapshot.error.toString());
+          }
+
+          final bookings = snapshot.data ?? const <UserBookingView>[];
+          if (bookings.isEmpty) {
+            return _buildEmptyState();
+          }
+
+          return RefreshIndicator(
+            onRefresh: _refreshTodayBookings,
+            child: ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemCount: bookings.length,
+              itemBuilder: (context, index) {
+                final bookingView = bookings[index];
+                return UserBookingTile(bookingView: bookingView);
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return RefreshIndicator(
+      onRefresh: _refreshTodayBookings,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: const [
+          SizedBox(height: 120),
+          Icon(Icons.event_available, size: 72, color: Colors.grey),
+          SizedBox(height: 12),
+          Center(
+            child: Text(
+              'Bạn chưa có lịch nào trong hôm nay.',
+              style: TextStyle(fontSize: 16, color: Colors.black54),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildError(String message) {
+    return RefreshIndicator(
+      onRefresh: _refreshTodayBookings,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 120),
+          const Icon(Icons.error_outline, size: 72, color: Colors.redAccent),
+          const SizedBox(height: 12),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 16, color: Colors.black87),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Center(
+            child: Text(
+              'Kéo xuống để thử tải lại.',
+              style: TextStyle(color: Colors.black45),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -57,6 +57,7 @@ class BookingService {
 
     final escapedUserId = _escapeFilterValue(userId);
     final filterBuffer = StringBuffer("user_id='$escapedUserId'");
+    filterBuffer.write(" && (status='confirmed' || status='confirm')");
 
     if (startTimeInclusive != null) {
       final normalizedStart = startTimeInclusive.toUtc().toIso8601String();

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -1,6 +1,7 @@
 import 'package:pocketbase/pocketbase.dart';
 
 import '../models/booking.dart';
+import '../models/user_booking_view.dart';
 import 'pocketbase_client.dart';
 
 class BookingServiceException implements Exception {
@@ -42,6 +43,49 @@ class BookingService {
     } catch (_) {
       throw BookingServiceException(
           'Không thể tải lịch đặt sân. Vui lòng thử lại sau.');
+    }
+  }
+
+  Future<List<UserBookingView>> listUserBookings({
+    required String userId,
+    DateTime? startTimeInclusive,
+    DateTime? endTimeExclusive,
+    int page = 1,
+    int perPage = 200,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+
+    final escapedUserId = _escapeFilterValue(userId);
+    final filterBuffer = StringBuffer("user_id='$escapedUserId'");
+
+    if (startTimeInclusive != null) {
+      final normalizedStart = startTimeInclusive.toUtc().toIso8601String();
+      filterBuffer.write(" && end_time >= '$normalizedStart'");
+    }
+
+    if (endTimeExclusive != null) {
+      final normalizedEnd = endTimeExclusive.toUtc().toIso8601String();
+      filterBuffer.write(" && start_time < '$normalizedEnd'");
+    }
+
+    try {
+      final result = await pocketBase.collection(collection).getList(
+            page: page,
+            perPage: perPage,
+            filter: filterBuffer.toString(),
+            sort: '-start_time',
+            expand: 'court_id,court_unit_id',
+          );
+
+      return result.items
+          .map((record) => UserBookingView.fromRecord(record, pocketBase))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw BookingServiceException(_mapClientException(error));
+    } catch (_) {
+      throw BookingServiceException(
+        'Không thể tải danh sách đặt sân. Vui lòng thử lại sau.',
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- add a view model and list tile for displaying booking information with related court details
- extend the booking service to fetch bookings for the authenticated user, including optional date filters
- add pages for booking history and today's bookings and link them from the profile screen

