### PR TITLE
Implement community posting and recruitment features

### DIFF
--- a/lib/components/create_post_card.dart
+++ b/lib/components/create_post_card.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../pages/auth/auth_manager.dart';
+import '../pages/social/social_manager.dart';
+
+class CreatePostCard extends StatefulWidget {
+  const CreatePostCard({super.key});
+
+  @override
+  State<CreatePostCard> createState() => _CreatePostCardState();
+}
+
+class _CreatePostCardState extends State<CreatePostCard> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSubmit() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Vui lòng nhập nội dung bài viết.')),
+      );
+      return;
+    }
+
+    final authManager = context.read<AuthManager>();
+    final user = authManager.user;
+    if (user == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Bạn cần đăng nhập để đăng bài.')),
+      );
+      return;
+    }
+
+    final socialManager = context.read<SocialManager>();
+
+    try {
+      await socialManager.createPost(authorId: user.id, content: text);
+      _controller.clear();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Đăng bài thành công.')),
+      );
+    } catch (error) {
+      final message = error.toString();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isLoading = context.watch<SocialManager>().isCreatingPost;
+    final cs = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+      child: Material(
+        elevation: 4,
+        borderRadius: BorderRadius.circular(20),
+        color: cs.surface,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                controller: _controller,
+                maxLines: null,
+                decoration: const InputDecoration(
+                  hintText: 'Chia sẻ điều gì đó với cộng đồng...',
+                  border: InputBorder.none,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: FilledButton.icon(
+                  onPressed: isLoading ? null : _handleSubmit,
+                  icon: isLoading
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.send_rounded),
+                  label: Text(isLoading ? 'Đang đăng...' : 'Đăng bài'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/my_post.dart
+++ b/lib/components/my_post.dart
@@ -2,26 +2,29 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class MyPost extends StatelessWidget {
-  final String message;
+  final String content;
   final String userName;
   final DateTime time;
+  final List<String> imageUrls;
+  final String? userAvatarUrl;
   final VoidCallback? onLikePressed;
 
   const MyPost({
     super.key,
-    required this.message,
+    required this.content,
     required this.userName,
     required this.time,
+    this.imageUrls = const [],
+    this.userAvatarUrl,
     this.onLikePressed,
   });
 
   @override
   Widget build(BuildContext context) {
-    final isImage = message.startsWith('http') ||
-        message.startsWith('https') &&
-            (message.contains('.jpg') ||
-                message.contains('.png') ||
-                message.contains('cloudinary'));
+    final hasImages = imageUrls.isNotEmpty;
+    final primaryImage = hasImages ? imageUrls.first : null;
+    final trimmedContent = content.trim();
+    final hasContent = trimmedContent.isNotEmpty;
     final cs = Theme.of(context).colorScheme;
 
     return Padding(
@@ -44,17 +47,18 @@ class MyPost extends StatelessWidget {
                     top: 15, bottom: 15, left: 15, right: 15),
                 child: Row(
                   children: [
-                    Container(
-                      padding: const EdgeInsets.all(10),
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.primary,
-                        borderRadius: BorderRadius.circular(30),
-                      ),
-                      child: const Icon(
-                        Icons.person,
-                        size: 35,
-                        color: Colors.white,
-                      ),
+                    CircleAvatar(
+                      radius: 26,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                      backgroundImage:
+                          userAvatarUrl != null ? NetworkImage(userAvatarUrl!) : null,
+                      child: userAvatarUrl == null
+                          ? const Icon(
+                              Icons.person,
+                              size: 28,
+                              color: Colors.white,
+                            )
+                          : null,
                     ),
                     const SizedBox(width: 15),
                     Column(
@@ -88,28 +92,28 @@ class MyPost extends StatelessWidget {
               ),
 
               // Post message
-              isImage
-                  ? ClipRRect(
-                      borderRadius: BorderRadius.circular(0),
-                      child: Center(
-                        child: Image.network(
-                          message,
-                          fit: BoxFit.cover,
-                          width: MediaQuery.of(context).size.width,
-                        ),
-                      ),
-                    )
-                  : Padding(
-                      padding:
-                          const EdgeInsets.only(left: 20, top: 10, bottom: 10),
-                      child: Text(
-                        message,
-                        style: const TextStyle(
-                          color: Colors.black87,
-                          fontSize: 20,
-                        ),
-                      ),
+              if (hasContent)
+                Padding(
+                  padding: const EdgeInsets.only(left: 20, top: 10, bottom: 10),
+                  child: Text(
+                    trimmedContent,
+                    style: const TextStyle(
+                      color: Colors.black87,
+                      fontSize: 18,
                     ),
+                  ),
+                ),
+              if (primaryImage != null)
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(0),
+                  child: Center(
+                    child: Image.network(
+                      primaryImage,
+                      fit: BoxFit.cover,
+                      width: MediaQuery.of(context).size.width,
+                    ),
+                  ),
+                ),
 
               // Action bar
               Padding(

--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -5,23 +5,33 @@ class RecruitmentPostCard extends StatelessWidget {
   final String hostName;
   final DateTime createdTime;
   final String? skillLevel;
-  final int requiredPlayers;
+  final String? playStyle;
+  final int? targetPlayers;
   final int joinedPlayers;
   final String? description;
   final String? courtName;
   final DateTime? playTime;
+  final String? hostAvatarUrl;
+  final bool isJoined;
+  final bool isJoinable;
+  final bool isJoining;
   final VoidCallback? onJoin;
 
   const RecruitmentPostCard({
     super.key,
     required this.hostName,
     required this.createdTime,
-    required this.requiredPlayers,
     required this.joinedPlayers,
+    this.targetPlayers,
     this.skillLevel,
+    this.playStyle,
     this.description,
     this.courtName,
     this.playTime,
+    this.hostAvatarUrl,
+    this.isJoined = false,
+    this.isJoinable = true,
+    this.isJoining = false,
     this.onJoin,
   });
 
@@ -29,10 +39,22 @@ class RecruitmentPostCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final totalSlots = requiredPlayers <= 0 ? joinedPlayers : requiredPlayers;
+    final totalSlots = targetPlayers == null || targetPlayers! <= 0
+        ? joinedPlayers
+        : targetPlayers!;
     final progress = totalSlots == 0
         ? 0.0
         : (joinedPlayers / totalSlots).clamp(0, 1).toDouble();
+    final isFull = targetPlayers != null && joinedPlayers >= targetPlayers!;
+    final isButtonDisabled =
+        !isJoinable || isJoined || isJoining || isFull || onJoin == null;
+    final buttonLabel = isFull
+        ? 'Đủ thành viên'
+        : isJoined
+            ? 'Đã tham gia'
+            : isJoining
+                ? 'Đang tham gia...'
+                : 'Tham gia';
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -60,16 +82,31 @@ class RecruitmentPostCard extends StatelessWidget {
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      'Đã có $joinedPlayers / $requiredPlayers thành viên',
+                      targetPlayers != null && targetPlayers! > 0
+                          ? 'Đã có $joinedPlayers / $targetPlayers thành viên'
+                          : 'Đã có $joinedPlayers thành viên',
                       style: textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),
                   FilledButton.icon(
-                    onPressed: onJoin,
-                    icon: const Icon(Icons.add_circle_outline),
-                    label: const Text('Tham gia'),
+                    onPressed: isButtonDisabled ? null : onJoin,
+                    icon: isJoining
+                        ? SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: cs.onPrimary,
+                            ),
+                          )
+                        : Icon(
+                            isJoined || isFull
+                                ? Icons.check_circle_outline
+                                : Icons.add_circle_outline,
+                          ),
+                    label: Text(buttonLabel),
                   ),
                 ],
               ),
@@ -95,11 +132,18 @@ class RecruitmentPostCard extends StatelessWidget {
                       color: cs.primaryContainer,
                       iconColor: cs.primary,
                     ),
+                  if (playStyle != null && playStyle!.isNotEmpty)
+                    _InfoChip(
+                      icon: Icons.sports_tennis,
+                      label: 'Loại hình: $playStyle',
+                      color: cs.secondaryContainer,
+                      iconColor: cs.secondary,
+                    ),
                   _InfoChip(
-                    icon: Icons.sports_tennis,
-                    label: 'Loại hình: Đánh đơn/đôi',
-                    color: cs.secondaryContainer,
-                    iconColor: cs.secondary,
+                    icon: Icons.people_alt_outlined,
+                    label: 'Đã có $joinedPlayers người',
+                    color: cs.surfaceVariant,
+                    iconColor: cs.primary,
                   ),
                   if (courtName != null && courtName!.isNotEmpty)
                     _InfoChip(
@@ -133,13 +177,17 @@ class RecruitmentPostCard extends StatelessWidget {
         CircleAvatar(
           radius: 26,
           backgroundColor: cs.primary,
-          child: Text(
-            (hostName.isNotEmpty ? hostName[0] : '?').toUpperCase(),
-            style: textTheme.titleMedium?.copyWith(
-              color: cs.onPrimary,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
+          backgroundImage:
+              hostAvatarUrl != null ? NetworkImage(hostAvatarUrl!) : null,
+          child: hostAvatarUrl == null
+              ? Text(
+                  (hostName.isNotEmpty ? hostName[0] : '?').toUpperCase(),
+                  style: textTheme.titleMedium?.copyWith(
+                    color: cs.onPrimary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                )
+              : null,
         ),
         const SizedBox(width: 16),
         Expanded(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
+import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -22,6 +23,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => AuthManager()),
         ChangeNotifierProvider(create: (_) => UserManager()),
         ChangeNotifierProvider(create: (_) => CourtManager()),
+        ChangeNotifierProvider(create: (_) => SocialManager()),
       ],
       child: const MyApp(),
     ),

--- a/lib/models/booked_court_option.dart
+++ b/lib/models/booked_court_option.dart
@@ -1,0 +1,45 @@
+import 'package:intl/intl.dart';
+
+import 'user_booking_view.dart';
+
+class BookedCourtOption {
+  BookedCourtOption({
+    required this.bookingId,
+    required this.courtId,
+    required this.startTime,
+    required this.endTime,
+    this.courtName,
+    this.courtUnitLabel,
+  });
+
+  factory BookedCourtOption.fromUserBooking(UserBookingView view) {
+    return BookedCourtOption(
+      bookingId: view.booking.id,
+      courtId: view.booking.courtId,
+      startTime: view.booking.startTime.toLocal(),
+      endTime: view.booking.endTime.toLocal(),
+      courtName: view.courtName,
+      courtUnitLabel: view.courtUnitLabel,
+    );
+  }
+
+  final String bookingId;
+  final String courtId;
+  final DateTime startTime;
+  final DateTime endTime;
+  final String? courtName;
+  final String? courtUnitLabel;
+
+  String get label {
+    final courtDisplay = [courtName, courtUnitLabel]
+        .where((value) => value != null && value!.trim().isNotEmpty)
+        .map((value) => value!.trim())
+        .join(' • ');
+    final formatter = DateFormat('HH:mm');
+    final timeRange = '${formatter.format(startTime)} - ${formatter.format(endTime)}';
+    if (courtDisplay.isEmpty) {
+      return timeRange;
+    }
+    return '$courtDisplay • $timeRange';
+  }
+}

--- a/lib/models/community_post.dart
+++ b/lib/models/community_post.dart
@@ -1,0 +1,151 @@
+import 'package:pocketbase/pocketbase.dart';
+
+class CommunityPost {
+  CommunityPost({
+    required this.id,
+    required this.authorId,
+    required this.authorName,
+    required this.content,
+    required this.createdAt,
+    required this.isActive,
+    this.authorAvatarUrl,
+    this.updatedAt,
+    List<String>? imageUrls,
+  }) : imageUrls = imageUrls ?? const [];
+
+  factory CommunityPost.fromRecord(
+    RecordModel record,
+    PocketBase pocketBase,
+  ) {
+    final data = record.data;
+    final expand = record.expand ?? {};
+
+    final authorRecord = _resolveExpandedRecord(expand['author']);
+    final rawAuthorName =
+        (authorRecord?.data['username'] as String?)?.trim() ?? '';
+    final avatarField = authorRecord?.data['avatar'];
+    final avatarName = _extractFirstFileName(avatarField);
+    final avatarUrl = (authorRecord != null && avatarName != null)
+        ? pocketBase.files.getUrl(authorRecord, avatarName).toString()
+        : null;
+
+    final rawImages = data['images'];
+    final imageNames = _extractFileList(rawImages);
+    final imageUrls = imageNames
+        .map((name) => pocketBase.files.getUrl(record, name).toString())
+        .toList(growable: false);
+
+    return CommunityPost(
+      id: record.id,
+      authorId: (data['author'] as String?)?.trim() ?? '',
+      authorName: rawAuthorName.isEmpty ? 'Người chơi' : rawAuthorName,
+      authorAvatarUrl: avatarUrl,
+      content: (data['content'] as String?)?.trim() ?? '',
+      createdAt: _parseDate(data['created']) ?? DateTime.now().toUtc(),
+      updatedAt: _parseDate(data['updated'])?.toUtc(),
+      isActive: _parseBool(data['is_active']),
+      imageUrls: imageUrls,
+    );
+  }
+
+  final String id;
+  final String authorId;
+  final String authorName;
+  final String content;
+  final DateTime createdAt;
+  final bool isActive;
+  final String? authorAvatarUrl;
+  final DateTime? updatedAt;
+  final List<String> imageUrls;
+
+  bool get hasImages => imageUrls.isNotEmpty;
+
+  CommunityPost copyWith({
+    String? content,
+    DateTime? updatedAt,
+    List<String>? imageUrls,
+  }) {
+    return CommunityPost(
+      id: id,
+      authorId: authorId,
+      authorName: authorName,
+      authorAvatarUrl: authorAvatarUrl,
+      content: content ?? this.content,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      isActive: isActive,
+      imageUrls: imageUrls ?? this.imageUrls,
+    );
+  }
+}
+
+RecordModel? _resolveExpandedRecord(dynamic expanded) {
+  if (expanded is RecordModel) {
+    return expanded;
+  }
+
+  if (expanded is List) {
+    for (final item in expanded) {
+      if (item is RecordModel) {
+        return item;
+      }
+    }
+  }
+
+  return null;
+}
+
+List<String> _extractFileList(dynamic raw) {
+  if (raw is String) {
+    return raw.isEmpty ? const [] : <String>[raw];
+  }
+
+  if (raw is List) {
+    return raw
+        .whereType<String>()
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  return const [];
+}
+
+String? _extractFirstFileName(dynamic value) {
+  if (value is String && value.trim().isNotEmpty) {
+    return value.trim();
+  }
+
+  if (value is List && value.isNotEmpty) {
+    final first = value.first;
+    if (first is String && first.trim().isNotEmpty) {
+      return first.trim();
+    }
+  }
+
+  return null;
+}
+
+DateTime? _parseDate(dynamic value) {
+  if (value == null) return null;
+  if (value is DateTime) return value.toUtc();
+  if (value is String && value.isNotEmpty) {
+    return DateTime.tryParse(value)?.toUtc();
+  }
+  return null;
+}
+
+bool _parseBool(dynamic value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    final lower = value.toLowerCase();
+    if (lower == 'true') return true;
+    if (lower == 'false') return false;
+    final numeric = num.tryParse(value);
+    if (numeric != null) {
+      return numeric != 0;
+    }
+  }
+  return false;
+}

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -1,0 +1,226 @@
+import 'package:pocketbase/pocketbase.dart';
+
+class RecruitmentPost {
+  RecruitmentPost({
+    required this.id,
+    required this.authorId,
+    required this.authorName,
+    required this.content,
+    required this.createdAt,
+    required this.isActive,
+    this.authorAvatarUrl,
+    this.updatedAt,
+    this.courtId,
+    this.courtName,
+    this.eventTime,
+    this.targetMemberCount,
+    this.skillLevel,
+    this.playStyle,
+    this.locationNote,
+    this.expiresAt,
+    this.hasCurrentUserJoined = false,
+    List<RecruitmentApplicant>? applicants,
+  }) : applicants = applicants ?? const [];
+
+  factory RecruitmentPost.fromRecord(
+    RecordModel record,
+    PocketBase pocketBase, {
+    String? currentUserId,
+  }) {
+    final data = record.data;
+    final expand = record.expand ?? {};
+
+    final authorRecord = _resolveExpandedRecord(expand['author']);
+    final rawAuthorName =
+        (authorRecord?.data['username'] as String?)?.trim() ?? '';
+    final avatarName = _extractFirstFileName(authorRecord?.data['avatar']);
+    final avatarUrl = (authorRecord != null && avatarName != null)
+        ? pocketBase.files.getUrl(authorRecord, avatarName).toString()
+        : null;
+
+    final courtRecord = _resolveExpandedRecord(expand['court']);
+    final courtName =
+        (courtRecord?.data['name'] as String?)?.trim().isNotEmpty == true
+            ? (courtRecord!.data['name'] as String).trim()
+            : null;
+
+    final applicantsRecords =
+        _resolveExpandedRecords(expand['recruitment_applicants(recruitment)']);
+    final applicants = applicantsRecords
+        .map((record) => RecruitmentApplicant.fromRecord(record))
+        .toList(growable: false);
+
+    final hasJoined = currentUserId != null &&
+        applicants.any((applicant) => applicant.userId == currentUserId);
+
+    final targetMembers = _parseInt(data['need_members']);
+
+    return RecruitmentPost(
+      id: record.id,
+      authorId: (data['author'] as String?)?.trim() ?? '',
+      authorName: rawAuthorName.isEmpty ? 'Người chơi' : rawAuthorName,
+      authorAvatarUrl: avatarUrl,
+      content: (data['content'] as String?)?.trim() ?? '',
+      courtId: (data['court'] as String?)?.trim(),
+      courtName: courtName,
+      eventTime: _parseDate(data['event_time']),
+      targetMemberCount: targetMembers > 0 ? targetMembers : null,
+      skillLevel: (data['skill_level'] as String?)?.trim(),
+      playStyle: (data['play_style'] as String?)?.trim(),
+      locationNote: (data['location_note'] as String?)?.trim(),
+      createdAt: _parseDate(data['created']) ?? DateTime.now().toUtc(),
+      updatedAt: _parseDate(data['updated']),
+      expiresAt: _parseDate(data['expires_at']),
+      isActive: _parseBool(data['is_active']),
+      applicants: applicants,
+      hasCurrentUserJoined: hasJoined,
+    );
+  }
+
+  final String id;
+  final String authorId;
+  final String authorName;
+  final String content;
+  final DateTime createdAt;
+  final bool isActive;
+  final String? authorAvatarUrl;
+  final DateTime? updatedAt;
+  final String? courtId;
+  final String? courtName;
+  final DateTime? eventTime;
+  final int? targetMemberCount;
+  final String? skillLevel;
+  final String? playStyle;
+  final String? locationNote;
+  final DateTime? expiresAt;
+  final bool hasCurrentUserJoined;
+  final List<RecruitmentApplicant> applicants;
+
+  int get applicantCount => applicants.length;
+
+  int get joinedMemberCount => applicantCount + 1; // +1 cho chủ bài đăng
+
+  RecruitmentPost copyWith({
+    List<RecruitmentApplicant>? applicants,
+    bool? hasCurrentUserJoined,
+  }) {
+    return RecruitmentPost(
+      id: id,
+      authorId: authorId,
+      authorName: authorName,
+      authorAvatarUrl: authorAvatarUrl,
+      content: content,
+      createdAt: createdAt,
+      isActive: isActive,
+      updatedAt: updatedAt,
+      courtId: courtId,
+      courtName: courtName,
+      eventTime: eventTime,
+      targetMemberCount: targetMemberCount,
+      skillLevel: skillLevel,
+      playStyle: playStyle,
+      locationNote: locationNote,
+      expiresAt: expiresAt,
+      applicants: applicants ?? this.applicants,
+      hasCurrentUserJoined: hasCurrentUserJoined ?? this.hasCurrentUserJoined,
+    );
+  }
+}
+
+class RecruitmentApplicant {
+  const RecruitmentApplicant({
+    required this.id,
+    required this.recruitmentId,
+    required this.userId,
+    required this.createdAt,
+  });
+
+  factory RecruitmentApplicant.fromRecord(RecordModel record) {
+    final data = record.data;
+    return RecruitmentApplicant(
+      id: record.id,
+      recruitmentId: (data['recruitment'] as String?)?.trim() ?? '',
+      userId: (data['user'] as String?)?.trim() ?? '',
+      createdAt: _parseDate(data['created']) ?? DateTime.now().toUtc(),
+    );
+  }
+
+  final String id;
+  final String recruitmentId;
+  final String userId;
+  final DateTime createdAt;
+}
+
+RecordModel? _resolveExpandedRecord(dynamic expanded) {
+  if (expanded is RecordModel) {
+    return expanded;
+  }
+
+  if (expanded is List) {
+    for (final item in expanded) {
+      if (item is RecordModel) {
+        return item;
+      }
+    }
+  }
+
+  return null;
+}
+
+List<RecordModel> _resolveExpandedRecords(dynamic expanded) {
+  if (expanded is RecordModel) {
+    return [expanded];
+  }
+
+  if (expanded is List) {
+    return expanded.whereType<RecordModel>().toList(growable: false);
+  }
+
+  return const [];
+}
+
+String? _extractFirstFileName(dynamic value) {
+  if (value is String && value.trim().isNotEmpty) {
+    return value.trim();
+  }
+
+  if (value is List && value.isNotEmpty) {
+    final first = value.first;
+    if (first is String && first.trim().isNotEmpty) {
+      return first.trim();
+    }
+  }
+
+  return null;
+}
+
+DateTime? _parseDate(dynamic value) {
+  if (value == null) return null;
+  if (value is DateTime) return value.toUtc();
+  if (value is String && value.isNotEmpty) {
+    return DateTime.tryParse(value)?.toUtc();
+  }
+  return null;
+}
+
+int _parseInt(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
+}
+
+bool _parseBool(dynamic value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    final lower = value.toLowerCase();
+    if (lower == 'true') return true;
+    if (lower == 'false') return false;
+    final numeric = num.tryParse(value);
+    if (numeric != null) {
+      return numeric != 0;
+    }
+  }
+  return false;
+}

--- a/lib/pages/social/recruitment/recruitment_form_manager.dart
+++ b/lib/pages/social/recruitment/recruitment_form_manager.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../models/booked_court_option.dart';
+import '../../../models/recruitment_post.dart';
+import '../../../services/booking_service.dart';
+import '../../../services/recruitment_service.dart';
+
+class RecruitmentFormManager with ChangeNotifier {
+  RecruitmentFormManager({
+    BookingService? bookingService,
+    RecruitmentService? recruitmentService,
+  })  : _bookingService = bookingService ?? BookingService(),
+        _recruitmentService = recruitmentService ?? RecruitmentService();
+
+  final BookingService _bookingService;
+  final RecruitmentService _recruitmentService;
+
+  bool _hasBookedCourt = true;
+  bool _isCheckingBookings = false;
+  bool _isSubmitting = false;
+  DateTime _selectedDateTime =
+      DateTime.now().add(const Duration(hours: 2)).toLocal();
+  List<BookedCourtOption> _availableBookings = const [];
+  BookedCourtOption? _selectedBooking;
+  String? _bookingMessage;
+
+  bool get hasBookedCourt => _hasBookedCourt;
+  bool get isCheckingBookings => _isCheckingBookings;
+  bool get isSubmitting => _isSubmitting;
+  DateTime get selectedDateTime => _selectedDateTime;
+  List<BookedCourtOption> get availableBookings => _availableBookings;
+  BookedCourtOption? get selectedBooking => _selectedBooking;
+  String? get bookingMessage => _bookingMessage;
+
+  Future<void> initialize({
+    required bool hasBookedCourt,
+    required DateTime initialDateTime,
+    required String userId,
+  }) async {
+    _hasBookedCourt = hasBookedCourt;
+    _selectedDateTime = initialDateTime;
+    _bookingMessage = null;
+    notifyListeners();
+
+    if (_hasBookedCourt) {
+      await _loadBookingsForDay(userId: userId);
+    }
+  }
+
+  Future<void> toggleHasBookedCourt(
+    bool value, {
+    required String userId,
+  }) async {
+    if (_hasBookedCourt == value) return;
+    _hasBookedCourt = value;
+    _bookingMessage = null;
+    if (!value) {
+      _availableBookings = const [];
+      _selectedBooking = null;
+      notifyListeners();
+      return;
+    }
+    notifyListeners();
+    await _loadBookingsForDay(userId: userId);
+  }
+
+  Future<void> setSelectedDateTime(
+    DateTime newDateTime, {
+    required String userId,
+  }) async {
+    _selectedDateTime = newDateTime;
+    notifyListeners();
+    if (_hasBookedCourt) {
+      await _loadBookingsForDay(userId: userId);
+    }
+  }
+
+  void selectBooking(BookedCourtOption? option) {
+    _selectedBooking = option;
+    notifyListeners();
+  }
+
+  Future<RecruitmentPost> submitRecruitmentPost({
+    required String authorId,
+    required String content,
+    required int targetMemberCount,
+    String? skillLevel,
+    String? playStyle,
+    String? locationNote,
+    DateTime? expiresAt,
+  }) async {
+    if (_isSubmitting) {
+      throw RecruitmentServiceException('Đang gửi bài, vui lòng chờ.');
+    }
+    _isSubmitting = true;
+    notifyListeners();
+
+    try {
+      final courtId = _hasBookedCourt ? _selectedBooking?.courtId : null;
+      return await _recruitmentService.createRecruitmentPost(
+        authorId: authorId,
+        content: content,
+        eventTime: _selectedDateTime,
+        targetMemberCount: targetMemberCount,
+        courtId: courtId,
+        skillLevel: skillLevel,
+        playStyle: playStyle,
+        locationNote: locationNote,
+        expiresAt: expiresAt,
+      );
+    } finally {
+      _isSubmitting = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _loadBookingsForDay({required String userId}) async {
+    _isCheckingBookings = true;
+    _bookingMessage = null;
+    notifyListeners();
+
+    final dayStart = DateTime(
+      _selectedDateTime.year,
+      _selectedDateTime.month,
+      _selectedDateTime.day,
+    );
+    final dayEnd = dayStart.add(const Duration(days: 1));
+
+    try {
+      final bookings = await _bookingService.listUserBookings(
+        userId: userId,
+        startTimeInclusive: dayStart,
+        endTimeExclusive: dayEnd,
+      );
+      final options = bookings
+          .map(BookedCourtOption.fromUserBooking)
+          .toList(growable: false);
+
+      _availableBookings = options;
+      if (options.isEmpty) {
+        _bookingMessage =
+            'Bạn chưa có sân nào trong ngày ${dayStart.day}/${dayStart.month}';
+        _selectedBooking = null;
+      } else {
+        _selectedBooking = options.first;
+      }
+    } catch (error) {
+      _bookingMessage = error.toString();
+      _availableBookings = const [];
+      _selectedBooking = null;
+    } finally {
+      _isCheckingBookings = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/pages/social/recruitment/recruitment_page.dart
+++ b/lib/pages/social/recruitment/recruitment_page.dart
@@ -1,3 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
+import 'package:badminton_booking_app/pages/social/social_manager.dart';
+import 'package:badminton_booking_app/pages/social/recruitment/recruitment_form_manager.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/court_info_section.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/intro_card.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/member_input_section.dart';
@@ -6,8 +13,7 @@ import 'package:badminton_booking_app/pages/social/recruitment/widgets/note_fiel
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/play_style_selector.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/skill_level_selector.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/submit_button.dart';
-import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:badminton_booking_app/services/recruitment_service.dart';
 
 class RecruitmentFormPage extends StatefulWidget {
   const RecruitmentFormPage({super.key});
@@ -17,24 +23,8 @@ class RecruitmentFormPage extends StatefulWidget {
 }
 
 class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
-  // Controllers
   final TextEditingController _noteController = TextEditingController();
   late final TextEditingController _memberCountController;
-
-  // State chính
-  bool _hasBookedCourt = true;
-  int _memberCount = 3;
-  String _skillLevel = 'Trung bình khá';
-  String _playStyle = 'Đánh đôi';
-  String? _selectedCourt;
-  DateTime _selectedDateTime = DateTime.now().add(const Duration(hours: 2));
-
-  // Dữ liệu mẫu
-  final List<String> _availableCourts = const [
-    'Sân Quận 7 - Court A',
-    'Sân Quận 1 - Court B',
-    'Sân Phú Nhuận - Court C',
-  ];
 
   final List<String> _playStyles = const [
     'Đánh đơn',
@@ -50,12 +40,16 @@ class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
     'Chuyên nghiệp',
   ];
 
+  int _memberCount = 3;
+  String _skillLevel = 'Trung bình khá';
+  String _playStyle = 'Đánh đôi';
+  late final DateTime _initialDateTime;
+
   @override
   void initState() {
     super.initState();
-    _selectedCourt = _availableCourts.first;
-    _memberCountController =
-        TextEditingController(text: _memberCount.toString());
+    _memberCountController = TextEditingController(text: _memberCount.toString());
+    _initialDateTime = DateTime.now().add(const Duration(hours: 2));
   }
 
   @override
@@ -65,10 +59,15 @@ class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
     super.dispose();
   }
 
-  Future<void> _pickDateTime() async {
+  Future<void> _pickDateTime(
+    BuildContext context,
+    RecruitmentFormManager manager,
+    String? userId,
+  ) async {
+    final initialDate = manager.selectedDateTime;
     final date = await showDatePicker(
       context: context,
-      initialDate: _selectedDateTime,
+      initialDate: initialDate,
       firstDate: DateTime.now(),
       lastDate: DateTime.now().add(const Duration(days: 30)),
     );
@@ -76,106 +75,208 @@ class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
 
     final time = await showTimePicker(
       context: context,
-      initialTime: TimeOfDay.fromDateTime(_selectedDateTime),
+      initialTime: TimeOfDay.fromDateTime(initialDate),
     );
     if (time == null) return;
 
-    setState(() {
-      _selectedDateTime = DateTime(
-        date.year,
-        date.month,
-        date.day,
-        time.hour,
-        time.minute,
+    final newDateTime = DateTime(
+      date.year,
+      date.month,
+      date.day,
+      time.hour,
+      time.minute,
+    );
+
+    await manager.setSelectedDateTime(
+      newDateTime,
+      userId: userId ?? '',
+    );
+  }
+
+  Future<void> _handleSubmit(
+    BuildContext context,
+    RecruitmentFormManager manager,
+  ) async {
+    final authManager = context.read<AuthManager>();
+    final user = authManager.user;
+    if (user == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Bạn cần đăng nhập để đăng bài.')),
       );
-    });
+      return;
+    }
+
+    if (_memberCount <= 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Số lượng thành viên phải lớn hơn 0.')),
+      );
+      return;
+    }
+
+    if (manager.hasBookedCourt && manager.selectedBooking == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Vui lòng chọn sân đã đặt.')),
+      );
+      return;
+    }
+
+    final note = _noteController.text.trim();
+    if (note.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Hãy nhập mô tả ngắn cho bài tuyển.')),
+      );
+      return;
+    }
+
+    try {
+      final post = await manager.submitRecruitmentPost(
+        authorId: user.id,
+        content: note,
+        targetMemberCount: _memberCount,
+        skillLevel: _skillLevel,
+        playStyle: _playStyle,
+      );
+
+      context.read<SocialManager>().addRecruitmentPost(post);
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Đăng bài tuyển thành viên thành công.')),
+      );
+      Navigator.of(context).pop();
+    } on RecruitmentServiceException catch (error) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.message)),
+      );
+    } catch (error) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
+    final authManager = context.read<AuthManager>();
+    final userId = authManager.user?.id;
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Tạo bài tuyển thành viên')),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              IntroCard(cs: cs, textTheme: textTheme),
-              const SizedBox(height: 24),
-
-              // 🔘 Toggle
-              SwitchListTile.adaptive(
-                contentPadding: EdgeInsets.zero,
-                title: const Text('Tôi đã đặt sân trước'),
-                value: _hasBookedCourt,
-                onChanged: (value) => setState(() => _hasBookedCourt = value),
+    return ChangeNotifierProvider<RecruitmentFormManager>(
+      create: (_) {
+        final manager = RecruitmentFormManager();
+        Future.microtask(() {
+          manager.initialize(
+            hasBookedCourt: userId != null,
+            initialDateTime: _initialDateTime,
+            userId: userId ?? '',
+          );
+        });
+        return manager;
+      },
+      child: Consumer<RecruitmentFormManager>(
+        builder: (context, manager, _) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Tạo bài tuyển thành viên')),
+            body: SafeArea(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    IntroCard(cs: cs, textTheme: textTheme),
+                    const SizedBox(height: 24),
+                    SwitchListTile.adaptive(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Tôi đã đặt sân trước'),
+                      value: manager.hasBookedCourt,
+                      onChanged: (value) async {
+                        if (userId == null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Bạn cần đăng nhập để kiểm tra sân đã đặt.'),
+                            ),
+                          );
+                          return;
+                        }
+                        await manager.toggleHasBookedCourt(
+                          value,
+                          userId: userId,
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 300),
+                      child: manager.hasBookedCourt
+                          ? _buildCourtSection(context, manager, userId)
+                          : const NoCourtInfoBox(),
+                    ),
+                    const SizedBox(height: 24),
+                    MemberInputSection(
+                      memberCount: _memberCount,
+                      controller: _memberCountController,
+                      onChanged: (val) => setState(() {
+                        _memberCount = val <= 0 ? 1 : val;
+                      }),
+                    ),
+                    const SizedBox(height: 24),
+                    PlayStyleSelector(
+                      playStyles: _playStyles,
+                      selectedStyle: _playStyle,
+                      onChanged: (value) => setState(() => _playStyle = value),
+                    ),
+                    const SizedBox(height: 24),
+                    SkillLevelSelector(
+                      skillLevels: _skillLevels,
+                      selectedLevel: _skillLevel,
+                      onChanged: (value) => setState(() => _skillLevel = value),
+                    ),
+                    const SizedBox(height: 24),
+                    NoteField(controller: _noteController),
+                    const SizedBox(height: 32),
+                    SubmitButton(
+                      onSubmit: () => _handleSubmit(context, manager),
+                      isLoading: manager.isSubmitting,
+                    ),
+                  ],
+                ),
               ),
-              const SizedBox(height: 16),
+            ),
+          );
+        },
+      ),
+    );
+  }
 
-              // 🏸 Nếu đã đặt sân / chưa đặt sân
-              AnimatedSwitcher(
-                duration: const Duration(milliseconds: 300),
-                child: _hasBookedCourt
-                    ? CourtInfoSection(
-                        selectedCourt: _selectedCourt!,
-                        availableCourts: _availableCourts,
-                        selectedDateTime: _selectedDateTime,
-                        onCourtChanged: (v) =>
-                            setState(() => _selectedCourt = v),
-                        onPickDateTime: _pickDateTime,
-                      )
-                    : NoCourtInfoBox(),
-              ),
-
-              const SizedBox(height: 24),
-
-              // 👥 Nhập số lượng
-              MemberInputSection(
-                memberCount: _memberCount,
-                controller: _memberCountController,
-                onChanged: (val) => setState(() => _memberCount = val),
-              ),
-              const SizedBox(height: 24),
-
-              // 🏸 Lối chơi
-              PlayStyleSelector(
-                playStyles: _playStyles,
-                selectedStyle: _playStyle,
-                onChanged: (v) => setState(() => _playStyle = v),
-              ),
-              const SizedBox(height: 24),
-
-              // 💪 Trình độ
-              SkillLevelSelector(
-                skillLevels: _skillLevels,
-                selectedLevel: _skillLevel,
-                onChanged: (v) => setState(() => _skillLevel = v),
-              ),
-              const SizedBox(height: 24),
-
-              // 📝 Ghi chú
-              NoteField(controller: _noteController),
-              const SizedBox(height: 32),
-
-              // 🚀 Nút đăng
-              SubmitButton(onSubmit: () {
-                print('--- THÔNG TIN BÀI TUYỂN ---');
-                print('Đã đặt sân: $_hasBookedCourt');
-                print('Sân: $_selectedCourt');
-                print('Giờ đánh: $_selectedDateTime');
-                print('Số lượng: $_memberCount');
-                print('Lối chơi: $_playStyle');
-                print('Trình độ: $_skillLevel');
-                print('Ghi chú: ${_noteController.text}');
-              }),
-            ],
+  Widget _buildCourtSection(
+    BuildContext context,
+    RecruitmentFormManager manager,
+    String? userId,
+  ) {
+    if (manager.isCheckingBookings) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 24),
+          child: CircularProgressIndicator(
+            color: Theme.of(context).colorScheme.primary,
           ),
         ),
-      ),
+      );
+    }
+
+    if (manager.availableBookings.isEmpty) {
+      final message = manager.bookingMessage ??
+          'Bạn chưa có sân nào trong ngày ${DateFormat('dd/MM').format(manager.selectedDateTime)}';
+      return NoCourtInfoBox(message: message);
+    }
+
+    return CourtInfoSection(
+      selectedBooking: manager.selectedBooking,
+      availableBookings: manager.availableBookings,
+      selectedDateTime: manager.selectedDateTime,
+      onBookingChanged: (value) => manager.selectBooking(value),
+      onPickDateTime: () => _pickDateTime(context, manager, userId),
     );
   }
 }

