### PR TITLE
Refactor authentication flow to use provider auth gate

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,8 +67,32 @@ class SplashScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: CircularProgressIndicator()),
+    final colorScheme = Theme.of(context).colorScheme;
+    final size = MediaQuery.of(context).size;
+    final logoSize = size.width * 0.5;
+
+    return Scaffold(
+      backgroundColor: colorScheme.background,
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Image.asset(
+              "assets/images/logo_splash.png",
+              width: logoSize,
+              height: logoSize,
+            ),
+            Text(
+              "C O U R T I F Y",
+              style: TextStyle(
+                fontSize: 30,
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onBackground,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,17 @@ Future<void> main() async {
 
   await dotenv.load(fileName: ".env");
   await initializeDateFormatting('vi_VN');
-  runApp(const MyApp());
+
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthManager()),
+        ChangeNotifierProvider(create: (_) => UserManager()),
+        ChangeNotifierProvider(create: (_) => CourtManager()),
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -23,41 +33,42 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider(
-          create: (ctx) => AuthManager(),
-        ),
-        ChangeNotifierProvider(
-          create: (ctx) => UserManager(),
-        ),
-        ChangeNotifierProvider(
-          create: (ctx) => CourtManager(),
-        ),
-      ],
-      child: Consumer<AuthManager>(
-        builder: (ctx, authManager, child) {
-          return MaterialApp(
-            debugShowCheckedModeBanner: false,
-            theme: mainTheme,
-            home: authManager.isAuth
-                ? NavBarPage()
-                : FutureBuilder<bool>(
-                    future: authManager.tryAutoLogin(),
-                    builder: (ctx, snapshot) {
-                      if (snapshot.connectionState == ConnectionState.waiting) {
-                        return const Scaffold(
-                          body: Center(child: CircularProgressIndicator()),
-                        );
-                      }
-                      return snapshot.data == true
-                          ? NavBarPage()
-                          : const LoginPage();
-                    },
-                  ),
-          );
-        },
-      ),
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: mainTheme,
+      home: const AppRoot(),
+    );
+  }
+}
+
+class AppRoot extends StatelessWidget {
+  const AppRoot({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AuthManager>(
+      builder: (_, authManager, __) {
+        if (authManager.isChecking) {
+          return const SplashScreen();
+        }
+
+        if (authManager.isAuth) {
+          return const NavBarPage();
+        }
+
+        return const LoginPage();
+      },
+    );
+  }
+}
+
+class SplashScreen extends StatelessWidget {
+  const SplashScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: CircularProgressIndicator()),
     );
   }
 }

