### PR TITLE
Add recruitment and chat UI screens to social page

### DIFF
--- a/lib/pages/social/recruitment_post_page.dart
+++ b/lib/pages/social/recruitment_post_page.dart
@@ -1,0 +1,314 @@
+import 'package:flutter/material.dart';
+
+class RecruitmentPostPage extends StatefulWidget {
+  const RecruitmentPostPage({super.key});
+
+  @override
+  State<RecruitmentPostPage> createState() => _RecruitmentPostPageState();
+}
+
+class _RecruitmentPostPageState extends State<RecruitmentPostPage> {
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _requirementsController = TextEditingController();
+
+  bool _linkExistingBooking = true;
+  String? _selectedBookingId;
+  int _desiredMembers = 2;
+  String _selectedSkill = 'Trung bình';
+
+  final List<_BookingOption> _bookingOptions = const [
+    _BookingOption(
+      id: 'booking-101',
+      courtName: 'Sân 1 - Nhà thi đấu Q.1',
+      date: '12/06/2024',
+      timeRange: '18:00 - 19:30',
+    ),
+    _BookingOption(
+      id: 'booking-102',
+      courtName: 'Sân 3 - Trung tâm Quận 7',
+      date: '14/06/2024',
+      timeRange: '19:30 - 21:00',
+    ),
+  ];
+
+  final List<String> _skillLevels = const [
+    'Mới bắt đầu',
+    'Trung bình',
+    'Khá',
+    'Chuyên nghiệp',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    if (_bookingOptions.isNotEmpty) {
+      _selectedBookingId = _bookingOptions.first.id;
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _requirementsController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Đăng tuyển thành viên'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Tiêu đề bài đăng',
+                  hintText: 'Ví dụ: Tuyển thêm 2 thành viên đánh đôi',
+                ),
+              ),
+              const SizedBox(height: 20),
+              TextField(
+                controller: _descriptionController,
+                minLines: 4,
+                maxLines: 6,
+                decoration: const InputDecoration(
+                  labelText: 'Mô tả chi tiết',
+                  hintText:
+                      'Chia sẻ thời gian, phong cách chơi và thông tin liên hệ của bạn...',
+                ),
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Switch(
+                    value: _linkExistingBooking,
+                    onChanged: (value) {
+                      setState(() {
+                        _linkExistingBooking = value;
+                      });
+                    },
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      _linkExistingBooking
+                          ? 'Liên kết với sân đã đặt'
+                          : 'Tự chọn số lượng cần tuyển',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              AnimatedCrossFade(
+                duration: const Duration(milliseconds: 250),
+                crossFadeState: _linkExistingBooking
+                    ? CrossFadeState.showFirst
+                    : CrossFadeState.showSecond,
+                firstChild: _buildLinkedBookingCard(colorScheme),
+                secondChild: _buildDesiredMemberSelector(colorScheme),
+              ),
+              const SizedBox(height: 24),
+              Text(
+                'Trình độ mong muốn',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 10,
+                runSpacing: 10,
+                children: _skillLevels.map((level) {
+                  final bool isSelected = _selectedSkill == level;
+                  return ChoiceChip(
+                    label: Text(level),
+                    selected: isSelected,
+                    onSelected: (_) {
+                      setState(() => _selectedSkill = level);
+                    },
+                    selectedColor: colorScheme.primaryContainer,
+                    labelStyle: TextStyle(
+                      color: isSelected
+                          ? colorScheme.onPrimaryContainer
+                          : colorScheme.onSurface,
+                    ),
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 24),
+              TextField(
+                controller: _requirementsController,
+                minLines: 3,
+                maxLines: 5,
+                decoration: const InputDecoration(
+                  labelText: 'Yêu cầu thêm (không bắt buộc)',
+                  hintText:
+                      'Ví dụ: Mang vợt riêng, đúng giờ hoặc mức phí chia sẻ...',
+                ),
+              ),
+              const SizedBox(height: 36),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.send_rounded),
+                  label: const Text('Đăng bài'),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    textStyle: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLinkedBookingCard(ColorScheme colorScheme) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: colorScheme.surfaceVariant.withOpacity(0.4),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Chọn sân đã đặt',
+            style: Theme.of(context)
+                .textTheme
+                .titleMedium
+                ?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<String>(
+            value: _selectedBookingId,
+            items: _bookingOptions
+                .map(
+                  (booking) => DropdownMenuItem(
+                    value: booking.id,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          booking.courtName,
+                          style: const TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: 4),
+                        Text('${booking.date} • ${booking.timeRange}'),
+                      ],
+                    ),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) {
+              setState(() {
+                _selectedBookingId = value;
+              });
+            },
+            decoration: const InputDecoration(
+              labelText: 'Lịch đặt sân',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDesiredMemberSelector(ColorScheme colorScheme) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: colorScheme.surfaceVariant.withOpacity(0.4),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Bạn muốn tuyển bao nhiêu người?',
+            style: Theme.of(context)
+                .textTheme
+                .titleMedium
+                ?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              IconButton(
+                onPressed: _desiredMembers > 1
+                    ? () => setState(() => _desiredMembers--)
+                    : null,
+                icon: const Icon(Icons.remove_circle_outline),
+              ),
+              Expanded(
+                child: Column(
+                  children: [
+                    Text(
+                      '$_desiredMembers người',
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    Slider(
+                      value: _desiredMembers.toDouble(),
+                      min: 1,
+                      max: 6,
+                      divisions: 5,
+                      label: '$_desiredMembers',
+                      onChanged: (value) {
+                        setState(() {
+                          _desiredMembers = value.round();
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                onPressed: _desiredMembers < 6
+                    ? () => setState(() => _desiredMembers++)
+                    : null,
+                icon: const Icon(Icons.add_circle_outline),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BookingOption {
+  final String id;
+  final String courtName;
+  final String date;
+  final String timeRange;
+
+  const _BookingOption({
+    required this.id,
+    required this.courtName,
+    required this.date,
+    required this.timeRange,
+  });
+}

--- a/lib/pages/social/user_chat_page.dart
+++ b/lib/pages/social/user_chat_page.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+
+class UserChatPage extends StatefulWidget {
+  final String userName;
+  final String? avatarUrl;
+
+  const UserChatPage({
+    super.key,
+    this.userName = 'Minh Nguyễn',
+    this.avatarUrl,
+  });
+
+  @override
+  State<UserChatPage> createState() => _UserChatPageState();
+}
+
+class _UserChatPageState extends State<UserChatPage> {
+  final TextEditingController _messageController = TextEditingController();
+
+  final List<_ChatMessage> _messages = [
+    const _ChatMessage(
+      content: 'Chào bạn, đội mình còn tuyển người không?',
+      isMine: false,
+      sentAt: '18:05',
+    ),
+    const _ChatMessage(
+      content: 'Chào bạn! Mình đang cần thêm 1 người đánh đơn tối nay.',
+      isMine: true,
+      sentAt: '18:06',
+    ),
+    const _ChatMessage(
+      content: 'Bạn có thể đến sân Trung tâm Q7 lúc 19h chứ?',
+      isMine: true,
+      sentAt: '18:06',
+    ),
+    const _ChatMessage(
+      content: 'Ok mình đến được, có cần chuẩn bị gì không?',
+      isMine: false,
+      sentAt: '18:07',
+    ),
+  ];
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        titleSpacing: 0,
+        title: Row(
+          children: [
+            CircleAvatar(
+              backgroundColor: colorScheme.primary,
+              backgroundImage: widget.avatarUrl != null
+                  ? NetworkImage(widget.avatarUrl!)
+                  : null,
+              child: widget.avatarUrl == null
+                  ? Text(
+                      widget.userName.isNotEmpty
+                          ? widget.userName.characters.first.toUpperCase()
+                          : 'U',
+                      style: TextStyle(color: colorScheme.onPrimary),
+                    )
+                  : null,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    widget.userName,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  Text(
+                    'Đang hoạt động',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.call_outlined),
+            ),
+            IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.more_vert),
+            ),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(20),
+              reverse: true,
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final message = _messages[_messages.length - 1 - index];
+                return _ChatBubble(message: message);
+              },
+            ),
+          ),
+          const Divider(height: 1),
+          SafeArea(
+            top: false,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              color: colorScheme.surface,
+              child: Row(
+                children: [
+                  IconButton(
+                    onPressed: () {},
+                    icon: const Icon(Icons.add_circle_outline),
+                  ),
+                  Expanded(
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      decoration: BoxDecoration(
+                        color: colorScheme.surfaceVariant.withOpacity(0.7),
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      child: TextField(
+                        controller: _messageController,
+                        minLines: 1,
+                        maxLines: 4,
+                        decoration: const InputDecoration(
+                          border: InputBorder.none,
+                          hintText: 'Nhập tin nhắn...',
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  ElevatedButton(
+                    onPressed: () {},
+                    style: ElevatedButton.styleFrom(
+                      shape: const CircleBorder(),
+                      padding: const EdgeInsets.all(14),
+                    ),
+                    child: const Icon(Icons.send_rounded),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChatBubble extends StatelessWidget {
+  final _ChatMessage message;
+
+  const _ChatBubble({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final alignment = message.isMine
+        ? Alignment.centerRight
+        : Alignment.centerLeft;
+    final backgroundColor = message.isMine
+        ? colorScheme.primary
+        : colorScheme.surfaceVariant;
+    final textColor = message.isMine
+        ? colorScheme.onPrimary
+        : colorScheme.onSurface;
+
+    return Align(
+      alignment: alignment,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.of(context).size.width * 0.75,
+          ),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: backgroundColor,
+              borderRadius: BorderRadius.only(
+                topLeft: const Radius.circular(18),
+                topRight: const Radius.circular(18),
+                bottomLeft:
+                    message.isMine ? const Radius.circular(18) : Radius.zero,
+                bottomRight:
+                    message.isMine ? Radius.zero : const Radius.circular(18),
+              ),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Column(
+                crossAxisAlignment: message.isMine
+                    ? CrossAxisAlignment.end
+                    : CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    message.content,
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: 15,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    message.sentAt,
+                    style: TextStyle(
+                      color: textColor.withOpacity(0.7),
+                      fontSize: 11,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ChatMessage {
+  final String content;
+  final bool isMine;
+  final String sentAt;
+
+  const _ChatMessage({
+    required this.content,
+    required this.isMine,
+    required this.sentAt,
+  });
+}

--- a/lib/pages/social_page.dart
+++ b/lib/pages/social_page.dart
@@ -1,4 +1,6 @@
 import 'package:badminton_booking_app/components/my_post.dart';
+import 'package:badminton_booking_app/pages/social/recruitment_post_page.dart';
+import 'package:badminton_booking_app/pages/social/user_chat_page.dart';
 import 'package:flutter/material.dart';
 
 class SocialPage extends StatelessWidget {
@@ -11,12 +13,23 @@ class SocialPage extends StatelessWidget {
     final DateTime time = DateTime.now();
 
     return Scaffold(
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => const RecruitmentPostPage(),
+            ),
+          );
+        },
+        icon: const Icon(Icons.post_add_outlined),
+        label: const Text('Đăng tuyển'),
+      ),
       body: Stack(
         children: [
           // List Bài Viết
           Container(
             margin: EdgeInsets.only(top: screenHeight / 18),
-            padding: const EdgeInsets.only(top: 50, bottom: 40),
+            padding: const EdgeInsets.only(top: 70, bottom: 40),
             child: ListView(
               children: [
                 MyPost(
@@ -53,17 +66,64 @@ class SocialPage extends StatelessWidget {
             height: screenHeight / 7,
             decoration: BoxDecoration(
               color: cs.primary,
+              boxShadow: [
+                BoxShadow(
+                  color: cs.shadow.withOpacity(0.15),
+                  blurRadius: 12,
+                  offset: const Offset(0, 6),
+                ),
+              ],
             ),
-            child: Padding(
-              padding: const EdgeInsets.only(top: 35),
-              child: Center(
-                child: Text(
-                  'W A L L',
-                  style: TextStyle(
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.onPrimary,
-                  ),
+            child: SafeArea(
+              bottom: false,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      'W A L L',
+                      style: TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.onPrimary,
+                      ),
+                    ),
+                    const Spacer(),
+                    FilledButton.icon(
+                      onPressed: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => const RecruitmentPostPage(),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.group_add_outlined),
+                      label: const Text('Tuyển thành viên'),
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 10,
+                        ),
+                        textStyle: const TextStyle(fontSize: 13),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    IconButton(
+                      onPressed: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => const UserChatPage(),
+                          ),
+                        );
+                      },
+                      icon: Icon(
+                        Icons.chat_bubble_outline_rounded,
+                        color: Theme.of(context).colorScheme.onPrimary,
+                      ),
+                      tooltip: 'Chat với người dùng',
+                    ),
+                  ],
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- add a recruitment post creation page that supports linking existing bookings or selecting desired team size
- add a dedicated chat conversation screen for user messaging
- surface entry points from the social wall header and floating action button for the new UIs

## Testing
- Not run (Flutter SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_69034b6c7290832b97721ac79ff8b478