--- a/lib/pages/social/recruitment/widgets/court_info_section.dart
+++ b/lib/pages/social/recruitment/widgets/court_info_section.dart
@@ -1,19 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../../../../models/booked_court_option.dart';
+
 class CourtInfoSection extends StatelessWidget {
-  final String selectedCourt;
-  final List<String> availableCourts;
+  final BookedCourtOption? selectedBooking;
+  final List<BookedCourtOption> availableBookings;
   final DateTime selectedDateTime;
-  final ValueChanged<String> onCourtChanged;
+  final ValueChanged<BookedCourtOption?> onBookingChanged;
   final VoidCallback onPickDateTime;
 
   const CourtInfoSection({
     super.key,
-    required this.selectedCourt,
-    required this.availableCourts,
+    required this.selectedBooking,
+    required this.availableBookings,
     required this.selectedDateTime,
-    required this.onCourtChanged,
+    required this.onBookingChanged,
     required this.onPickDateTime,
   });
 
@@ -27,14 +29,22 @@ class CourtInfoSection extends StatelessWidget {
       children: [
         Text('Thông tin sân đã đặt', style: textTheme.titleMedium),
         const SizedBox(height: 12),
-        DropdownButtonFormField<String>(
-          value: selectedCourt,
+        DropdownButtonFormField<BookedCourtOption>(
+          value: selectedBooking,
           decoration: _inputDecoration(cs, 'Chọn sân đã đặt'),
-          items: availableCourts
+          items: availableBookings
               .map(
-                  (court) => DropdownMenuItem(value: court, child: Text(court)))
+                (booking) => DropdownMenuItem<BookedCourtOption>(
+                  value: booking,
+                  child: Text(
+                    booking.label,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              )
               .toList(),
-          onChanged: (v) => v != null ? onCourtChanged(v) : null,
+          onChanged:
+              availableBookings.isEmpty ? null : (value) => onBookingChanged(value),
         ),
         const SizedBox(height: 16),
         GestureDetector(

--- a/lib/pages/social/recruitment/widgets/no_court_info_box.dart
+++ b/lib/pages/social/recruitment/widgets/no_court_info_box.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
 
 class NoCourtInfoBox extends StatelessWidget {
-  const NoCourtInfoBox({super.key});
+  final String message;
+
+  const NoCourtInfoBox({
+    super.key,
+    this.message =
+        'Bạn chưa đặt sân — hãy nhập số lượng thành viên bạn muốn tuyển và mô tả yêu cầu để mọi người cùng tham gia.',
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +30,7 @@ class NoCourtInfoBox extends StatelessWidget {
           const SizedBox(width: 16),
           Expanded(
             child: Text(
-              'Bạn chưa đặt sân — hãy nhập số lượng thành viên bạn muốn tuyển và mô tả yêu cầu để mọi người cùng tham gia.',
+              message,
               style: textTheme.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
             ),
           ),

--- a/lib/pages/social/recruitment/widgets/submit_button.dart
+++ b/lib/pages/social/recruitment/widgets/submit_button.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 class SubmitButton extends StatelessWidget {
   final VoidCallback onSubmit;
+  final bool isLoading;
 
   const SubmitButton({
     super.key,
     required this.onSubmit,
+    this.isLoading = false,
   });
 
   @override
@@ -13,9 +15,16 @@ class SubmitButton extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
 
     return FilledButton.icon(
-      onPressed: onSubmit,
-      icon: const Icon(Icons.send_rounded),
-      label: const Text('Đăng bài tuyển thành viên'),
+      onPressed: isLoading ? null : onSubmit,
+      icon: isLoading
+          ? const SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : const Icon(Icons.send_rounded),
+      label:
+          Text(isLoading ? 'Đang đăng...' : 'Đăng bài tuyển thành viên'),
       style: FilledButton.styleFrom(
         minimumSize: const Size.fromHeight(54),
         textStyle: textTheme.titleMedium?.copyWith(

--- a/lib/pages/social/social_manager.dart
+++ b/lib/pages/social/social_manager.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/foundation.dart';
+
+import '../../models/community_post.dart';
+import '../../models/recruitment_post.dart';
+import '../../services/post_service.dart';
+import '../../services/recruitment_service.dart';
+
+class SocialManager with ChangeNotifier {
+  SocialManager({
+    PostService? postService,
+    RecruitmentService? recruitmentService,
+  })  : _postService = postService ?? PostService(),
+        _recruitmentService = recruitmentService ?? RecruitmentService();
+
+  final PostService _postService;
+  final RecruitmentService _recruitmentService;
+
+  bool _isLoadingPosts = false;
+  bool _isLoadingRecruitments = false;
+  bool _isCreatingPost = false;
+  bool _isCreatingRecruitment = false;
+  final Set<String> _joiningRecruitmentIds = {};
+
+  List<CommunityPost> _posts = const [];
+  List<RecruitmentPost> _recruitmentPosts = const [];
+  String? _postErrorMessage;
+  String? _recruitmentErrorMessage;
+
+  bool get isLoadingPosts => _isLoadingPosts;
+  bool get isLoadingRecruitments => _isLoadingRecruitments;
+  bool get isCreatingPost => _isCreatingPost;
+  bool get isCreatingRecruitment => _isCreatingRecruitment;
+  List<CommunityPost> get posts => _posts;
+  List<RecruitmentPost> get recruitmentPosts => _recruitmentPosts;
+  String? get postErrorMessage => _postErrorMessage;
+  String? get recruitmentErrorMessage => _recruitmentErrorMessage;
+
+  bool isJoiningRecruitment(String recruitmentId) =>
+      _joiningRecruitmentIds.contains(recruitmentId);
+
+  Future<void> loadInitialData(String? currentUserId) async {
+    await Future.wait([
+      refreshPosts(),
+      refreshRecruitmentPosts(currentUserId: currentUserId),
+    ]);
+  }
+
+  Future<void> refreshPosts() async {
+    _isLoadingPosts = true;
+    _postErrorMessage = null;
+    notifyListeners();
+
+    try {
+      _posts = await _postService.fetchPosts();
+    } on PostServiceException catch (error) {
+      _postErrorMessage = error.message;
+    } finally {
+      _isLoadingPosts = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshRecruitmentPosts({String? currentUserId}) async {
+    _isLoadingRecruitments = true;
+    _recruitmentErrorMessage = null;
+    notifyListeners();
+
+    try {
+      _recruitmentPosts =
+          await _recruitmentService.fetchRecruitmentPosts(
+        currentUserId: currentUserId,
+      );
+    } on RecruitmentServiceException catch (error) {
+      _recruitmentErrorMessage = error.message;
+    } finally {
+      _isLoadingRecruitments = false;
+      notifyListeners();
+    }
+  }
+
+  Future<CommunityPost?> createPost({
+    required String authorId,
+    required String content,
+  }) async {
+    if (_isCreatingPost) return null;
+
+    _isCreatingPost = true;
+    notifyListeners();
+
+    try {
+      final newPost = await _postService.createPost(
+        authorId: authorId,
+        content: content,
+      );
+      _posts = [newPost, ..._posts];
+      return newPost;
+    } on PostServiceException catch (error) {
+      _postErrorMessage = error.message;
+      rethrow;
+    } finally {
+      _isCreatingPost = false;
+      notifyListeners();
+    }
+  }
+
+  Future<RecruitmentPost?> createRecruitmentPost({
+    required String authorId,
+    required String content,
+    required DateTime eventTime,
+    required int targetMemberCount,
+    String? courtId,
+    String? skillLevel,
+    String? playStyle,
+    String? locationNote,
+    DateTime? expiresAt,
+  }) async {
+    if (_isCreatingRecruitment) return null;
+
+    _isCreatingRecruitment = true;
+    notifyListeners();
+
+    try {
+      final post = await _recruitmentService.createRecruitmentPost(
+        authorId: authorId,
+        content: content,
+        eventTime: eventTime,
+        targetMemberCount: targetMemberCount,
+        courtId: courtId,
+        skillLevel: skillLevel,
+        playStyle: playStyle,
+        locationNote: locationNote,
+        expiresAt: expiresAt,
+      );
+      _recruitmentPosts = [post, ..._recruitmentPosts];
+      return post;
+    } on RecruitmentServiceException catch (error) {
+      _recruitmentErrorMessage = error.message;
+      rethrow;
+    } finally {
+      _isCreatingRecruitment = false;
+      notifyListeners();
+    }
+  }
+
+  void addRecruitmentPost(RecruitmentPost post) {
+    _recruitmentPosts = [post, ..._recruitmentPosts];
+    notifyListeners();
+  }
+
+  Future<void> joinRecruitment({
+    required String recruitmentId,
+    required String userId,
+  }) async {
+    if (_joiningRecruitmentIds.contains(recruitmentId)) {
+      return;
+    }
+    _joiningRecruitmentIds.add(recruitmentId);
+    notifyListeners();
+
+    try {
+      await _recruitmentService.joinRecruitment(
+        recruitmentId: recruitmentId,
+        userId: userId,
+      );
+
+      final index =
+          _recruitmentPosts.indexWhere((post) => post.id == recruitmentId);
+      if (index != -1) {
+        final post = _recruitmentPosts[index];
+        final updatedApplicants = [
+          ...post.applicants,
+          RecruitmentApplicant(
+            id: 'local-$userId',
+            recruitmentId: recruitmentId,
+            userId: userId,
+            createdAt: DateTime.now(),
+          ),
+        ];
+        _recruitmentPosts = [
+          ..._recruitmentPosts.sublist(0, index),
+          post.copyWith(
+            applicants: updatedApplicants,
+            hasCurrentUserJoined: true,
+          ),
+          ..._recruitmentPosts.sublist(index + 1),
+        ];
+      }
+    } on RecruitmentServiceException catch (error) {
+      _recruitmentErrorMessage = error.message;
+      rethrow;
+    } finally {
+      _joiningRecruitmentIds.remove(recruitmentId);
+      notifyListeners();
+    }
+  }
+}

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1,51 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:badminton_booking_app/components/create_post_card.dart';
 import 'package:badminton_booking_app/components/my_post.dart';
 import 'package:badminton_booking_app/components/recruitment_post_card.dart';
+import 'package:badminton_booking_app/models/community_post.dart';
+import 'package:badminton_booking_app/models/recruitment_post.dart';
+import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_home_page.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/recruitment_page.dart';
-import 'package:flutter/material.dart';
+import 'package:badminton_booking_app/pages/social/social_manager.dart';
 
-class SocialPage extends StatelessWidget {
-  SocialPage({super.key});
+class SocialPage extends StatefulWidget {
+  const SocialPage({super.key});
 
-  final DateTime _now = DateTime.now();
+  @override
+  State<SocialPage> createState() => _SocialPageState();
+}
 
-  final List<_RecruitmentPost> _recruitmentPosts = [
-    _RecruitmentPost(
-      hostName: 'Bảo Minh',
-      createdAt: DateTime.now().subtract(const Duration(minutes: 15)),
-      description:
-          'Cần 2 bạn trình trung bình khá đánh đôi giao lưu. Team rất vui tính.',
-      requiredPlayers: 4,
-      joinedPlayers: 2,
-      skillLevel: 'Trung bình khá',
-      courtName: 'Sân Quận 7 - Court A',
-      playTime: DateTime.now().add(const Duration(hours: 2)),
-    ),
-    _RecruitmentPost(
-      hostName: 'Ngọc Anh',
-      createdAt: DateTime.now().subtract(const Duration(hours: 1, minutes: 10)),
-      description:
-          'Tuyển gấp 1 nữ trình trung bình để đánh đôi cố định sáng chủ nhật hàng tuần.',
-      requiredPlayers: 4,
-      joinedPlayers: 3,
-      skillLevel: 'Trung bình',
-      courtName: 'Sân Phú Nhuận - Court C',
-      playTime: DateTime.now().add(const Duration(days: 1, hours: 10)),
-    ),
-    _RecruitmentPost(
-      hostName: 'Văn Hòa',
-      createdAt: DateTime.now().subtract(const Duration(hours: 3)),
-      description:
-          'Nhóm mình chưa có sân, cần tuyển 3 bạn trình nâng cao lập team đi đánh giải.',
-      requiredPlayers: 5,
-      joinedPlayers: 1,
-      skillLevel: 'Nâng cao',
-    ),
-  ];
+class _SocialPageState extends State<SocialPage> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      final auth = context.read<AuthManager>();
+      final currentUserId = auth.user?.id;
+      context.read<SocialManager>().loadInitialData(currentUserId);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final socialManager = context.watch<SocialManager>();
+    final authManager = context.watch<AuthManager>();
+    final currentUserId = authManager.user?.id;
+
+    final recruitmentPosts = socialManager.recruitmentPosts;
+    final communityPosts = socialManager.posts;
 
     return Scaffold(
       backgroundColor: cs.surfaceVariant.withOpacity(0.3),
@@ -76,71 +68,253 @@ class SocialPage extends StatelessWidget {
                 child: _buildWelcomeCard(context),
               ),
             ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
-                child: Text(
-                  'Bài tuyển thành viên',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleLarge
-                      ?.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ),
+            const SliverToBoxAdapter(
+              child: CreatePostCard(),
             ),
-            SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (context, index) {
-                  final post = _recruitmentPosts[index];
-                  return RecruitmentPostCard(
-                    hostName: post.hostName,
-                    createdTime: post.createdAt,
-                    requiredPlayers: post.requiredPlayers,
-                    joinedPlayers: post.joinedPlayers,
-                    description: post.description,
-                    skillLevel: post.skillLevel,
-                    courtName: post.courtName,
-                    playTime: post.playTime,
-                    onJoin: () {},
-                  );
-                },
-                childCount: _recruitmentPosts.length,
-              ),
+            ..._buildRecruitmentSlivers(
+              context,
+              socialManager,
+              recruitmentPosts,
+              currentUserId,
             ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 24, 20, 4),
-                child: Text(
-                  'Bảng tin cộng đồng',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleLarge
-                      ?.copyWith(fontWeight: FontWeight.bold),
-                ),
-              ),
+            ..._buildCommunityPostSlivers(
+              context,
+              socialManager,
+              communityPosts,
             ),
-            SliverList(
-              delegate: SliverChildListDelegate.fixed([
-                MyPost(
-                  message: 'https://picsum.photos/seed/recruitment1/1200/600',
-                  userName: 'Bảo Minh',
-                  time: _now,
-                ),
-                MyPost(
-                  message:
-                      'Đánh giao hữu cuối tuần này ở Quận 2, ai rảnh thì join nhé!',
-                  userName: 'Ngọc Anh',
-                  time: _now.subtract(const Duration(hours: 5)),
-                ),
-                MyPost(
-                  message: 'https://picsum.photos/seed/recruitment2/1200/600',
-                  userName: 'Văn Hòa',
-                  time: _now.subtract(const Duration(hours: 9)),
-                ),
-              ]),
-            ),
-            SliverPadding(padding: const EdgeInsets.only(bottom: 100)),
+            const SliverPadding(padding: EdgeInsets.only(bottom: 100)),
           ],
+        ),
+      ),
+    );
+  }
+
+  SliverToBoxAdapter _buildRecruitmentTitle(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+        child: Text(
+          'Bài tuyển thành viên',
+          style:
+              Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecruitmentList(
+    BuildContext context,
+    SocialManager manager,
+    List<RecruitmentPost> recruitmentPosts,
+    String? currentUserId,
+  ) {
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) {
+          final post = recruitmentPosts[index];
+          final joinedCount = post.joinedMemberCount;
+          final targetCount = post.targetMemberCount;
+          final isAuthor = post.authorId == currentUserId;
+          final isFull = targetCount != null && joinedCount >= targetCount;
+          final description = post.locationNote != null && post.locationNote!.isNotEmpty
+              ? '${post.content}\nĐịa điểm: ${post.locationNote}'
+              : post.content;
+
+          return RecruitmentPostCard(
+            hostName: post.authorName,
+            createdTime: post.createdAt.toLocal(),
+            joinedPlayers: joinedCount,
+            targetPlayers: targetCount,
+            skillLevel: post.skillLevel,
+            playStyle: post.playStyle,
+            description: description,
+            courtName: post.courtName,
+            playTime: post.eventTime?.toLocal(),
+            hostAvatarUrl: post.authorAvatarUrl,
+            isJoined: post.hasCurrentUserJoined || isAuthor,
+            isJoinable: !isAuthor && !isFull,
+            isJoining: manager.isJoiningRecruitment(post.id),
+            onJoin: (!isAuthor && !isFull && !post.hasCurrentUserJoined)
+                ? () async {
+                    final auth = context.read<AuthManager>();
+                    final user = auth.user;
+                    if (user == null) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Bạn cần đăng nhập để tham gia.')),
+                      );
+                      return;
+                    }
+                    try {
+                      await manager.joinRecruitment(
+                        recruitmentId: post.id,
+                        userId: user.id,
+                      );
+                      if (!mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Tham gia thành công.')),
+                      );
+                    } catch (error) {
+                      final message = error.toString();
+                      if (!mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(message)),
+                      );
+                    }
+                  }
+                : null,
+          );
+        },
+        childCount: recruitmentPosts.length,
+      ),
+    );
+  }
+
+  List<Widget> _buildRecruitmentSlivers(
+    BuildContext context,
+    SocialManager manager,
+    List<RecruitmentPost> recruitmentPosts,
+    String? currentUserId,
+  ) {
+    final slivers = <Widget>[_buildRecruitmentTitle(context)];
+
+    if (manager.isLoadingRecruitments && recruitmentPosts.isEmpty) {
+      slivers.add(_buildLoadingSliver(context));
+      return slivers;
+    }
+
+    if (manager.recruitmentErrorMessage != null && recruitmentPosts.isEmpty) {
+      slivers.add(
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+            child: Text(
+              manager.recruitmentErrorMessage!,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: Theme.of(context).colorScheme.error),
+            ),
+          ),
+        ),
+      );
+      return slivers;
+    }
+
+    if (recruitmentPosts.isEmpty) {
+      slivers.add(
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+            child: Text(
+              'Chưa có bài tuyển nào. Hãy là người đầu tiên tạo bài!',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+        ),
+      );
+      return slivers;
+    }
+
+    slivers.add(
+      _buildRecruitmentList(context, manager, recruitmentPosts, currentUserId),
+    );
+
+    if (manager.isLoadingRecruitments && recruitmentPosts.isNotEmpty) {
+      slivers.add(_buildLoadingSliver(context));
+    }
+
+    return slivers;
+  }
+
+  List<Widget> _buildCommunityPostSlivers(
+    BuildContext context,
+    SocialManager manager,
+    List<CommunityPost> communityPosts,
+  ) {
+    final slivers = <Widget>[
+      SliverToBoxAdapter(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 24, 20, 4),
+          child: Text(
+            'Bảng tin cộng đồng',
+            style:
+                Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+          ),
+        ),
+      ),
+    ];
+
+    if (manager.isLoadingPosts && communityPosts.isEmpty) {
+      slivers.add(_buildLoadingSliver(context));
+      return slivers;
+    }
+
+    if (manager.postErrorMessage != null && communityPosts.isEmpty) {
+      slivers.add(
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+            child: Text(
+              manager.postErrorMessage!,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: Theme.of(context).colorScheme.error),
+            ),
+          ),
+        ),
+      );
+      return slivers;
+    }
+
+    if (communityPosts.isEmpty) {
+      slivers.add(
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+            child: Text(
+              'Chưa có bài đăng nào. Hãy chia sẻ điều gì đó!',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+        ),
+      );
+      return slivers;
+    }
+
+    slivers.add(
+      SliverList(
+        delegate: SliverChildBuilderDelegate(
+          (context, index) {
+            final post = communityPosts[index];
+            return MyPost(
+              content: post.content,
+              userName: post.authorName,
+              time: post.createdAt.toLocal(),
+              imageUrls: post.imageUrls,
+              userAvatarUrl: post.authorAvatarUrl,
+            );
+          },
+          childCount: communityPosts.length,
+        ),
+      ),
+    );
+
+    if (manager.isLoadingPosts && communityPosts.isNotEmpty) {
+      slivers.add(_buildLoadingSliver(context));
+    }
+
+    return slivers;
+  }
+
+  Widget _buildLoadingSliver(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24),
+        child: Center(
+          child: CircularProgressIndicator(
+            color: Theme.of(context).colorScheme.primary,
+          ),
         ),
       ),
     );