--- a/lib/pages/auth/auth_manager.dart
+++ b/lib/pages/auth/auth_manager.dart
@@ -7,22 +7,23 @@ import '../../services/auth_service.dart';
 
 class AuthManager with ChangeNotifier {
   late final AuthService _authService;
-
   User? _loggedInUser;
+  bool _isChecking = true;
 
   AuthManager() {
-    _authService = AuthService(onAuthChange: (User? user) {
-      _loggedInUser = user;
-      notifyListeners();
-    });
+    _authService = AuthService(onAuthChange: _handleAuthChange);
+    Future.microtask(tryAutoLogin);
   }
 
-  bool get isAuth {
-    return _loggedInUser != null;
-  }
+  bool get isAuth => _loggedInUser != null;
 
-  User? get user {
-    return _loggedInUser;
+  bool get isChecking => _isChecking;
+
+  User? get user => _loggedInUser;
+
+  void _handleAuthChange(User? user) {
+    _loggedInUser = user;
+    notifyListeners();
   }
 
   Future<User> signup(
@@ -30,25 +31,40 @@ class AuthManager with ChangeNotifier {
     String password,
     String phone,
     String username,
-  ) {
-    return _authService.signup(email, password, phone, username);
+  ) async {
+    final user = await _authService.signup(email, password, phone, username);
+    _loggedInUser = user;
+    notifyListeners();
+    return user;
   }
 
-  Future<User> login(String email, String password) {
-    return _authService.login(email, password);
+  Future<User> login(String email, String password) async {
+    final user = await _authService.login(email, password);
+    _loggedInUser = user;
+    notifyListeners();
+    return user;
   }
 
   Future<bool> tryAutoLogin() async {
-    final user = await _authService.getUserFromStore();
-    if (user != null) {
+    try {
+      final user = await _authService.getUserFromStore();
       _loggedInUser = user;
+      return user != null;
+    } finally {
+      _isChecking = false;
       notifyListeners();
-      return true;
     }
-    return false;
   }
 
   Future<void> logout() async {
-    return _authService.logout();
+    await _authService.logout();
+    _loggedInUser = null;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _authService.dispose();
+    super.dispose();
   }
 }

--- a/lib/pages/auth/login_page.dart
+++ b/lib/pages/auth/login_page.dart
@@ -3,7 +3,6 @@ import 'dart:developer';
 import 'package:badminton_booking_app/components/my_button.dart';
 import 'package:badminton_booking_app/components/my_text_field.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
-import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/pages/auth/sign_up_page.dart';
 import 'package:badminton_booking_app/utils/dialog_utils.dart';
 import 'package:flutter/material.dart';
@@ -20,16 +19,15 @@ class _LoginPageState extends State<LoginPage> {
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwdController = TextEditingController();
   final GlobalKey<FormState> _formKey = GlobalKey();
+  final ValueNotifier<bool> _isSubmitting = ValueNotifier<bool>(false);
 
   @override
   void dispose() {
     emailController.dispose();
     passwdController.dispose();
-
+    _isSubmitting.dispose();
     super.dispose();
   }
-
-  final _isSubmitting = ValueNotifier<bool>(false);
 
   Future<void> _submit(BuildContext context) async {
     if (!_formKey.currentState!.validate()) {
@@ -44,18 +42,10 @@ class _LoginPageState extends State<LoginPage> {
       final email = emailController.text.trim();
       final password = passwdController.text;
 
-      // Sign user up
       await context.read<AuthManager>().login(
             email,
             password,
           );
-
-      if (!mounted) return;
-
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(builder: (_) => const NavBarPage()),
-      );
     } catch (e, st) {
       log('login error: $e', stackTrace: st);
       if (!mounted) return;
@@ -198,51 +188,13 @@ class _LoginPageState extends State<LoginPage> {
                             fontSize: 17,
                             fontWeight: FontWeight.bold,
                           )),
+                      SizedBox(width: 5),
+                      Icon(Icons.arrow_forward,
+                          color: colorScheme.primary, size: 22),
                     ],
                   ),
-                ),
+                )
               ],
-            ),
-            const SizedBox(height: 40),
-            GestureDetector(
-              onTap: () {},
-              child: Container(
-                margin: const EdgeInsets.symmetric(horizontal: 30),
-                child: Material(
-                  elevation: 2,
-                  borderRadius: BorderRadius.circular(12),
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 12, vertical: 12),
-                    width: MediaQuery.of(context).size.width,
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      border: Border.all(color: Colors.grey.shade300),
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Image.asset(
-                          "assets/images/google_logo.png",
-                          height: 30,
-                          width: 30,
-                        ),
-                        const SizedBox(width: 12),
-                        const Text(
-                          'Sign in with Google',
-                          style: TextStyle(
-                            color: Colors.black54,
-                            fontSize: 20,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
             )
           ],
         ),

--- a/lib/pages/auth/sign_up_page.dart
+++ b/lib/pages/auth/sign_up_page.dart
@@ -5,7 +5,6 @@ import 'package:badminton_booking_app/components/my_button.dart';
 import 'package:badminton_booking_app/components/my_text_field.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
 import 'package:badminton_booking_app/pages/auth/login_page.dart';
-import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/utils/dialog_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:intl_phone_field/intl_phone_field.dart';
@@ -58,20 +57,12 @@ class _SignUpPageState extends State<SignUpPage> {
       final phone = rawPhone.replaceAll(RegExp(r'\s+'), '');
       final username = nameController.text.trim();
 
-      // Sign user up
       await context.read<AuthManager>().signup(
             email,
             password,
             phone,
             username,
           );
-
-      if (!mounted) return;
-
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(builder: (_) => const NavBarPage()),
-      );
     } catch (e, st) {
       log('signup error: $e', stackTrace: st);
       if (!mounted) return;
@@ -200,12 +191,15 @@ class _SignUpPageState extends State<SignUpPage> {
                         ),
                         const SizedBox(height: 10),
                         MyTextfield(
-                          hintText: "Enter your username...",
+                          hintText: "Enter your Username...",
                           controller: nameController,
                           prefixIcon: const Icon(Icons.person),
                           validator: (v) {
                             if (v == null || v.trim().isEmpty) {
                               return 'Vui lòng nhập username';
+                            }
+                            if (v.trim().length < 3) {
+                              return 'Username phải có ít nhất 3 ký tự';
                             }
                             return null;
                           },
@@ -220,13 +214,13 @@ class _SignUpPageState extends State<SignUpPage> {
                         ),
                         const SizedBox(height: 10),
                         MyTextfield(
-                          hintText: "Enter your password...",
+                          hintText: "Enter your Password...",
                           controller: passwdController,
                           obscureText: true,
                           prefixIcon: const Icon(Icons.password),
                           validator: (v) {
                             if (v == null || v.length < 8) {
-                              return 'Mật khẩu tối thiểu 8 ký tự';
+                              return 'Password phải có ít nhất 8 ký tự';
                             }
                             return null;
                           },
@@ -235,71 +229,32 @@ class _SignUpPageState extends State<SignUpPage> {
 
                         // Confirm password field
                         const Text(
-                          'Comfirm Password',
+                          'Confirm Password',
                           style: TextStyle(
                               fontSize: 16, fontWeight: FontWeight.bold),
                         ),
                         const SizedBox(height: 10),
                         MyTextfield(
-                          hintText: "Confirm your password...",
+                          hintText: "Enter your Password again...",
                           controller: confirmPWController,
                           obscureText: true,
                           prefixIcon: const Icon(Icons.password),
                           validator: (v) {
-                            if (v == null || v.isEmpty) {
-                              return 'Vui lòng xác nhận mật khẩu';
+                            if (v == null || v.length < 8) {
+                              return 'Confirm Password phải có ít nhất 8 ký tự';
                             }
                             if (v != passwdController.text) {
-                              return 'Không khớp mật khẩu';
+                              return 'Password và Confirm password không khớp';
                             }
                             return null;
                           },
                         ),
                         const SizedBox(height: 20),
 
-                        // Navigate to Login page
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              "Already have an account?",
-                              style: TextStyle(
-                                color: Color(0xFF311937),
-                                fontSize: 17,
-                                fontWeight: FontWeight.w500,
-                              ),
-                            ),
-                            const SizedBox(width: 5),
-                            GestureDetector(
-                              onTap: () {
-                                Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                        builder: (context) => LoginPage()));
-                              },
-                              child: Row(
-                                mainAxisAlignment: MainAxisAlignment.end,
-                                children: [
-                                  Text("Login Here",
-                                      style: TextStyle(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .primary,
-                                        fontSize: 17,
-                                        fontWeight: FontWeight.bold,
-                                      )),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 20),
-
-                        // Sign up button
                         ValueListenableBuilder<bool>(
                           valueListenable: _isSubmitting,
                           builder: (_, loading, __) => MyButton(
-                            text: loading ? "Signing Up..." : "Sign Up",
+                            text: loading ? "Wait a second..." : "Sign Up",
                             onTap: loading ? null : () => _submit(context),
                           ),
                         ),
@@ -308,6 +263,47 @@ class _SignUpPageState extends State<SignUpPage> {
                   ),
                 ),
               ),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  'Already have an account?',
+                  style: TextStyle(
+                    color: const Color(0xFF311937),
+                    fontSize: 17,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(width: 5),
+                GestureDetector(
+                  onTap: () {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(builder: (_) => const LoginPage()),
+                    );
+                  },
+                  child: Row(
+                    children: [
+                      Text(
+                        'Login here',
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.primary,
+                          fontSize: 17,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(width: 5),
+                      Icon(
+                        Icons.arrow_back,
+                        color: Theme.of(context).colorScheme.primary,
+                        size: 22,
+                      )
+                    ],
+                  ),
+                )
+              ],
             ),
             const SizedBox(height: 20),
           ],

