### PR TITLE
Add social posting and recruitment submission flows

### DIFF
--- a/lib/components/my_post.dart
+++ b/lib/components/my_post.dart
@@ -2,26 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class MyPost extends StatelessWidget {
-  final String message;
   final String userName;
   final DateTime time;
+  final String? content;
+  final List<String> imageUrls;
   final VoidCallback? onLikePressed;
 
   const MyPost({
     super.key,
-    required this.message,
     required this.userName,
     required this.time,
+    this.content,
+    this.imageUrls = const <String>[],
     this.onLikePressed,
   });
 
   @override
   Widget build(BuildContext context) {
-    final isImage = message.startsWith('http') ||
-        message.startsWith('https') &&
-            (message.contains('.jpg') ||
-                message.contains('.png') ||
-                message.contains('cloudinary'));
     final cs = Theme.of(context).colorScheme;
 
     return Padding(
@@ -87,29 +84,36 @@ class MyPost extends StatelessWidget {
                 ),
               ),
 
-              // Post message
-              isImage
-                  ? ClipRRect(
-                      borderRadius: BorderRadius.circular(0),
-                      child: Center(
-                        child: Image.network(
-                          message,
-                          fit: BoxFit.cover,
-                          width: MediaQuery.of(context).size.width,
-                        ),
-                      ),
-                    )
-                  : Padding(
-                      padding:
-                          const EdgeInsets.only(left: 20, top: 10, bottom: 10),
-                      child: Text(
-                        message,
-                        style: const TextStyle(
-                          color: Colors.black87,
-                          fontSize: 20,
-                        ),
-                      ),
+              if (content != null && content!.isNotEmpty)
+                Padding(
+                  padding:
+                      const EdgeInsets.only(left: 20, right: 20, bottom: 10),
+                  child: Text(
+                    content!,
+                    style: const TextStyle(
+                      color: Colors.black87,
+                      fontSize: 20,
                     ),
+                  ),
+                ),
+              if (imageUrls.isNotEmpty)
+                Column(
+                  children: imageUrls
+                      .map(
+                        (url) => Padding(
+                          padding: const EdgeInsets.only(bottom: 12),
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(0),
+                            child: Image.network(
+                              url,
+                              fit: BoxFit.cover,
+                              width: double.infinity,
+                            ),
+                          ),
+                        ),
+                      )
+                      .toList(),
+                ),
 
               // Action bar
               Padding(
@@ -126,14 +130,7 @@ class MyPost extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(width: 8),
-                    Text(
-                      '100',
-                      style: const TextStyle(
-                        color: Colors.black87,
-                        fontWeight: FontWeight.w400,
-                        fontSize: 18,
-                      ),
-                    ),
+                    const SizedBox(width: 8),
                     const SizedBox(width: 10),
                     IconButton(
                       icon: const Icon(Icons.comment_outlined,

--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -10,6 +10,8 @@ class RecruitmentPostCard extends StatelessWidget {
   final String? description;
   final String? courtName;
   final DateTime? playTime;
+  final String? playStyle;
+  final String? locationNote;
   final VoidCallback? onJoin;
 
   const RecruitmentPostCard({
@@ -22,6 +24,8 @@ class RecruitmentPostCard extends StatelessWidget {
     this.description,
     this.courtName,
     this.playTime,
+    this.playStyle,
+    this.locationNote,
     this.onJoin,
   });
 
@@ -95,16 +99,26 @@ class RecruitmentPostCard extends StatelessWidget {
                       color: cs.primaryContainer,
                       iconColor: cs.primary,
                     ),
-                  _InfoChip(
-                    icon: Icons.sports_tennis,
-                    label: 'Loại hình: Đánh đơn/đôi',
-                    color: cs.secondaryContainer,
-                    iconColor: cs.secondary,
-                  ),
+                  if (playStyle != null && playStyle!.isNotEmpty)
+                    _InfoChip(
+                      icon: Icons.sports_tennis,
+                      label: 'Lối chơi: $playStyle',
+                      color: cs.secondaryContainer,
+                      iconColor: cs.secondary,
+                    ),
                   if (courtName != null && courtName!.isNotEmpty)
                     _InfoChip(
                       icon: Icons.location_on_outlined,
                       label: 'Sân: $courtName',
+                      color: cs.tertiaryContainer,
+                      iconColor: cs.tertiary,
+                    ),
+                  if ((courtName == null || courtName!.isEmpty) &&
+                      locationNote != null &&
+                      locationNote!.isNotEmpty)
+                    _InfoChip(
+                      icon: Icons.location_on_outlined,
+                      label: locationNote!,
                       color: cs.tertiaryContainer,
                       iconColor: cs.tertiary,
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
+import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
+import 'package:badminton_booking_app/providers/file_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
@@ -22,6 +24,8 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => AuthManager()),
         ChangeNotifierProvider(create: (_) => UserManager()),
         ChangeNotifierProvider(create: (_) => CourtManager()),
+        ChangeNotifierProvider(create: (_) => SocialFeedManager()),
+        ChangeNotifierProvider(create: (_) => FileManager()),
       ],
       child: const MyApp(),
     ),

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -1,0 +1,126 @@
+import 'package:pocketbase/pocketbase.dart';
+
+class Post {
+  final String id;
+  final String authorId;
+  final String authorName;
+  final String? authorAvatarUrl;
+  final String? content;
+  final List<String> imageUrls;
+  final bool isActive;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const Post({
+    required this.id,
+    required this.authorId,
+    required this.authorName,
+    required this.content,
+    required this.imageUrls,
+    required this.isActive,
+    required this.createdAt,
+    required this.updatedAt,
+    this.authorAvatarUrl,
+  });
+
+  factory Post.fromRecord(PocketBase client, RecordModel record) {
+    final data = record.toJson();
+    final authorInfo = _extractAuthor(client, record);
+    final rawImages = data['images'];
+
+    final imageUrls = <String>[];
+    if (rawImages is String && rawImages.isNotEmpty) {
+      imageUrls.add(client.files.getUrl(record, rawImages).toString());
+    } else if (rawImages is List) {
+      for (final item in rawImages) {
+        if (item is String && item.isNotEmpty) {
+          imageUrls.add(client.files.getUrl(record, item).toString());
+        }
+      }
+    }
+
+    return Post(
+      id: data['id'] as String? ?? '',
+      authorId: data['author'] as String? ?? authorInfo?.id ?? '',
+      authorName: authorInfo?.username ?? 'Ẩn danh',
+      authorAvatarUrl: authorInfo?.avatarUrl,
+      content: (data['content'] as String?)?.trim(),
+      imageUrls: imageUrls,
+      isActive: _parseBool(data['is_active']),
+      createdAt: _parseDate(data['created']) ?? DateTime.now(),
+      updatedAt: _parseDate(data['updated']) ?? DateTime.now(),
+    );
+  }
+
+  static _AuthorInfo? _extractAuthor(PocketBase client, RecordModel record) {
+    final expand = record.expand;
+    if (expand == null || expand.isEmpty) {
+      return null;
+    }
+
+    final expandedAuthor = expand['author'];
+
+    if (expandedAuthor is RecordModel) {
+      return _AuthorInfo.fromRecord(client, expandedAuthor);
+    }
+
+    if (expandedAuthor is List) {
+      for (final item in expandedAuthor) {
+        if (item is RecordModel) {
+          return _AuthorInfo.fromRecord(client, item);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  static bool _parseBool(dynamic value) {
+    if (value is bool) return value;
+    if (value is num) return value != 0;
+    if (value is String) {
+      final lower = value.toLowerCase();
+      if (lower == 'true') return true;
+      if (lower == 'false') return false;
+      final number = num.tryParse(value);
+      if (number != null) return number != 0;
+    }
+    return false;
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value is DateTime) return value;
+    if (value is String && value.isNotEmpty) {
+      return DateTime.tryParse(value);
+    }
+    return null;
+  }
+}
+
+class _AuthorInfo {
+  final String id;
+  final String username;
+  final String? avatarUrl;
+
+  _AuthorInfo({
+    required this.id,
+    required this.username,
+    this.avatarUrl,
+  });
+
+  factory _AuthorInfo.fromRecord(PocketBase client, RecordModel record) {
+    final data = record.toJson();
+    final avatarField = data['avatar'];
+    String? avatarUrl;
+
+    if (avatarField is String && avatarField.isNotEmpty) {
+      avatarUrl = client.files.getUrl(record, avatarField).toString();
+    }
+
+    return _AuthorInfo(
+      id: data['id'] as String? ?? '',
+      username: data['username'] as String? ?? 'Người dùng',
+      avatarUrl: avatarUrl,
+    );
+  }
+}

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -58,16 +58,23 @@ class Post {
       return null;
     }
 
-    final expandedAuthor = expand['author'];
-
-    if (expandedAuthor is RecordModel) {
-      return _AuthorInfo.fromRecord(client, expandedAuthor);
+    final authorRecord = _firstRecord(expand['author']);
+    if (authorRecord == null) {
+      return null;
     }
 
-    if (expandedAuthor is List) {
-      for (final item in expandedAuthor) {
+    return _AuthorInfo.fromRecord(client, authorRecord);
+  }
+
+  static RecordModel? _firstRecord(dynamic value) {
+    if (value is RecordModel) {
+      return value;
+    }
+
+    if (value is List) {
+      for (final dynamic item in value) {
         if (item is RecordModel) {
-          return _AuthorInfo.fromRecord(client, item);
+          return item;
         }
       }
     }

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -86,42 +86,26 @@ class RecruitmentPost {
 
   static _AuthorInfo? _extractAuthor(RecordModel record) {
     final expand = record.expand;
-    if (expand == null) return null;
-    final expandedAuthor = expand['author'];
+    if (expand == null || expand.isEmpty) return null;
 
-    if (expandedAuthor is RecordModel) {
-      return _AuthorInfo.fromRecord(expandedAuthor);
+    final authorRecord = _firstRecord(expand['author']);
+    if (authorRecord == null) {
+      return null;
     }
 
-    if (expandedAuthor is List) {
-      for (final item in expandedAuthor) {
-        if (item is RecordModel) {
-          return _AuthorInfo.fromRecord(item);
-        }
-      }
-    }
-
-    return null;
+    return _AuthorInfo.fromRecord(authorRecord);
   }
 
   static _CourtInfo? _extractCourt(RecordModel record) {
     final expand = record.expand;
-    if (expand == null) return null;
-    final expandedCourt = expand['court'];
+    if (expand == null || expand.isEmpty) return null;
 
-    if (expandedCourt is RecordModel) {
-      return _CourtInfo.fromRecord(expandedCourt);
+    final courtRecord = _firstRecord(expand['court']);
+    if (courtRecord == null) {
+      return null;
     }
 
-    if (expandedCourt is List) {
-      for (final item in expandedCourt) {
-        if (item is RecordModel) {
-          return _CourtInfo.fromRecord(item);
-        }
-      }
-    }
-
-    return null;
+    return _CourtInfo.fromRecord(courtRecord);
   }
 
   static int _parseInt(dynamic value) {
@@ -153,6 +137,22 @@ class RecruitmentPost {
     }
     return null;
   }
+}
+
+RecordModel? _firstRecord(dynamic value) {
+  if (value is RecordModel) {
+    return value;
+  }
+
+  if (value is List) {
+    for (final dynamic item in value) {
+      if (item is RecordModel) {
+        return item;
+      }
+    }
+  }
+
+  return null;
 }
 
 class _AuthorInfo {

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -1,0 +1,192 @@
+import 'package:pocketbase/pocketbase.dart';
+
+class RecruitmentPost {
+  final String id;
+  final String authorId;
+  final String authorName;
+  final String? courtId;
+  final String? courtName;
+  final String? content;
+  final DateTime createdAt;
+  final DateTime? eventTime;
+  final DateTime? expiresAt;
+  final int requiredMembers;
+  final int joinedMembers;
+  final String? skillLevel;
+  final String? playStyle;
+  final String? locationNote;
+  final bool isActive;
+
+  const RecruitmentPost({
+    required this.id,
+    required this.authorId,
+    required this.authorName,
+    required this.courtId,
+    required this.courtName,
+    required this.content,
+    required this.createdAt,
+    required this.eventTime,
+    required this.expiresAt,
+    required this.requiredMembers,
+    required this.joinedMembers,
+    required this.skillLevel,
+    required this.playStyle,
+    required this.locationNote,
+    required this.isActive,
+  });
+
+  RecruitmentPost copyWith({
+    int? joinedMembers,
+  }) {
+    return RecruitmentPost(
+      id: id,
+      authorId: authorId,
+      authorName: authorName,
+      courtId: courtId,
+      courtName: courtName,
+      content: content,
+      createdAt: createdAt,
+      eventTime: eventTime,
+      expiresAt: expiresAt,
+      requiredMembers: requiredMembers,
+      joinedMembers: joinedMembers ?? this.joinedMembers,
+      skillLevel: skillLevel,
+      playStyle: playStyle,
+      locationNote: locationNote,
+      isActive: isActive,
+    );
+  }
+
+  factory RecruitmentPost.fromRecord(
+    RecordModel record, {
+    int joinedCount = 0,
+  }) {
+    final data = record.toJson();
+    final authorInfo = _extractAuthor(record);
+    final courtInfo = _extractCourt(record);
+
+    return RecruitmentPost(
+      id: data['id'] as String? ?? '',
+      authorId: data['author'] as String? ?? authorInfo?.id ?? '',
+      authorName: authorInfo?.username ?? 'Ẩn danh',
+      courtId: data['court'] as String? ?? courtInfo?.id,
+      courtName: courtInfo?.name,
+      content: (data['content'] as String?)?.trim(),
+      createdAt: _parseDate(data['created']) ?? DateTime.now(),
+      eventTime: _parseDate(data['event_time']),
+      expiresAt: _parseDate(data['expires_at']),
+      requiredMembers: _parseInt(data['need_members']),
+      joinedMembers: joinedCount,
+      skillLevel: (data['skill_level'] as String?)?.trim(),
+      playStyle: (data['play_style'] as String?)?.trim(),
+      locationNote: (data['location_note'] as String?)?.trim(),
+      isActive: _parseBool(data['is_active']),
+    );
+  }
+
+  static _AuthorInfo? _extractAuthor(RecordModel record) {
+    final expand = record.expand;
+    if (expand == null) return null;
+    final expandedAuthor = expand['author'];
+
+    if (expandedAuthor is RecordModel) {
+      return _AuthorInfo.fromRecord(expandedAuthor);
+    }
+
+    if (expandedAuthor is List) {
+      for (final item in expandedAuthor) {
+        if (item is RecordModel) {
+          return _AuthorInfo.fromRecord(item);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  static _CourtInfo? _extractCourt(RecordModel record) {
+    final expand = record.expand;
+    if (expand == null) return null;
+    final expandedCourt = expand['court'];
+
+    if (expandedCourt is RecordModel) {
+      return _CourtInfo.fromRecord(expandedCourt);
+    }
+
+    if (expandedCourt is List) {
+      for (final item in expandedCourt) {
+        if (item is RecordModel) {
+          return _CourtInfo.fromRecord(item);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  static int _parseInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) {
+      return int.tryParse(value) ?? 0;
+    }
+    return 0;
+  }
+
+  static bool _parseBool(dynamic value) {
+    if (value is bool) return value;
+    if (value is num) return value != 0;
+    if (value is String) {
+      final lower = value.toLowerCase();
+      if (lower == 'true') return true;
+      if (lower == 'false') return false;
+      final parsed = num.tryParse(value);
+      if (parsed != null) return parsed != 0;
+    }
+    return false;
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value is DateTime) return value;
+    if (value is String && value.isNotEmpty) {
+      return DateTime.tryParse(value);
+    }
+    return null;
+  }
+}
+
+class _AuthorInfo {
+  final String id;
+  final String username;
+
+  _AuthorInfo({
+    required this.id,
+    required this.username,
+  });
+
+  factory _AuthorInfo.fromRecord(RecordModel record) {
+    final data = record.toJson();
+    return _AuthorInfo(
+      id: data['id'] as String? ?? '',
+      username: data['username'] as String? ?? 'Người chơi',
+    );
+  }
+}
+
+class _CourtInfo {
+  final String id;
+  final String name;
+
+  _CourtInfo({
+    required this.id,
+    required this.name,
+  });
+
+  factory _CourtInfo.fromRecord(RecordModel record) {
+    final data = record.toJson();
+    return _CourtInfo(
+      id: data['id'] as String? ?? '',
+      name: data['name'] as String? ?? 'Sân cầu lông',
+    );
+  }
+}

--- a/lib/pages/social/create_post_page.dart
+++ b/lib/pages/social/create_post_page.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/file_manager.dart';
+import 'social_manager.dart';
+
+class CreatePostPage extends StatefulWidget {
+  const CreatePostPage({super.key});
+
+  @override
+  State<CreatePostPage> createState() => _CreatePostPageState();
+}
+
+class _CreatePostPageState extends State<CreatePostPage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _contentController = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_isSubmitting) return;
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    final fileManager = context.read<FileManager>();
+    final socialManager = context.read<SocialFeedManager>();
+    final content = _contentController.text.trim();
+    final imageFiles = fileManager.toFiles();
+
+    setState(() => _isSubmitting = true);
+
+    try {
+      await socialManager.createPost(
+        content: content,
+        imageFiles: imageFiles,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Đăng bài thành công.')),
+        );
+        fileManager.clear();
+        Navigator.of(context).pop(true);
+      }
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tạo bài viết mới')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextFormField(
+                  controller: _contentController,
+                  maxLines: 6,
+                  decoration: const InputDecoration(
+                    labelText: 'Nội dung bài viết',
+                    hintText: 'Chia sẻ hoạt động hoặc tin tức của bạn...',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    final text = value?.trim() ?? '';
+                    final hasImages =
+                        context.read<FileManager>().pickedImages.isNotEmpty;
+                    if (text.isEmpty && !hasImages) {
+                      return 'Vui lòng nhập nội dung hoặc chọn ít nhất một ảnh.';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                _ImagePickerSection(colorScheme: colorScheme),
+                const Spacer(),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _isSubmitting ? null : _submit,
+                    icon: _isSubmitting
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.send),
+                    label: Text(
+                      _isSubmitting ? 'Đang đăng...' : 'Đăng bài',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ImagePickerSection extends StatelessWidget {
+  const _ImagePickerSection({required this.colorScheme});
+
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<FileManager>(
+      builder: (context, manager, _) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                FilledButton.icon(
+                  onPressed: manager.pickImages,
+                  icon: const Icon(Icons.photo_library_outlined),
+                  label: const Text('Chọn ảnh'),
+                ),
+                const SizedBox(width: 12),
+                OutlinedButton.icon(
+                  onPressed: manager.pickFromCamera,
+                  icon: const Icon(Icons.photo_camera_outlined),
+                  label: const Text('Chụp ảnh'),
+                ),
+              ],
+            ),
+            if (manager.pickedImages.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              SizedBox(
+                height: 110,
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  itemBuilder: (context, index) {
+                    final file = manager.pickedImages[index];
+                    return Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(16),
+                          child: Image.file(
+                            File(file.path),
+                            width: 110,
+                            height: 110,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                        Positioned(
+                          top: -8,
+                          right: -8,
+                          child: IconButton(
+                            onPressed: () => manager.removeAt(index),
+                            style: IconButton.styleFrom(
+                              backgroundColor:
+                                  colorScheme.surface.withOpacity(0.9),
+                            ),
+                            icon: const Icon(Icons.close),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                  separatorBuilder: (_, __) => const SizedBox(width: 12),
+                  itemCount: manager.pickedImages.length,
+                ),
+              ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/social/recruitment/recruitment_page.dart
+++ b/lib/pages/social/recruitment/recruitment_page.dart
@@ -1,13 +1,15 @@
-import 'package:badminton_booking_app/pages/social/recruitment/widgets/court_info_section.dart';
-import 'package:badminton_booking_app/pages/social/recruitment/widgets/intro_card.dart';
-import 'package:badminton_booking_app/pages/social/recruitment/widgets/member_input_section.dart';
-import 'package:badminton_booking_app/pages/social/recruitment/widgets/no_court_info_box.dart';
-import 'package:badminton_booking_app/pages/social/recruitment/widgets/note_field.dart';
-import 'package:badminton_booking_app/pages/social/recruitment/widgets/play_style_selector.dart';
-import 'package:badminton_booking_app/pages/social/recruitment/widgets/skill_level_selector.dart';
-import 'package:badminton_booking_app/pages/social/recruitment/widgets/submit_button.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../../services/court_service.dart';
+import '../../social/social_manager.dart';
+import '../recruitment/widgets/court_info_section.dart';
+import '../recruitment/widgets/intro_card.dart';
+import '../recruitment/widgets/member_input_section.dart';
+import '../recruitment/widgets/no_court_info_box.dart';
+import '../recruitment/widgets/note_field.dart';
+import '../recruitment/widgets/play_style_selector.dart';
+import '../recruitment/widgets/skill_level_selector.dart';
+import '../recruitment/widgets/submit_button.dart';
 
 class RecruitmentFormPage extends StatefulWidget {
   const RecruitmentFormPage({super.key});
@@ -17,52 +19,89 @@ class RecruitmentFormPage extends StatefulWidget {
 }
 
 class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
-  // Controllers
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _noteController = TextEditingController();
+  final TextEditingController _locationNoteController = TextEditingController();
   late final TextEditingController _memberCountController;
 
-  // State chính
+  final CourtService _courtService = CourtService();
+
   bool _hasBookedCourt = true;
+  bool _isSubmitting = false;
+  bool _isLoadingCourts = true;
   int _memberCount = 3;
-  String _skillLevel = 'Trung bình khá';
-  String _playStyle = 'Đánh đôi';
-  String? _selectedCourt;
+  String _selectedSkillLevel = 'Intermediate';
+  String _selectedPlayStyle = 'doubles';
+  String? _selectedCourtId;
   DateTime _selectedDateTime = DateTime.now().add(const Duration(hours: 2));
+  String? _courtErrorMessage;
 
-  // Dữ liệu mẫu
-  final List<String> _availableCourts = const [
-    'Sân Quận 7 - Court A',
-    'Sân Quận 1 - Court B',
-    'Sân Phú Nhuận - Court C',
+  List<CourtOption> _availableCourts = const [];
+
+  final List<PlayStyleOption> _playStyles = const [
+    PlayStyleOption(value: 'singles', label: 'Đánh đơn'),
+    PlayStyleOption(value: 'doubles', label: 'Đánh đôi'),
+    PlayStyleOption(value: 'mixed', label: 'Đánh đôi nam nữ'),
   ];
 
-  final List<String> _playStyles = const [
-    'Đánh đơn',
-    'Đánh đôi',
-    'Linh hoạt',
-  ];
-
-  final List<String> _skillLevels = const [
-    'Mới chơi',
-    'Trung bình',
-    'Trung bình khá',
-    'Nâng cao',
-    'Chuyên nghiệp',
+  final List<SkillLevelOption> _skillLevels = const [
+    SkillLevelOption(value: 'Beginner', label: 'Mới chơi'),
+    SkillLevelOption(value: 'Lower Intermediate', label: 'Trung bình yếu'),
+    SkillLevelOption(value: 'Intermediate', label: 'Trung bình'),
+    SkillLevelOption(value: 'Upper Intermediate', label: 'Trung bình khá'),
+    SkillLevelOption(value: 'Advanced', label: 'Nâng cao'),
   ];
 
   @override
   void initState() {
     super.initState();
-    _selectedCourt = _availableCourts.first;
     _memberCountController =
         TextEditingController(text: _memberCount.toString());
+    _loadCourts();
   }
 
   @override
   void dispose() {
     _noteController.dispose();
+    _locationNoteController.dispose();
     _memberCountController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadCourts() async {
+    setState(() {
+      _isLoadingCourts = true;
+      _courtErrorMessage = null;
+    });
+
+    try {
+      final courts = await _courtService.listCourts(
+        perPage: 200,
+        filter: "is_active = true",
+      );
+
+      setState(() {
+        _availableCourts = courts
+            .map(
+              (court) => CourtOption(
+                id: court.id,
+                name: '${court.name} - ${court.location}',
+              ),
+            )
+            .toList(growable: false);
+        if (_availableCourts.isNotEmpty) {
+          _selectedCourtId = _availableCourts.first.id;
+        }
+      });
+    } on CourtServiceException catch (error) {
+      setState(() => _courtErrorMessage = error.message);
+    } catch (error) {
+      setState(() => _courtErrorMessage = error.toString());
+    } finally {
+      if (mounted) {
+        setState(() => _isLoadingCourts = false);
+      }
+    }
   }
 
   Future<void> _pickDateTime() async {
@@ -91,6 +130,55 @@ class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
     });
   }
 
+  Future<void> _handleSubmit() async {
+    if (_isSubmitting) return;
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    if (_hasBookedCourt && (_selectedCourtId == null || _selectedCourtId!.isEmpty)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Vui lòng chọn sân bạn đã đặt.')),
+      );
+      return;
+    }
+
+    final socialManager = context.read<SocialFeedManager>();
+    final content = _noteController.text.trim();
+    final locationNote =
+        _hasBookedCourt ? null : _locationNoteController.text.trim();
+
+    setState(() => _isSubmitting = true);
+
+    try {
+      await socialManager.createRecruitmentPost(
+        content: content,
+        requiredMembers: _memberCount,
+        courtId: _hasBookedCourt ? _selectedCourtId : null,
+        eventTime: _hasBookedCourt ? _selectedDateTime : null,
+        skillLevel: _selectedSkillLevel,
+        playStyle: _selectedPlayStyle,
+        locationNote: locationNote,
+      );
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Đăng bài tuyển thành viên thành công.')),
+      );
+      Navigator.of(context).pop(true);
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -99,83 +187,124 @@ class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
     return Scaffold(
       appBar: AppBar(title: const Text('Tạo bài tuyển thành viên')),
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              IntroCard(cs: cs, textTheme: textTheme),
-              const SizedBox(height: 24),
-
-              // 🔘 Toggle
-              SwitchListTile.adaptive(
-                contentPadding: EdgeInsets.zero,
-                title: const Text('Tôi đã đặt sân trước'),
-                value: _hasBookedCourt,
-                onChanged: (value) => setState(() => _hasBookedCourt = value),
-              ),
-              const SizedBox(height: 16),
-
-              // 🏸 Nếu đã đặt sân / chưa đặt sân
-              AnimatedSwitcher(
-                duration: const Duration(milliseconds: 300),
-                child: _hasBookedCourt
-                    ? CourtInfoSection(
-                        selectedCourt: _selectedCourt!,
-                        availableCourts: _availableCourts,
-                        selectedDateTime: _selectedDateTime,
-                        onCourtChanged: (v) =>
-                            setState(() => _selectedCourt = v),
-                        onPickDateTime: _pickDateTime,
-                      )
-                    : NoCourtInfoBox(),
-              ),
-
-              const SizedBox(height: 24),
-
-              // 👥 Nhập số lượng
-              MemberInputSection(
-                memberCount: _memberCount,
-                controller: _memberCountController,
-                onChanged: (val) => setState(() => _memberCount = val),
-              ),
-              const SizedBox(height: 24),
-
-              // 🏸 Lối chơi
-              PlayStyleSelector(
-                playStyles: _playStyles,
-                selectedStyle: _playStyle,
-                onChanged: (v) => setState(() => _playStyle = v),
-              ),
-              const SizedBox(height: 24),
-
-              // 💪 Trình độ
-              SkillLevelSelector(
-                skillLevels: _skillLevels,
-                selectedLevel: _skillLevel,
-                onChanged: (v) => setState(() => _skillLevel = v),
-              ),
-              const SizedBox(height: 24),
-
-              // 📝 Ghi chú
-              NoteField(controller: _noteController),
-              const SizedBox(height: 32),
-
-              // 🚀 Nút đăng
-              SubmitButton(onSubmit: () {
-                print('--- THÔNG TIN BÀI TUYỂN ---');
-                print('Đã đặt sân: $_hasBookedCourt');
-                print('Sân: $_selectedCourt');
-                print('Giờ đánh: $_selectedDateTime');
-                print('Số lượng: $_memberCount');
-                print('Lối chơi: $_playStyle');
-                print('Trình độ: $_skillLevel');
-                print('Ghi chú: ${_noteController.text}');
-              }),
-            ],
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                IntroCard(cs: cs, textTheme: textTheme),
+                const SizedBox(height: 24),
+                SwitchListTile.adaptive(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Tôi đã đặt sân trước'),
+                  value: _hasBookedCourt,
+                  onChanged: (value) {
+                    setState(() {
+                      _hasBookedCourt = value;
+                      if (!value) {
+                        _selectedCourtId = null;
+                      } else if (_availableCourts.isNotEmpty) {
+                        _selectedCourtId ??= _availableCourts.first.id;
+                      }
+                    });
+                  },
+                ),
+                const SizedBox(height: 16),
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 300),
+                  child: _hasBookedCourt
+                      ? _buildCourtSection(cs)
+                      : _buildNoCourtSection(textTheme),
+                ),
+                const SizedBox(height: 24),
+                MemberInputSection(
+                  memberCount: _memberCount,
+                  controller: _memberCountController,
+                  onChanged: (val) => setState(() => _memberCount = val),
+                ),
+                const SizedBox(height: 24),
+                PlayStyleSelector(
+                  playStyles: _playStyles,
+                  selectedValue: _selectedPlayStyle,
+                  onChanged: (value) => setState(() => _selectedPlayStyle = value),
+                ),
+                const SizedBox(height: 24),
+                SkillLevelSelector(
+                  skillLevels: _skillLevels,
+                  selectedValue: _selectedSkillLevel,
+                  onChanged: (value) => setState(() => _selectedSkillLevel = value),
+                ),
+                const SizedBox(height: 24),
+                NoteField(controller: _noteController),
+                if (!_hasBookedCourt) ...[
+                  const SizedBox(height: 24),
+                  TextFormField(
+                    controller: _locationNoteController,
+                    decoration: const InputDecoration(
+                      labelText: 'Gợi ý khu vực hoặc địa điểm mong muốn',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 32),
+                SubmitButton(
+                  onSubmit: _handleSubmit,
+                  isLoading: _isSubmitting,
+                ),
+              ],
+            ),
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildCourtSection(ColorScheme cs) {
+    if (_isLoadingCourts) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 24),
+          child: CircularProgressIndicator(color: cs.primary),
+        ),
+      );
+    }
+
+    if (_availableCourts.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: cs.surfaceVariant.withOpacity(0.6),
+          borderRadius: BorderRadius.circular(18),
+        ),
+        child: Text(
+          _courtErrorMessage ?? 'Bạn chưa có sân nào để chọn. Vui lòng tạo sân trước.',
+          style: TextStyle(color: cs.onSurfaceVariant),
+        ),
+      );
+    }
+
+    return CourtInfoSection(
+      selectedCourtId: _selectedCourtId,
+      availableCourts: _availableCourts,
+      selectedDateTime: _selectedDateTime,
+      onCourtChanged: (value) => setState(() => _selectedCourtId = value),
+      onPickDateTime: _pickDateTime,
+    );
+  }
+
+  Widget _buildNoCourtSection(TextTheme textTheme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const NoCourtInfoBox(),
+        const SizedBox(height: 12),
+        Text(
+          'Bạn có thể mô tả khu vực mong muốn ở phần bên dưới.',
+          style: textTheme.bodySmall,
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/social/recruitment/widgets/court_info_section.dart
+++ b/lib/pages/social/recruitment/widgets/court_info_section.dart
@@ -1,16 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+class CourtOption {
+  final String id;
+  final String name;
+
+  const CourtOption({
+    required this.id,
+    required this.name,
+  });
+}
+
 class CourtInfoSection extends StatelessWidget {
-  final String selectedCourt;
-  final List<String> availableCourts;
+  final String? selectedCourtId;
+  final List<CourtOption> availableCourts;
   final DateTime selectedDateTime;
-  final ValueChanged<String> onCourtChanged;
+  final ValueChanged<String?> onCourtChanged;
   final VoidCallback onPickDateTime;
 
   const CourtInfoSection({
     super.key,
-    required this.selectedCourt,
+    required this.selectedCourtId,
     required this.availableCourts,
     required this.selectedDateTime,
     required this.onCourtChanged,
@@ -28,13 +38,17 @@ class CourtInfoSection extends StatelessWidget {
         Text('Thông tin sân đã đặt', style: textTheme.titleMedium),
         const SizedBox(height: 12),
         DropdownButtonFormField<String>(
-          value: selectedCourt,
+          value: selectedCourtId,
           decoration: _inputDecoration(cs, 'Chọn sân đã đặt'),
           items: availableCourts
               .map(
-                  (court) => DropdownMenuItem(value: court, child: Text(court)))
+                (court) => DropdownMenuItem(
+                  value: court.id,
+                  child: Text(court.name),
+                ),
+              )
               .toList(),
-          onChanged: (v) => v != null ? onCourtChanged(v) : null,
+          onChanged: onCourtChanged,
         ),
         const SizedBox(height: 16),
         GestureDetector(

--- a/lib/pages/social/recruitment/widgets/play_style_selector.dart
+++ b/lib/pages/social/recruitment/widgets/play_style_selector.dart
@@ -1,14 +1,24 @@
 import 'package:flutter/material.dart';
 
+class PlayStyleOption {
+  final String value;
+  final String label;
+
+  const PlayStyleOption({
+    required this.value,
+    required this.label,
+  });
+}
+
 class PlayStyleSelector extends StatelessWidget {
-  final List<String> playStyles;
-  final String selectedStyle;
+  final List<PlayStyleOption> playStyles;
+  final String selectedValue;
   final ValueChanged<String> onChanged;
 
   const PlayStyleSelector({
     super.key,
     required this.playStyles,
-    required this.selectedStyle,
+    required this.selectedValue,
     required this.onChanged,
   });
 
@@ -26,11 +36,11 @@ class PlayStyleSelector extends StatelessWidget {
           spacing: 12,
           runSpacing: 12,
           children: playStyles.map((style) {
-            final isSelected = selectedStyle == style;
+            final isSelected = selectedValue == style.value;
             return ChoiceChip(
-              label: Text(style),
+              label: Text(style.label),
               selected: isSelected,
-              onSelected: (_) => onChanged(style),
+              onSelected: (_) => onChanged(style.value),
               selectedColor: cs.primaryContainer,
               labelStyle: textTheme.bodyMedium?.copyWith(
                 color: isSelected ? cs.primary : cs.onSurface,

--- a/lib/pages/social/recruitment/widgets/skill_level_selector.dart
+++ b/lib/pages/social/recruitment/widgets/skill_level_selector.dart
@@ -1,14 +1,24 @@
 import 'package:flutter/material.dart';
 
+class SkillLevelOption {
+  final String value;
+  final String label;
+
+  const SkillLevelOption({
+    required this.value,
+    required this.label,
+  });
+}
+
 class SkillLevelSelector extends StatelessWidget {
-  final List<String> skillLevels;
-  final String selectedLevel;
+  final List<SkillLevelOption> skillLevels;
+  final String selectedValue;
   final ValueChanged<String> onChanged;
 
   const SkillLevelSelector({
     super.key,
     required this.skillLevels,
-    required this.selectedLevel,
+    required this.selectedValue,
     required this.onChanged,
   });
 
@@ -26,11 +36,11 @@ class SkillLevelSelector extends StatelessWidget {
           spacing: 12,
           runSpacing: 12,
           children: skillLevels.map((level) {
-            final isSelected = selectedLevel == level;
+            final isSelected = selectedValue == level.value;
             return ChoiceChip(
-              label: Text(level),
+              label: Text(level.label),
               selected: isSelected,
-              onSelected: (_) => onChanged(level),
+              onSelected: (_) => onChanged(level.value),
               selectedColor: cs.primaryContainer,
               labelStyle: textTheme.bodyMedium?.copyWith(
                 color: isSelected ? cs.primary : cs.onSurface,

--- a/lib/pages/social/recruitment/widgets/submit_button.dart
+++ b/lib/pages/social/recruitment/widgets/submit_button.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 class SubmitButton extends StatelessWidget {
   final VoidCallback onSubmit;
+  final bool isLoading;
 
   const SubmitButton({
     super.key,
     required this.onSubmit,
+    this.isLoading = false,
   });
 
   @override
@@ -13,9 +15,15 @@ class SubmitButton extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
 
     return FilledButton.icon(
-      onPressed: onSubmit,
-      icon: const Icon(Icons.send_rounded),
-      label: const Text('Đăng bài tuyển thành viên'),
+      onPressed: isLoading ? null : onSubmit,
+      icon: isLoading
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : const Icon(Icons.send_rounded),
+      label: Text(isLoading ? 'Đang đăng...' : 'Đăng bài tuyển thành viên'),
       style: FilledButton.styleFrom(
         minimumSize: const Size.fromHeight(54),
         textStyle: textTheme.titleMedium?.copyWith(

--- a/lib/pages/social/social_manager.dart
+++ b/lib/pages/social/social_manager.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import '../../models/post.dart';
+import '../../models/recruitment_post.dart';
+import '../../services/post_service.dart';
+import '../../services/recruitment_service.dart';
+
+class SocialFeedManager with ChangeNotifier {
+  SocialFeedManager({
+    PostService? postService,
+    RecruitmentService? recruitmentService,
+  })  : _postService = postService ?? PostService(),
+        _recruitmentService = recruitmentService ?? RecruitmentService();
+
+  final PostService _postService;
+  final RecruitmentService _recruitmentService;
+
+  final List<Post> _posts = [];
+  final List<RecruitmentPost> _recruitmentPosts = [];
+
+  bool _isLoadingPosts = false;
+  bool _isLoadingRecruitments = false;
+
+  List<Post> get posts => List.unmodifiable(_posts);
+
+  List<RecruitmentPost> get recruitmentPosts =>
+      List.unmodifiable(_recruitmentPosts);
+
+  bool get isLoadingPosts => _isLoadingPosts;
+
+  bool get isLoadingRecruitments => _isLoadingRecruitments;
+
+  Future<void> loadPosts() async {
+    if (_isLoadingPosts) return;
+    _isLoadingPosts = true;
+    notifyListeners();
+
+    try {
+      final items = await _postService.fetchPosts();
+      _posts
+        ..clear()
+        ..addAll(items);
+    } finally {
+      _isLoadingPosts = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadRecruitmentPosts() async {
+    if (_isLoadingRecruitments) return;
+    _isLoadingRecruitments = true;
+    notifyListeners();
+
+    try {
+      final items = await _recruitmentService.fetchRecruitmentPosts();
+      _recruitmentPosts
+        ..clear()
+        ..addAll(items);
+    } finally {
+      _isLoadingRecruitments = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshAll() async {
+    await Future.wait([
+      loadPosts(),
+      loadRecruitmentPosts(),
+    ]);
+  }
+
+  Future<Post> createPost({
+    required String content,
+    List<File> imageFiles = const <File>[],
+  }) async {
+    final post = await _postService.createPost(
+      content: content,
+      imageFiles: imageFiles,
+    );
+    _posts.insert(0, post);
+    notifyListeners();
+    return post;
+  }
+
+  Future<RecruitmentPost> createRecruitmentPost({
+    required String content,
+    required int requiredMembers,
+    String? courtId,
+    DateTime? eventTime,
+    String? skillLevel,
+    String? playStyle,
+    String? locationNote,
+  }) async {
+    final post = await _recruitmentService.createRecruitmentPost(
+      content: content,
+      requiredMembers: requiredMembers,
+      courtId: courtId,
+      eventTime: eventTime,
+      skillLevel: skillLevel,
+      playStyle: playStyle,
+      locationNote: locationNote,
+    );
+    _recruitmentPosts.insert(0, post);
+    notifyListeners();
+    return post;
+  }
+}

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1,54 +1,49 @@
-import 'package:badminton_booking_app/components/my_post.dart';
-import 'package:badminton_booking_app/components/recruitment_post_card.dart';
-import 'package:badminton_booking_app/pages/social/chat/chat_home_page.dart';
-import 'package:badminton_booking_app/pages/social/recruitment/recruitment_page.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-class SocialPage extends StatelessWidget {
-  SocialPage({super.key});
+import '../../components/my_post.dart';
+import '../../components/recruitment_post_card.dart';
+import '../../providers/file_manager.dart';
+import 'chat/chat_home_page.dart';
+import 'create_post_page.dart';
+import 'recruitment/recruitment_page.dart';
+import 'social_manager.dart';
 
-  final DateTime _now = DateTime.now();
+class SocialPage extends StatefulWidget {
+  const SocialPage({super.key});
 
-  final List<_RecruitmentPost> _recruitmentPosts = [
-    _RecruitmentPost(
-      hostName: 'Bảo Minh',
-      createdAt: DateTime.now().subtract(const Duration(minutes: 15)),
-      description:
-          'Cần 2 bạn trình trung bình khá đánh đôi giao lưu. Team rất vui tính.',
-      requiredPlayers: 4,
-      joinedPlayers: 2,
-      skillLevel: 'Trung bình khá',
-      courtName: 'Sân Quận 7 - Court A',
-      playTime: DateTime.now().add(const Duration(hours: 2)),
-    ),
-    _RecruitmentPost(
-      hostName: 'Ngọc Anh',
-      createdAt: DateTime.now().subtract(const Duration(hours: 1, minutes: 10)),
-      description:
-          'Tuyển gấp 1 nữ trình trung bình để đánh đôi cố định sáng chủ nhật hàng tuần.',
-      requiredPlayers: 4,
-      joinedPlayers: 3,
-      skillLevel: 'Trung bình',
-      courtName: 'Sân Phú Nhuận - Court C',
-      playTime: DateTime.now().add(const Duration(days: 1, hours: 10)),
-    ),
-    _RecruitmentPost(
-      hostName: 'Văn Hòa',
-      createdAt: DateTime.now().subtract(const Duration(hours: 3)),
-      description:
-          'Nhóm mình chưa có sân, cần tuyển 3 bạn trình nâng cao lập team đi đánh giải.',
-      requiredPlayers: 5,
-      joinedPlayers: 1,
-      skillLevel: 'Nâng cao',
-    ),
-  ];
+  @override
+  State<SocialPage> createState() => _SocialPageState();
+}
+
+class _SocialPageState extends State<SocialPage> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      final manager = context.read<SocialFeedManager>();
+      manager.refreshAll();
+    });
+  }
+
+  Future<void> _refreshFeed() {
+    return context.read<SocialFeedManager>().refreshAll();
+  }
+
+  Future<void> _openCreatePost() async {
+    final fileManager = context.read<FileManager>();
+    fileManager.clear();
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const CreatePostPage()),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      backgroundColor: cs.surfaceVariant.withOpacity(0.3),
+      backgroundColor: colorScheme.surfaceVariant.withOpacity(0.3),
       appBar: AppBar(
         title: const Text(
           'Cộng đồng cầu lông',
@@ -64,83 +59,146 @@ class SocialPage extends StatelessWidget {
               );
             },
           ),
+          IconButton(
+            icon: const Icon(Icons.post_add, size: 30),
+            tooltip: 'Tạo bài viết',
+            onPressed: _openCreatePost,
+          ),
           const SizedBox(width: 6),
         ],
       ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _openCreatePost,
+        icon: const Icon(Icons.post_add),
+        label: const Text('Đăng bài'),
+      ),
       body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-                child: _buildWelcomeCard(context),
+        child: Consumer<SocialFeedManager>(
+          builder: (context, manager, _) {
+            final recruitmentPosts = manager.recruitmentPosts;
+            final posts = manager.posts;
+            final isLoading =
+                (manager.isLoadingPosts && manager.posts.isEmpty) ||
+                    (manager.isLoadingRecruitments &&
+                        manager.recruitmentPosts.isEmpty);
+
+            return RefreshIndicator(
+              onRefresh: _refreshFeed,
+              child: CustomScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                slivers: [
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+                      child: _buildWelcomeCard(context),
+                    ),
+                  ),
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+                      child: Text(
+                        'Bài tuyển thành viên',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleLarge
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                  if (isLoading && recruitmentPosts.isEmpty)
+                    const SliverToBoxAdapter(
+                      child: Center(
+                        child: Padding(
+                          padding: EdgeInsets.symmetric(vertical: 24),
+                          child: CircularProgressIndicator(),
+                        ),
+                      ),
+                    )
+                  else if (recruitmentPosts.isEmpty)
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 20, vertical: 16),
+                        child: Text(
+                          'Chưa có bài tuyển nào. Hãy là người đầu tiên đăng bài!',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    )
+                  else
+                    SliverList(
+                      delegate: SliverChildBuilderDelegate(
+                        (context, index) {
+                          final post = recruitmentPosts[index];
+                          return RecruitmentPostCard(
+                            hostName: post.authorName,
+                            createdTime: post.createdAt,
+                            requiredPlayers: post.requiredMembers,
+                            joinedPlayers: post.joinedMembers,
+                            description: post.content,
+                            skillLevel: post.skillLevel,
+                            courtName: post.courtName,
+                            playTime: post.eventTime,
+                            playStyle: _mapPlayStyle(post.playStyle),
+                            locationNote: post.locationNote,
+                            onJoin: () {},
+                          );
+                        },
+                        childCount: recruitmentPosts.length,
+                      ),
+                    ),
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 24, 20, 4),
+                      child: Text(
+                        'Bảng tin cộng đồng',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleLarge
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                  if (isLoading && posts.isEmpty)
+                    const SliverToBoxAdapter(
+                      child: Center(
+                        child: Padding(
+                          padding: EdgeInsets.symmetric(vertical: 24),
+                          child: CircularProgressIndicator(),
+                        ),
+                      ),
+                    )
+                  else if (posts.isEmpty)
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 20, vertical: 16),
+                        child: Text(
+                          'Chưa có bài đăng nào. Hãy chia sẻ khoảnh khắc của bạn!',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    )
+                  else
+                    SliverList(
+                      delegate: SliverChildBuilderDelegate(
+                        (context, index) {
+                          final post = posts[index];
+                          return MyPost(
+                            userName: post.authorName,
+                            time: post.createdAt,
+                            content: post.content,
+                            imageUrls: post.imageUrls,
+                          );
+                        },
+                        childCount: posts.length,
+                      ),
+                    ),
+                  const SliverPadding(padding: EdgeInsets.only(bottom: 100)),
+                ],
               ),
-            ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
-                child: Text(
-                  'Bài tuyển thành viên',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleLarge
-                      ?.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ),
-            ),
-            SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (context, index) {
-                  final post = _recruitmentPosts[index];
-                  return RecruitmentPostCard(
-                    hostName: post.hostName,
-                    createdTime: post.createdAt,
-                    requiredPlayers: post.requiredPlayers,
-                    joinedPlayers: post.joinedPlayers,
-                    description: post.description,
-                    skillLevel: post.skillLevel,
-                    courtName: post.courtName,
-                    playTime: post.playTime,
-                    onJoin: () {},
-                  );
-                },
-                childCount: _recruitmentPosts.length,
-              ),
-            ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 24, 20, 4),
-                child: Text(
-                  'Bảng tin cộng đồng',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleLarge
-                      ?.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ),
-            ),
-            SliverList(
-              delegate: SliverChildListDelegate.fixed([
-                MyPost(
-                  message: 'https://picsum.photos/seed/recruitment1/1200/600',
-                  userName: 'Bảo Minh',
-                  time: _now,
-                ),
-                MyPost(
-                  message:
-                      'Đánh giao hữu cuối tuần này ở Quận 2, ai rảnh thì join nhé!',
-                  userName: 'Ngọc Anh',
-                  time: _now.subtract(const Duration(hours: 5)),
-                ),
-                MyPost(
-                  message: 'https://picsum.photos/seed/recruitment2/1200/600',
-                  userName: 'Văn Hòa',
-                  time: _now.subtract(const Duration(hours: 9)),
-                ),
-              ]),
-            ),
-            SliverPadding(padding: const EdgeInsets.only(bottom: 100)),
-          ],
+            );
+          },
         ),
       ),
     );
@@ -199,50 +257,25 @@ class SocialPage extends StatelessWidget {
                   style: FilledButton.styleFrom(
                     backgroundColor: cs.onPrimary,
                     foregroundColor: cs.primary,
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 20, vertical: 12),
                   ),
                 ),
               ],
-            ),
-          ),
-          const SizedBox(width: 16),
-          Container(
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: cs.onPrimary,
-              borderRadius: BorderRadius.circular(18),
-            ),
-            child: Icon(
-              Icons.sports_tennis,
-              size: 42,
-              color: cs.primary,
             ),
           ),
         ],
       ),
     );
   }
-}
 
-class _RecruitmentPost {
-  final String hostName;
-  final DateTime createdAt;
-  final int requiredPlayers;
-  final int joinedPlayers;
-  final String? skillLevel;
-  final String? description;
-  final String? courtName;
-  final DateTime? playTime;
-
-  const _RecruitmentPost({
-    required this.hostName,
-    required this.createdAt,
-    required this.requiredPlayers,
-    required this.joinedPlayers,
-    this.skillLevel,
-    this.description,
-    this.courtName,
-    this.playTime,
-  });
+  String? _mapPlayStyle(String? value) {
+    switch (value) {
+      case 'singles':
+        return 'Đánh đơn';
+      case 'doubles':
+        return 'Đánh đôi';
+      case 'mixed':
+        return 'Đánh đôi nam nữ';
+    }
+    return value;
+  }
 }

--- a/lib/providers/file_manager.dart
+++ b/lib/providers/file_manager.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:image_picker/image_picker.dart';
+
+class FileManager with ChangeNotifier {
+  FileManager() : _picker = ImagePicker();
+
+  final ImagePicker _picker;
+  final List<XFile> _pickedImages = [];
+
+  List<XFile> get pickedImages => List.unmodifiable(_pickedImages);
+
+  bool get hasImages => _pickedImages.isNotEmpty;
+
+  Future<void> pickImages() async {
+    final images = await _picker.pickMultiImage(imageQuality: 85);
+    if (images.isEmpty) {
+      return;
+    }
+    _pickedImages
+      ..clear()
+      ..addAll(images);
+    notifyListeners();
+  }
+
+  Future<void> pickFromCamera() async {
+    final image = await _picker.pickImage(source: ImageSource.camera);
+    if (image == null) {
+      return;
+    }
+    _pickedImages
+      ..clear()
+      ..add(image);
+    notifyListeners();
+  }
+
+  void removeAt(int index) {
+    if (index < 0 || index >= _pickedImages.length) {
+      return;
+    }
+    _pickedImages.removeAt(index);
+    notifyListeners();
+  }
+
+  void clear() {
+    if (_pickedImages.isEmpty) {
+      return;
+    }
+    _pickedImages.clear();
+    notifyListeners();
+  }
+
+  List<File> toFiles() {
+    return _pickedImages
+        .where((xfile) => xfile.path.isNotEmpty)
+        .map((xfile) => File(xfile.path))
+        .toList(growable: false);
+  }
+}

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/post.dart';
+import 'pocketbase_client.dart';
+
+class PostServiceException implements Exception {
+  PostServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class PostService {
+  static const String collection = 'posts';
+
+  Future<List<Post>> fetchPosts({
+    int page = 1,
+    int perPage = 20,
+  }) async {
+    final client = await getPocketbaseInstance();
+
+    try {
+      final result = await client.collection(collection).getList(
+            page: page,
+            perPage: perPage,
+            filter: "is_active = true",
+            sort: '-created',
+            expand: 'author',
+          );
+
+      return result.items
+          .map((record) => Post.fromRecord(client, record))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientError(error));
+    } catch (_) {
+      throw PostServiceException(
+        'Không thể tải danh sách bài viết. Vui lòng thử lại sau.',
+      );
+    }
+  }
+
+  Future<Post> createPost({
+    required String content,
+    List<File> imageFiles = const <File>[],
+  }) async {
+    final client = await getPocketbaseInstance();
+    final authorId = client.authStore.record?.id;
+
+    if (authorId == null || authorId.isEmpty) {
+      throw PostServiceException('Bạn cần đăng nhập trước khi đăng bài.');
+    }
+
+    try {
+      final files = await _buildMultipartFiles(imageFiles);
+
+      final record = await client.collection(collection).create(
+        body: {
+          'content': content.trim(),
+          'author': authorId,
+          'is_active': true,
+        },
+        files: files,
+      );
+
+      if (record.expand == null || record.expand!.isEmpty) {
+        final refreshed = await client.collection(collection).getOne(
+              record.id,
+              expand: 'author',
+            );
+        return Post.fromRecord(client, refreshed);
+      }
+
+      return Post.fromRecord(client, record);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientError(error));
+    } catch (error) {
+      throw PostServiceException(
+        'Đăng bài thất bại. Vui lòng thử lại. Lỗi: $error',
+      );
+    }
+  }
+
+  Future<List<http.MultipartFile>> _buildMultipartFiles(List<File> files) async {
+    final result = <http.MultipartFile>[];
+
+    for (final file in files) {
+      if (!await file.exists()) {
+        continue;
+      }
+      final bytes = await file.readAsBytes();
+      final fileName = p.basename(file.path);
+      result.add(
+        http.MultipartFile.fromBytes(
+          'images',
+          bytes,
+          filename: fileName,
+        ),
+      );
+    }
+
+    return result;
+  }
+
+  String _mapClientError(ClientException error) {
+    if (error.response['message'] is String) {
+      return error.response['message'] as String;
+    }
+    if (error.statusCode == 401) {
+      return 'Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.';
+    }
+    if (error.statusCode == 403) {
+      return 'Bạn không có quyền thực hiện thao tác này.';
+    }
+    return 'Có lỗi xảy ra. Mã lỗi: ${error.statusCode ?? 'không xác định'}';
+  }
+}

--- a/lib/services/recruitment_service.dart
+++ b/lib/services/recruitment_service.dart
@@ -1,0 +1,148 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/recruitment_post.dart';
+import 'pocketbase_client.dart';
+
+class RecruitmentServiceException implements Exception {
+  RecruitmentServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class RecruitmentService {
+  static const String collection = 'recruitment_posts';
+
+  Future<List<RecruitmentPost>> fetchRecruitmentPosts({
+    int page = 1,
+    int perPage = 20,
+  }) async {
+    final client = await getPocketbaseInstance();
+    final nowIso = DateTime.now().toUtc().toIso8601String();
+
+    try {
+      final result = await client.collection(collection).getList(
+            page: page,
+            perPage: perPage,
+            sort: '-created',
+            filter:
+                "is_active = true && (expires_at = '' || expires_at >= '$nowIso')",
+            expand: 'author,court',
+          );
+
+      final futures = result.items.map((record) async {
+        final joined = await _countApplicants(client, record.id);
+        return RecruitmentPost.fromRecord(
+          record,
+          joinedCount: joined,
+        );
+      }).toList();
+
+      return Future.wait(futures);
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (_) {
+      throw RecruitmentServiceException(
+        'Không thể tải danh sách bài tuyển thành viên. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<RecruitmentPost> createRecruitmentPost({
+    required String content,
+    required int requiredMembers,
+    String? courtId,
+    DateTime? eventTime,
+    String? skillLevel,
+    String? playStyle,
+    String? locationNote,
+  }) async {
+    final client = await getPocketbaseInstance();
+    final authorId = client.authStore.record?.id;
+
+    if (authorId == null || authorId.isEmpty) {
+      throw RecruitmentServiceException('Bạn cần đăng nhập để đăng bài tuyển.');
+    }
+
+    try {
+      final body = <String, dynamic>{
+        'author': authorId,
+        'content': content.trim(),
+        'need_members': requiredMembers,
+        'is_active': true,
+      };
+
+      if (courtId != null && courtId.isNotEmpty) {
+        body['court'] = courtId;
+      }
+
+      if (eventTime != null) {
+        body['event_time'] = eventTime.toUtc().toIso8601String();
+        body['expires_at'] = eventTime.toUtc().toIso8601String();
+      }
+
+      if (skillLevel != null && skillLevel.trim().isNotEmpty) {
+        body['skill_level'] = skillLevel.trim();
+      }
+
+      if (playStyle != null && playStyle.trim().isNotEmpty) {
+        body['play_style'] = playStyle.trim();
+      }
+
+      if (locationNote != null && locationNote.trim().isNotEmpty) {
+        body['location_note'] = locationNote.trim();
+      }
+
+      final record = await client.collection(collection).create(
+            body: body,
+          );
+
+      final refreshed = await client.collection(collection).getOne(
+            record.id,
+            expand: 'author,court',
+          );
+
+      return RecruitmentPost.fromRecord(refreshed);
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (error) {
+      throw RecruitmentServiceException(
+        'Không thể đăng bài tuyển thành viên. Lỗi: $error',
+      );
+    }
+  }
+
+  Future<int> _countApplicants(PocketBase client, String recruitmentId) async {
+    final escapedId = _escapeFilterValue(recruitmentId);
+
+    try {
+      final result = await client.collection('recruitment_applicants').getList(
+            page: 1,
+            perPage: 1,
+            filter: "recruitment='$escapedId'",
+          );
+      return result.totalItems;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  String _escapeFilterValue(String value) {
+    return value.replaceAll("'", "\\'");
+  }
+
+  String _mapClientError(ClientException error) {
+    if (error.response['message'] is String) {
+      return error.response['message'] as String;
+    }
+    if (error.statusCode == 401) {
+      return 'Phiên đăng nhập hết hạn. Vui lòng đăng nhập lại.';
+    }
+    if (error.statusCode == 403) {
+      return 'Bạn không có quyền thực hiện thao tác này.';
+    }
+    return 'Có lỗi xảy ra. Mã lỗi: ${error.statusCode ?? 'không xác định'}';
+  }
+}


### PR DESCRIPTION
## Summary
- add PocketBase models and services for posts and recruitment posts
- wire providers and managers to create and list community posts
- refresh social and recruitment UIs to use real data and submission workflows

## Testing
- not run (flutter sdk unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690cd5d5a9bc832ba3833ba57951c416