@@ -199,8 +373,8 @@ class SocialPage extends StatelessWidget {
                   style: FilledButton.styleFrom(
                     backgroundColor: cs.onPrimary,
                     foregroundColor: cs.primary,
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 20, vertical: 12),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
                   ),
                 ),
               ],
@@ -223,26 +397,4 @@ class SocialPage extends StatelessWidget {
       ),
     );
   }
-}
-
-class _RecruitmentPost {
-  final String hostName;
-  final DateTime createdAt;
-  final int requiredPlayers;
-  final int joinedPlayers;
-  final String? skillLevel;
-  final String? description;
-  final String? courtName;
-  final DateTime? playTime;
-
-  const _RecruitmentPost({
-    required this.hostName,
-    required this.createdAt,
-    required this.requiredPlayers,
-    required this.joinedPlayers,
-    this.skillLevel,
-    this.description,
-    this.courtName,
-    this.playTime,
-  });
 }

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -1,0 +1,81 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/community_post.dart';
+import 'pocketbase_client.dart';
+
+class PostServiceException implements Exception {
+  PostServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class PostService {
+  static const collection = 'posts';
+
+  Future<List<CommunityPost>> fetchPosts({
+    int page = 1,
+    int perPage = 20,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+
+    try {
+      final result = await pocketBase.collection(collection).getList(
+            page: page,
+            perPage: perPage,
+            filter: "is_active = true",
+            expand: 'author',
+            sort: '-created',
+          );
+      return result.items
+          .map((record) => CommunityPost.fromRecord(record, pocketBase))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientException(error));
+    } catch (_) {
+      throw PostServiceException('Không thể tải bài viết. Vui lòng thử lại.');
+    }
+  }
+
+  Future<CommunityPost> createPost({
+    required String authorId,
+    required String content,
+  }) async {
+    final trimmed = content.trim();
+    if (trimmed.isEmpty) {
+      throw PostServiceException('Nội dung bài viết không được để trống.');
+    }
+
+    final pocketBase = await getPocketbaseInstance();
+
+    try {
+      final record = await pocketBase.collection(collection).create(body: {
+        'author': authorId,
+        'content': trimmed,
+        'is_active': true,
+      });
+      final fetched = await pocketBase.collection(collection).getOne(
+            record.id,
+            expand: 'author',
+          );
+      return CommunityPost.fromRecord(fetched, pocketBase);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientException(error));
+    } catch (_) {
+      throw PostServiceException('Không thể đăng bài viết. Vui lòng thử lại.');
+    }
+  }
+
+  String _mapClientException(ClientException error) {
+    final response = error.response;
+    if (response is Map<String, dynamic>) {
+      final message = response['message'] as String?;
+      if (message != null && message.trim().isNotEmpty) {
+        return message.trim();
+      }
+    }
+    return 'Đã có lỗi xảy ra. Vui lòng thử lại.';
+  }
+}