--- a/lib/pages/auth/sign_up_page.dart
+++ b/lib/pages/auth/sign_up_page.dart
@@ -296,7 +296,7 @@ class _SignUpPageState extends State<SignUpPage> {
                       ),
                       const SizedBox(width: 5),
                       Icon(
-                        Icons.arrow_back,
+                        Icons.arrow_forward,
                         color: Theme.of(context).colorScheme.primary,
                         size: 22,
                       )

--- a/lib/pages/user/profile_page.dart
+++ b/lib/pages/user/profile_page.dart
@@ -4,7 +4,6 @@ import 'package:badminton_booking_app/components/my_icon_button.dart';
 
 import 'package:badminton_booking_app/models/user_details.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
-import 'package:badminton_booking_app/pages/auth/login_page.dart';
 import 'package:badminton_booking_app/pages/user/user_booking_history_page.dart';
 import 'package:badminton_booking_app/pages/user/user_detail.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
@@ -317,18 +316,7 @@ class _ProfilePageState extends State<ProfilePage> {
                               if (!confirm) return;
 
                               try {
-                                final authManager = context.read<AuthManager>();
-                                final navigator = Navigator.of(context);
-                                await authManager.logout();
-
-                                if (!mounted) return;
-
-                                // Xoá toàn bộ stack và quay về LoginPage
-                                navigator.pushAndRemoveUntil(
-                                  MaterialPageRoute(
-                                      builder: (_) => LoginPage()),
-                                  (route) => false,
-                                );
+                                await context.read<AuthManager>().logout();
                               } catch (e) {
                                 if (!mounted) return;
                                 await showErrorDialog(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:pocketbase/pocketbase.dart';
 
 import '../models/user.dart';
@@ -6,14 +8,15 @@ import 'pocketbase_client.dart';
 
 class AuthService {
   void Function(User? user)? onAuthChange;
+  StreamSubscription<dynamic>? _authSubscription;
 
   AuthService({this.onAuthChange}) {
     if (onAuthChange != null) {
       getPocketbaseInstance().then((pb) {
-        pb.authStore.onChange.listen((event) {
-          onAuthChange!(event.record == null
-              ? null
-              : User.fromJson(event.record!.toJson()));
+        _authSubscription = pb.authStore.onChange.listen((event) {
+          onAuthChange!(
+            event.record == null ? null : User.fromJson(event.record!.toJson()),
+          );
         });
       });
     }
@@ -99,5 +102,10 @@ class AuthService {
     }
 
     return User.fromJson(model.toJson());
+  }
+
+  void dispose() {
+    _authSubscription?.cancel();
+    _authSubscription = null;
   }
 }


### PR DESCRIPTION
## Summary
- register global providers in `main` and introduce an `AppRoot` gate that renders splash, auth, or home
- enhance `AuthManager`/`AuthService` to handle auto-login, login/logout notifications, and dispose listeners safely
- simplify login, signup, and profile logout flows to rely on provider state changes instead of manual navigation

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690336156c94832b89f27a1bf329f2ba