--- a/lib/services/recruitment_service.dart
+++ b/lib/services/recruitment_service.dart
@@ -1,0 +1,164 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/recruitment_post.dart';
+import 'pocketbase_client.dart';
+
+class RecruitmentServiceException implements Exception {
+  RecruitmentServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class RecruitmentService {
+  static const recruitmentCollection = 'recruitment_posts';
+  static const applicantCollection = 'recruitment_applicants';
+
+  Future<List<RecruitmentPost>> fetchRecruitmentPosts({
+    String? currentUserId,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+    final nowIso = DateTime.now().toUtc().toIso8601String();
+    final filter =
+        "is_active = true && (expires_at = null || expires_at = '' || expires_at >= '$nowIso')";
+
+    try {
+      final result = await pocketBase.collection(recruitmentCollection).getList(
+            filter: filter,
+            expand:
+                'author,court,recruitment_applicants(recruitment),recruitment_applicants(recruitment).user',
+            sort: '-created',
+            perPage: 200,
+          );
+      return result.items
+          .map((record) => RecruitmentPost.fromRecord(
+                record,
+                pocketBase,
+                currentUserId: currentUserId,
+              ))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientException(error));
+    } catch (_) {
+      throw RecruitmentServiceException(
+        'Không thể tải bài tuyển thành viên. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<RecruitmentPost> createRecruitmentPost({
+    required String authorId,
+    required String content,
+    required DateTime eventTime,
+    required int targetMemberCount,
+    String? courtId,
+    String? skillLevel,
+    String? playStyle,
+    String? locationNote,
+    DateTime? expiresAt,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+
+    final body = <String, dynamic>{
+      'author': authorId,
+      'content': content.trim(),
+      'event_time': eventTime.toUtc().toIso8601String(),
+      'need_members': targetMemberCount,
+      'is_active': true,
+    };
+
+    if (courtId != null && courtId.isNotEmpty) {
+      body['court'] = courtId;
+    }
+    if (skillLevel != null && skillLevel.isNotEmpty) {
+      body['skill_level'] = skillLevel;
+    }
+    if (playStyle != null && playStyle.isNotEmpty) {
+      body['play_style'] = playStyle;
+    }
+    if (locationNote != null && locationNote.isNotEmpty) {
+      body['location_note'] = locationNote.trim();
+    }
+    if (expiresAt != null) {
+      body['expires_at'] = expiresAt.toUtc().toIso8601String();
+    }
+
+    try {
+      final record = await pocketBase
+          .collection(recruitmentCollection)
+          .create(body: body);
+      final fetched = await pocketBase.collection(recruitmentCollection).getOne(
+            record.id,
+            expand:
+                'author,court,recruitment_applicants(recruitment),recruitment_applicants(recruitment).user',
+          );
+      return RecruitmentPost.fromRecord(
+        fetched,
+        pocketBase,
+        currentUserId: authorId,
+      );
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientException(error));
+    } catch (_) {
+      throw RecruitmentServiceException(
+        'Không thể đăng bài tuyển thành viên. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<void> joinRecruitment({
+    required String recruitmentId,
+    required String userId,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+
+    try {
+      await pocketBase.collection(applicantCollection).create(body: {
+        'recruitment': recruitmentId,
+        'user': userId,
+      });
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientException(error));
+    } catch (_) {
+      throw RecruitmentServiceException(
+        'Không thể tham gia bài tuyển. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  String _mapClientException(ClientException error) {
+    final response = error.response;
+    if (response is Map<String, dynamic>) {
+      final message = response['message'] as String?;
+      if (message != null && message.trim().isNotEmpty) {
+        return message.trim();
+      }
+
+      final data = response['data'];
+      if (data is Map<String, dynamic>) {
+        final recruitmentError = data['recruitment'];
+        final userError = data['user'];
+        final msgBuffer = StringBuffer();
+        if (recruitmentError is Map<String, dynamic>) {
+          final message = recruitmentError['message'] as String?;
+          if (message != null && message.trim().isNotEmpty) {
+            msgBuffer.write(message.trim());
+          }
+        }
+        if (userError is Map<String, dynamic>) {
+          final message = userError['message'] as String?;
+          if (message != null && message.trim().isNotEmpty) {
+            if (msgBuffer.isNotEmpty) msgBuffer.write('\n');
+            msgBuffer.write(message.trim());
+          }
+        }
+        if (msgBuffer.isNotEmpty) {
+          return msgBuffer.toString();
+        }
+      }
+    }
+    return 'Đã có lỗi xảy ra. Vui lòng thử lại.';
+  }
+}


### PR DESCRIPTION
## Summary
- add PocketBase-backed models and services for community posts and recruitment workflows
- introduce SocialManager and update the social feed to create posts, list recruitment cards, and handle join actions
- enhance the recruitment form with booking validation, provider-driven state, and improved widgets

## Testing
- ⚠️ `flutter pub get` *(command not available in container)*
- ⚠️ `dart format lib` *(command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690ce2697d90832bbd89d28999db9645