### PR TITLE
feat: enable social posting and recruitment flows

### DIFF
--- a/lib/components/create_post.dart
+++ b/lib/components/create_post.dart
@@ -1,0 +1,217 @@
+// lib/widgets/create_post_bar.dart
+import 'package:flutter/material.dart';
+
+class CreatePostBar extends StatelessWidget {
+  const CreatePostBar({
+    super.key,
+    required this.onCreatePost,
+    this.onPickPhoto,
+    this.onInviteFriends,
+    this.avatarImageProvider,
+    this.hintText = 'Bạn đang nghĩ gì thế?',
+    this.backgroundColor,
+    this.primaryColor,
+    this.elevation = 1.0,
+    this.compact = false,
+  });
+
+  /// Tap vào “ô nhập” để mở trang tạo bài viết
+  final VoidCallback onCreatePost;
+
+  /// Các action bên dưới (tùy chọn)
+  final VoidCallback? onPickPhoto;
+  final VoidCallback? onInviteFriends;
+
+  /// Ảnh đại diện (NetworkImage/FileImage/AssetImage…)
+  final ImageProvider? avatarImageProvider;
+
+  /// Placeholder trong ô nhập
+  final String hintText;
+
+  /// Màu nền khối
+  final Color? backgroundColor;
+
+  /// Màu chủ đạo (icon/nhấn)
+  final Color? primaryColor;
+
+  /// Độ nổi khối thẻ (0 = phẳng)
+  final double elevation;
+
+  /// Chế độ gọn hơn (ẩn hàng action)
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final basePrimary = primaryColor ?? colorScheme.primary;
+
+    return Material(
+      elevation: elevation,
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        decoration: BoxDecoration(
+          color: backgroundColor ?? theme.cardColor,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: colorScheme.outline),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Hàng avatar + “ô nhập”
+            Row(
+              children: [
+                _Avatar(imageProvider: avatarImageProvider),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: _FakeInput(
+                    hintText: hintText,
+                    onTap: onCreatePost,
+                  ),
+                ),
+              ],
+            ),
+            if (!compact) const SizedBox(height: 8),
+            if (!compact)
+              Divider(
+                height: 16,
+                thickness: 0.8,
+                color: theme.dividerColor.withOpacity(0.6),
+              ),
+            if (!compact) const SizedBox(height: 2),
+            if (!compact)
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  _Action(
+                    icon: Icons.photo_library_outlined,
+                    label: 'Ảnh',
+                    onTap: onPickPhoto,
+                    activeColor: basePrimary,
+                  ),
+                  _Action(
+                    icon: Icons.person_add_alt_1_outlined,
+                    label: 'Mời bạn bè',
+                    onTap: onInviteFriends,
+                    activeColor: basePrimary,
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar({this.imageProvider});
+
+  final ImageProvider? imageProvider;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return CircleAvatar(
+      radius: 30,
+      backgroundColor: theme.colorScheme.surfaceVariant,
+      backgroundImage: imageProvider,
+      child: imageProvider == null
+          ? Icon(Icons.person, color: theme.colorScheme.onSurfaceVariant)
+          : null,
+    );
+  }
+}
+
+class _FakeInput extends StatelessWidget {
+  const _FakeInput({
+    required this.hintText,
+    required this.onTap,
+  });
+
+  final String hintText;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = Theme.of(context).colorScheme;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(24),
+      child: Container(
+        height: 55,
+        padding: const EdgeInsets.symmetric(horizontal: 14),
+        alignment: Alignment.centerLeft,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(color: cs.outline),
+        ),
+        child: Text(
+          hintText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontSize: 16, // ✅ thêm dòng này để tăng font size
+            color: theme.hintColor,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Action extends StatelessWidget {
+  const _Action({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    required this.activeColor,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onTap;
+  final Color activeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isEnabled = onTap != null;
+
+    return Expanded(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          height: 40,
+          alignment: Alignment.center,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                icon,
+                size: 20,
+                color: isEnabled ? activeColor : theme.disabledColor,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: isEnabled
+                      ? theme.textTheme.bodyMedium?.color
+                      : theme.disabledColor,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/my_post.dart
+++ b/lib/components/my_post.dart
@@ -1,157 +1,226 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-class MyPost extends StatelessWidget {
-  final String message;
-  final String userName;
-  final DateTime time;
-  final VoidCallback? onLikePressed;
-
+class MyPost extends StatefulWidget {
   const MyPost({
     super.key,
-    required this.message,
+    required this.content,
     required this.userName,
     required this.time,
+    this.imageUrls = const [],
     this.onLikePressed,
   });
 
+  final String content;
+  final String userName;
+  final DateTime time;
+  final List<String> imageUrls;
+  final VoidCallback? onLikePressed;
+
+  @override
+  State<MyPost> createState() => _MyPostState();
+}
+
+class _MyPostState extends State<MyPost> {
+  late final PageController _pageController;
+  int _currentIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    final isImage = message.startsWith('http') ||
-        message.startsWith('https') &&
-            (message.contains('.jpg') ||
-                message.contains('.png') ||
-                message.contains('cloudinary'));
+    final cs = Theme.of(context).colorScheme;
+    final hasImages = widget.imageUrls.isNotEmpty;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      child: Material(
+        elevation: 6,
+        borderRadius: BorderRadius.circular(24),
+        color: cs.surface,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildHeader(context),
+            if (hasImages) _buildImageCarousel(context),
+            if (widget.content.trim().isNotEmpty) _buildMessage(context),
+            _buildActionBar(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
     return Padding(
-      padding: const EdgeInsets.all(20),
-      child: Material(
-        elevation: 6,
-        borderRadius: BorderRadius.circular(25),
-        child: Container(
-          decoration: BoxDecoration(
-            color: cs.surface,
-            borderRadius: BorderRadius.circular(25),
-            border: Border.all(color: cs.outline),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 26,
+            backgroundColor: cs.primary,
+            child: Text(
+              widget.userName.isNotEmpty
+                  ? widget.userName[0].toUpperCase()
+                  : 'U',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(color: cs.onPrimary, fontWeight: FontWeight.bold),
+            ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header
-              Padding(
-                padding: const EdgeInsets.only(
-                    top: 15, bottom: 15, left: 15, right: 15),
-                child: Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(10),
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.primary,
-                        borderRadius: BorderRadius.circular(30),
-                      ),
-                      child: const Icon(
-                        Icons.person,
-                        size: 35,
-                        color: Colors.white,
-                      ),
-                    ),
-                    const SizedBox(width: 15),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          userName,
-                          style: const TextStyle(
-                            color: Colors.black87,
-                            fontWeight: FontWeight.bold,
-                            fontSize: 16,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          softWrap: false,
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  widget.userName,
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w700),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  DateFormat('dd/MM/yyyy HH:mm').format(widget.time),
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: cs.onSurfaceVariant),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.more_horiz_rounded),
+            color: cs.onSurfaceVariant,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildImageCarousel(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(24),
+        child: Stack(
+          alignment: Alignment.bottomCenter,
+          children: [
+            AspectRatio(
+              aspectRatio: 4 / 5,
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: widget.imageUrls.length,
+                onPageChanged: (index) => setState(() => _currentIndex = index),
+                itemBuilder: (context, index) {
+                  return Ink.image(
+                    image: NetworkImage(widget.imageUrls[index]),
+                    fit: BoxFit.cover,
+                  );
+                },
+              ),
+            ),
+            if (widget.imageUrls.length > 1)
+              Positioned(
+                bottom: 12,
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: cs.surface.withOpacity(0.7),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: List.generate(widget.imageUrls.length, (index) {
+                      final isActive = _currentIndex == index;
+                      return AnimatedContainer(
+                        duration: const Duration(milliseconds: 250),
+                        margin: const EdgeInsets.symmetric(horizontal: 3),
+                        width: isActive ? 10 : 6,
+                        height: 6,
+                        decoration: BoxDecoration(
+                          color: isActive
+                              ? cs.primary
+                              : cs.onSurfaceVariant.withOpacity(0.4),
+                          borderRadius: BorderRadius.circular(12),
                         ),
-                        Text(
-                          DateFormat('dd-MM-yyyy HH:mm').format((time)),
-                          style: const TextStyle(
-                            color: Colors.black87,
-                            fontWeight: FontWeight.w400,
-                            fontSize: 14,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const Spacer(),
-                    const Icon(Icons.more_vert, color: Colors.grey, size: 30),
-                  ],
+                      );
+                    }),
+                  ),
                 ),
               ),
-
-              // Post message
-              isImage
-                  ? ClipRRect(
-                      borderRadius: BorderRadius.circular(0),
-                      child: Center(
-                        child: Image.network(
-                          message,
-                          fit: BoxFit.cover,
-                          width: MediaQuery.of(context).size.width,
-                        ),
-                      ),
-                    )
-                  : Padding(
-                      padding:
-                          const EdgeInsets.only(left: 20, top: 10, bottom: 10),
-                      child: Text(
-                        message,
-                        style: const TextStyle(
-                          color: Colors.black87,
-                          fontSize: 20,
-                        ),
-                      ),
-                    ),
-
-              // Action bar
-              Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
-                child: Row(
-                  children: [
-                    GestureDetector(
-                      onTap: onLikePressed,
-                      child: Icon(
-                        Icons.favorite_border,
-                        color: Colors.grey,
-                        size: 30,
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      '100',
-                      style: const TextStyle(
-                        color: Colors.black87,
-                        fontWeight: FontWeight.w400,
-                        fontSize: 18,
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    IconButton(
-                      icon: const Icon(Icons.comment_outlined,
-                          color: Colors.grey, size: 30),
-                      onPressed: () {},
-                    ),
-                    const SizedBox(width: 10),
-                    const Icon(Icons.send_outlined,
-                        color: Colors.grey, size: 30),
-                    const Spacer(),
-                    const Icon(Icons.bookmark_border,
-                        color: Colors.grey, size: 30),
-                  ],
-                ),
-              ),
-            ],
-          ),
+          ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildMessage(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      child: Text(
+        widget.content,
+        style: Theme.of(context)
+            .textTheme
+            .bodyLarge
+            ?.copyWith(height: 1.4, fontWeight: FontWeight.w500),
+      ),
+    );
+  }
+
+  Widget _buildActionBar(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      child: Row(
+        children: [
+          IconButton(
+            onPressed: widget.onLikePressed,
+            icon: Icon(Icons.favorite_border, color: cs.onSurfaceVariant),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            'Thích',
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(color: cs.onSurfaceVariant),
+          ),
+          const SizedBox(width: 20),
+          Icon(Icons.chat_bubble_outline_rounded,
+              color: cs.onSurfaceVariant),
+          const SizedBox(width: 8),
+          Text(
+            'Bình luận',
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(color: cs.onSurfaceVariant),
+          ),
+          const Spacer(),
+          Icon(Icons.bookmark_border, color: cs.onSurfaceVariant),
+        ],
       ),
     );
   }

--- a/lib/components/my_post.dart
+++ b/lib/components/my_post.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 class MyPost extends StatefulWidget {
   const MyPost({
@@ -9,13 +8,27 @@ class MyPost extends StatefulWidget {
     required this.time,
     this.imageUrls = const [],
     this.onLikePressed,
+    this.onCommentPressed,
+    this.onSharePressed,
+    this.onSavePressed,
+    this.isLiked = false,
+    this.likesCount,
   });
 
   final String content;
   final String userName;
   final DateTime time;
   final List<String> imageUrls;
+
+  // Actions
   final VoidCallback? onLikePressed;
+  final VoidCallback? onCommentPressed;
+  final VoidCallback? onSharePressed;
+  final VoidCallback? onSavePressed;
+
+  // UI state (optional)
+  final bool isLiked;
+  final int? likesCount;
 
   @override
   State<MyPost> createState() => _MyPostState();
@@ -24,11 +37,13 @@ class MyPost extends StatefulWidget {
 class _MyPostState extends State<MyPost> {
   late final PageController _pageController;
   int _currentIndex = 0;
+  late bool _liked;
 
   @override
   void initState() {
     super.initState();
     _pageController = PageController();
+    _liked = widget.isLiked;
   }
 
   @override
@@ -37,190 +52,239 @@ class _MyPostState extends State<MyPost> {
     super.dispose();
   }
 
+  // ---------------- UI ----------------
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final hasImages = widget.imageUrls.isNotEmpty;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-      child: Material(
-        elevation: 6,
-        borderRadius: BorderRadius.circular(24),
-        color: cs.surface,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildHeader(context),
-            if (hasImages) _buildImageCarousel(context),
-            if (widget.content.trim().isNotEmpty) _buildMessage(context),
-            _buildActionBar(context),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildHeader(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-      child: Row(
-        children: [
-          CircleAvatar(
-            radius: 26,
-            backgroundColor: cs.primary,
-            child: Text(
-              widget.userName.isNotEmpty
-                  ? widget.userName[0].toUpperCase()
-                  : 'U',
-              style: Theme.of(context)
-                  .textTheme
-                  .titleMedium
-                  ?.copyWith(color: cs.onPrimary, fontWeight: FontWeight.bold),
-            ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Header
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 20,
+                backgroundColor: cs.primary,
+                child: Text(
+                  widget.userName.isNotEmpty
+                      ? widget.userName[0].toUpperCase()
+                      : 'U',
+                  style: TextStyle(
+                    color: cs.onPrimary,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
                   widget.userName,
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleMedium
-                      ?.copyWith(fontWeight: FontWeight.w700),
-                  maxLines: 1,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w500,
+                    fontSize: 18,
+                  ),
                   overflow: TextOverflow.ellipsis,
                 ),
-                const SizedBox(height: 4),
-                Text(
-                  DateFormat('dd/MM/yyyy HH:mm').format(widget.time),
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodySmall
-                      ?.copyWith(color: cs.onSurfaceVariant),
+              ),
+              IconButton(
+                visualDensity: VisualDensity.compact,
+                onPressed: () {},
+                icon: const Icon(Icons.more_horiz_rounded),
+                color: cs.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+
+        // Image (square, pageable)
+        if (hasImages)
+          _SquareMedia(
+            child: Stack(
+              alignment: Alignment.bottomCenter,
+              children: [
+                PageView.builder(
+                  controller: _pageController,
+                  itemCount: widget.imageUrls.length,
+                  onPageChanged: (i) => setState(() => _currentIndex = i),
+                  itemBuilder: (_, i) => Ink.image(
+                    image: NetworkImage(widget.imageUrls[i]),
+                    fit: BoxFit.cover,
+                  ),
                 ),
+                if (widget.imageUrls.length > 1)
+                  Positioned(
+                    bottom: 10,
+                    child: _Dots(
+                      length: widget.imageUrls.length,
+                      index: _currentIndex,
+                    ),
+                  ),
               ],
             ),
           ),
-          IconButton(
-            onPressed: () {},
-            icon: const Icon(Icons.more_horiz_rounded),
-            color: cs.onSurfaceVariant,
-          ),
-        ],
-      ),
-    );
-  }
 
-  Widget _buildImageCarousel(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(24),
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            AspectRatio(
-              aspectRatio: 4 / 5,
-              child: PageView.builder(
-                controller: _pageController,
-                itemCount: widget.imageUrls.length,
-                onPageChanged: (index) => setState(() => _currentIndex = index),
-                itemBuilder: (context, index) {
-                  return Ink.image(
-                    image: NetworkImage(widget.imageUrls[index]),
-                    fit: BoxFit.cover,
-                  );
+        // Action row
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          child: Row(
+            children: [
+              IconButton(
+                onPressed: () {
+                  setState(() => _liked = !_liked);
+                  widget.onLikePressed?.call();
                 },
+                icon: Icon(
+                  _liked ? Icons.favorite : Icons.favorite_border,
+                  size: 30,
+                ),
+                color: _liked ? Colors.red : cs.onSurface,
               ),
-            ),
-            if (widget.imageUrls.length > 1)
-              Positioned(
-                bottom: 12,
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  decoration: BoxDecoration(
-                    color: cs.surface.withOpacity(0.7),
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: List.generate(widget.imageUrls.length, (index) {
-                      final isActive = _currentIndex == index;
-                      return AnimatedContainer(
-                        duration: const Duration(milliseconds: 250),
-                        margin: const EdgeInsets.symmetric(horizontal: 3),
-                        width: isActive ? 10 : 6,
-                        height: 6,
-                        decoration: BoxDecoration(
-                          color: isActive
-                              ? cs.primary
-                              : cs.onSurfaceVariant.withOpacity(0.4),
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      );
-                    }),
-                  ),
+              IconButton(
+                onPressed: widget.onCommentPressed,
+                icon: const Icon(
+                  Icons.chat_bubble_outline_rounded,
+                  size: 25,
                 ),
               ),
-          ],
+              IconButton(
+                onPressed: widget.onSharePressed,
+                icon: const Icon(
+                  Icons.send_outlined,
+                  size: 25,
+                ),
+              ),
+              const Spacer(),
+              IconButton(
+                onPressed: widget.onSavePressed,
+                icon: const Icon(
+                  Icons.bookmark_border,
+                  size: 30,
+                ),
+              ),
+            ],
+          ),
         ),
-      ),
-    );
-  }
 
-  Widget _buildMessage(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-      child: Text(
-        widget.content,
-        style: Theme.of(context)
-            .textTheme
-            .bodyLarge
-            ?.copyWith(height: 1.4, fontWeight: FontWeight.w500),
-      ),
-    );
-  }
+        // Likes (optional)
+        if ((widget.likesCount ?? 0) > 0)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              '${widget.likesCount} lượt thích',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+          ),
 
-  Widget _buildActionBar(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-      child: Row(
-        children: [
-          IconButton(
-            onPressed: widget.onLikePressed,
-            icon: Icon(Icons.favorite_border, color: cs.onSurfaceVariant),
+        // Caption: Username + content (like Instagram)
+        if (widget.content.trim().isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(
+                    text: '${widget.userName} ',
+                    style: const TextStyle(
+                        fontWeight: FontWeight.w700, fontSize: 16),
+                  ),
+                  TextSpan(
+                    text: widget.content,
+                    style: const TextStyle(fontSize: 15),
+                  ),
+                ],
+              ),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    height: 1.35,
+                  ),
+            ),
           ),
-          const SizedBox(width: 8),
-          Text(
-            'Thích',
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: cs.onSurfaceVariant),
-          ),
-          const SizedBox(width: 20),
-          Icon(Icons.chat_bubble_outline_rounded,
-              color: cs.onSurfaceVariant),
-          const SizedBox(width: 8),
-          Text(
-            'Bình luận',
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: cs.onSurfaceVariant),
-          ),
-          const Spacer(),
-          Icon(Icons.bookmark_border, color: cs.onSurfaceVariant),
         ],
+
+        // Time ago
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 4, 12, 12),
+          child: Text(
+            _timeAgo(widget.time).toUpperCase(),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                  letterSpacing: 0.2,
+                ),
+          ),
+        ),
+
+        // Thin divider between posts
+        Divider(height: 1, color: cs.outlineVariant.withOpacity(0.6)),
+      ],
+    );
+  }
+
+  // -------- Helpers --------
+
+  String _timeAgo(DateTime t) {
+    final diff = DateTime.now().difference(t);
+    if (diff.inMinutes < 1) return 'VỪA XONG';
+    if (diff.inMinutes < 60) return '${diff.inMinutes} phút';
+    if (diff.inHours < 24) return '${diff.inHours} giờ';
+    if (diff.inDays < 7) return '${diff.inDays} ngày';
+    final weeks = (diff.inDays / 7).floor();
+    if (weeks < 5) return '$weeks tuần';
+    final months = (diff.inDays / 30).floor();
+    if (months < 12) return '$months tháng';
+    final years = (diff.inDays / 365).floor();
+    return '$years năm';
+  }
+}
+
+/// Keeps media square like Instagram feed
+class _SquareMedia extends StatelessWidget {
+  const _SquareMedia({required this.child});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(aspectRatio: 1, child: child);
+  }
+}
+
+/// Minimal dot indicator
+class _Dots extends StatelessWidget {
+  const _Dots({required this.length, required this.index});
+  final int length;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: cs.surface.withOpacity(0.7),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(length, (i) {
+          final active = i == index;
+          return AnimatedContainer(
+            duration: const Duration(milliseconds: 220),
+            margin: const EdgeInsets.symmetric(horizontal: 3),
+            width: active ? 10 : 6,
+            height: 6,
+            decoration: BoxDecoration(
+              color:
+                  active ? cs.primary : cs.onSurfaceVariant.withOpacity(0.35),
+              borderRadius: BorderRadius.circular(10),
+            ),
+          );
+        }),
       ),
     );
   }

--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -77,16 +77,17 @@ class RecruitmentPostCard extends StatelessWidget {
                     ),
                   ),
                   FilledButton.icon(
-                    onPressed: (isJoined || isOwner || isJoinLoading)
-                        ? null
-                        : onJoin,
+                    onPressed:
+                        (isJoined || isOwner || isJoinLoading) ? null : onJoin,
                     icon: isJoinLoading
                         ? const SizedBox(
                             width: 18,
                             height: 18,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : Icon(isJoined ? Icons.check_circle : Icons.add_circle_outline),
+                        : Icon(isJoined
+                            ? Icons.check_circle
+                            : Icons.add_circle_outline),
                     label: Text(
                       isOwner
                           ? 'Bài của bạn'
@@ -133,18 +134,11 @@ class RecruitmentPostCard extends StatelessWidget {
                       color: cs.tertiaryContainer,
                       iconColor: cs.tertiary,
                     ),
-                  if ((locationNote ?? '').trim().isNotEmpty)
-                    _InfoChip(
-                      icon: Icons.map_outlined,
-                      label: 'Địa điểm: ${locationNote!.trim()}',
-                      color: cs.surfaceVariant,
-                      iconColor: cs.primary,
-                    ),
                   if (playTime != null)
                     _InfoChip(
                       icon: Icons.access_time,
                       label:
-                          'Giờ đánh: ${DateFormat('HH:mm dd/MM').format(playTime!)}',
+                          'Giờ đánh: ${DateFormat('HH:mm - dd/MM').format(playTime!)}',
                       color: cs.surfaceVariant,
                       iconColor: cs.primary,
                     ),
@@ -187,7 +181,8 @@ class RecruitmentPostCard extends StatelessWidget {
               const SizedBox(height: 4),
               Text(
                 DateFormat('dd/MM/yyyy HH:mm').format(createdTime),
-                style: textTheme.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                style:
+                    textTheme.bodySmall?.copyWith(color: cs.onSurfaceVariant),
               ),
             ],
           ),

--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -11,6 +11,10 @@ class RecruitmentPostCard extends StatelessWidget {
   final String? courtName;
   final DateTime? playTime;
   final VoidCallback? onJoin;
+  final String? playStyle;
+  final bool isJoined;
+  final bool isOwner;
+  final bool isJoinLoading;
 
   const RecruitmentPostCard({
     super.key,
@@ -23,6 +27,10 @@ class RecruitmentPostCard extends StatelessWidget {
     this.courtName,
     this.playTime,
     this.onJoin,
+    this.playStyle,
+    this.isJoined = false,
+    this.isOwner = false,
+    this.isJoinLoading = false,
   });
 
   @override
@@ -67,9 +75,23 @@ class RecruitmentPostCard extends StatelessWidget {
                     ),
                   ),
                   FilledButton.icon(
-                    onPressed: onJoin,
-                    icon: const Icon(Icons.add_circle_outline),
-                    label: const Text('Tham gia'),
+                    onPressed: (isJoined || isOwner || isJoinLoading)
+                        ? null
+                        : onJoin,
+                    icon: isJoinLoading
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Icon(isJoined ? Icons.check_circle : Icons.add_circle_outline),
+                    label: Text(
+                      isOwner
+                          ? 'Bài của bạn'
+                          : isJoined
+                              ? 'Đã tham gia'
+                              : 'Tham gia',
+                    ),
                   ),
                 ],
               ),
@@ -95,12 +117,13 @@ class RecruitmentPostCard extends StatelessWidget {
                       color: cs.primaryContainer,
                       iconColor: cs.primary,
                     ),
-                  _InfoChip(
-                    icon: Icons.sports_tennis,
-                    label: 'Loại hình: Đánh đơn/đôi',
-                    color: cs.secondaryContainer,
-                    iconColor: cs.secondary,
-                  ),
+                  if (playStyle != null && playStyle!.isNotEmpty)
+                    _InfoChip(
+                      icon: Icons.sports_tennis,
+                      label: 'Lối chơi: $playStyle',
+                      color: cs.secondaryContainer,
+                      iconColor: cs.secondary,
+                    ),
                   if (courtName != null && courtName!.isNotEmpty)
                     _InfoChip(
                       icon: Icons.location_on_outlined,
@@ -221,6 +244,7 @@ class _InfoChip extends StatelessWidget {
                   fontWeight: FontWeight.w600,
                   color: Theme.of(context).colorScheme.onSurface,
                 ),
+            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),

--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -10,6 +10,7 @@ class RecruitmentPostCard extends StatelessWidget {
   final String? description;
   final String? courtName;
   final DateTime? playTime;
+  final String? locationNote;
   final VoidCallback? onJoin;
   final String? playStyle;
   final bool isJoined;
@@ -26,6 +27,7 @@ class RecruitmentPostCard extends StatelessWidget {
     this.description,
     this.courtName,
     this.playTime,
+    this.locationNote,
     this.onJoin,
     this.playStyle,
     this.isJoined = false,
@@ -130,6 +132,13 @@ class RecruitmentPostCard extends StatelessWidget {
                       label: 'Sân: $courtName',
                       color: cs.tertiaryContainer,
                       iconColor: cs.tertiary,
+                    ),
+                  if ((locationNote ?? '').trim().isNotEmpty)
+                    _InfoChip(
+                      icon: Icons.map_outlined,
+                      label: 'Địa điểm: ${locationNote!.trim()}',
+                      color: cs.surfaceVariant,
+                      iconColor: cs.primary,
                     ),
                   if (playTime != null)
                     _InfoChip(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
+import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -22,6 +23,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => AuthManager()),
         ChangeNotifierProvider(create: (_) => UserManager()),
         ChangeNotifierProvider(create: (_) => CourtManager()),
+        ChangeNotifierProvider(create: (_) => SocialManager()),
       ],
       child: const MyApp(),
     ),

--- a/lib/models/community_post.dart
+++ b/lib/models/community_post.dart
@@ -1,0 +1,92 @@
+import 'package:pocketbase/pocketbase.dart';
+
+class CommunityPost {
+  const CommunityPost({
+    required this.id,
+    required this.authorId,
+    required this.authorName,
+    required this.content,
+    required this.imageUrls,
+    required this.isActive,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory CommunityPost.fromRecord(RecordModel record, PocketBase pocketBase) {
+    final data = record.data;
+    final rawImages = data['images'];
+
+    final imageUrls = <String>[];
+    final fileNames = _normalizeFileList(rawImages);
+    for (final fileName in fileNames) {
+      final url = pocketBase.files.getUrl(record, fileName).toString();
+      imageUrls.add(url);
+    }
+
+    final authorRecord = _resolveExpandedRecord(record.expand?['author']);
+    final authorData = authorRecord?.data;
+    final displayName = _sanitizeName(
+      (authorData?['username'] as String?) ??
+          (authorData?['email'] as String?) ??
+          'Người dùng',
+    );
+
+    return CommunityPost(
+      id: record.id,
+      authorId: (data['author'] as String?) ?? authorRecord?.id ?? '',
+      authorName: displayName,
+      content: (data['content'] as String?)?.trim() ?? '',
+      imageUrls: imageUrls,
+      isActive: data['is_active'] == true,
+      createdAt: DateTime.parse(data['created'] as String),
+      updatedAt: DateTime.parse(data['updated'] as String),
+    );
+  }
+
+  final String id;
+  final String authorId;
+  final String authorName;
+  final String content;
+  final List<String> imageUrls;
+  final bool isActive;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  bool get hasImages => imageUrls.isNotEmpty;
+}
+
+List<String> _normalizeFileList(dynamic value) {
+  if (value is String && value.isNotEmpty) {
+    return [value];
+  }
+  if (value is List) {
+    return value
+        .whereType<String>()
+        .map((name) => name.trim())
+        .where((name) => name.isNotEmpty)
+        .toList();
+  }
+  return const [];
+}
+
+RecordModel? _resolveExpandedRecord(dynamic expanded) {
+  if (expanded is RecordModel) {
+    return expanded;
+  }
+  if (expanded is List) {
+    for (final item in expanded) {
+      if (item is RecordModel) {
+        return item;
+      }
+    }
+  }
+  return null;
+}
+
+String _sanitizeName(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) {
+    return 'Người dùng';
+  }
+  return trimmed;
+}

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -31,17 +31,19 @@ class RecruitmentPost {
     final authorData = authorRecord?.data;
     final authorId = (data['author'] as String?) ?? authorRecord?.id ?? '';
     final authorName = _sanitizeName(
-      (authorData?['username'] as String?) ??
-          (authorData?['email'] as String?) ??
-          'Người chơi',
-    );
+          (authorData?['username'] as String?) ??
+              (authorData?['email'] as String?),
+          // Bỏ fallback 'Người chơi' ở trong này
+        ) ??
+        'Người chơi';
 
     final courtRecord = _resolveExpandedRecord(record.expand?['court']);
     final courtData = courtRecord?.data;
     final courtName = _sanitizeName(courtData?['name'] as String?);
 
     final applicantUserIds = applicants
-        .map((rec) => (rec.data['user'] as String?) ?? rec.getStringValue('user'))
+        .map((rec) =>
+            (rec.data['user'] as String?) ?? rec.getStringValue('user'))
         .where((id) => id != null && id.isNotEmpty)
         .cast<String>()
         .toList();

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -1,0 +1,140 @@
+import 'package:badminton_booking_app/utils/recruitment_dictionary.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+class RecruitmentPost {
+  const RecruitmentPost({
+    required this.id,
+    required this.authorId,
+    required this.authorName,
+    required this.description,
+    required this.requiredPlayers,
+    required this.joinedPlayers,
+    required this.skillLevel,
+    required this.playStyle,
+    required this.createdAt,
+    required this.eventTime,
+    required this.courtName,
+    required this.isJoined,
+    required this.isOwner,
+    required this.locationNote,
+  });
+
+  factory RecruitmentPost.fromRecord({
+    required RecordModel record,
+    required PocketBase pocketBase,
+    required String? currentUserId,
+    List<RecordModel> applicants = const [],
+  }) {
+    final data = record.data;
+
+    final authorRecord = _resolveExpandedRecord(record.expand?['author']);
+    final authorData = authorRecord?.data;
+    final authorId = (data['author'] as String?) ?? authorRecord?.id ?? '';
+    final authorName = _sanitizeName(
+      (authorData?['username'] as String?) ??
+          (authorData?['email'] as String?) ??
+          'Người chơi',
+    );
+
+    final courtRecord = _resolveExpandedRecord(record.expand?['court']);
+    final courtData = courtRecord?.data;
+    final courtName = _sanitizeName(courtData?['name'] as String?);
+
+    final applicantUserIds = applicants
+        .map((rec) => (rec.data['user'] as String?) ?? rec.getStringValue('user'))
+        .where((id) => id != null && id.isNotEmpty)
+        .cast<String>()
+        .toList();
+
+    final joinedCount = applicantUserIds.length + 1; // tính cả chủ bài
+    final hasJoined = applicantUserIds.contains(currentUserId);
+
+    return RecruitmentPost(
+      id: record.id,
+      authorId: authorId,
+      authorName: authorName,
+      description: (data['content'] as String?)?.trim() ?? '',
+      requiredPlayers: (data['need_members'] as int?) ?? 0,
+      joinedPlayers: joinedCount,
+      skillLevel:
+          RecruitmentDictionary.skillLabelFromValue(data['skill_level']),
+      playStyle: RecruitmentDictionary.playStyleLabelFromValue(
+        data['play_style'] as String?,
+      ),
+      createdAt: DateTime.parse(data['created'] as String),
+      eventTime: _tryParseDateTime(data['event_time']),
+      courtName: courtName,
+      isJoined: hasJoined || authorId == currentUserId,
+      isOwner: authorId == currentUserId,
+      locationNote: (data['location_note'] as String?)?.trim(),
+    );
+  }
+
+  final String id;
+  final String authorId;
+  final String authorName;
+  final String description;
+  final int requiredPlayers;
+  final int joinedPlayers;
+  final String skillLevel;
+  final String playStyle;
+  final DateTime createdAt;
+  final DateTime? eventTime;
+  final String? courtName;
+  final bool isJoined;
+  final bool isOwner;
+  final String? locationNote;
+
+  RecruitmentPost copyWith({
+    int? joinedPlayers,
+    bool? isJoined,
+  }) {
+    return RecruitmentPost(
+      id: id,
+      authorId: authorId,
+      authorName: authorName,
+      description: description,
+      requiredPlayers: requiredPlayers,
+      joinedPlayers: joinedPlayers ?? this.joinedPlayers,
+      skillLevel: skillLevel,
+      playStyle: playStyle,
+      createdAt: createdAt,
+      eventTime: eventTime,
+      courtName: courtName,
+      isJoined: isJoined ?? this.isJoined,
+      isOwner: isOwner,
+      locationNote: locationNote,
+    );
+  }
+}
+
+RecordModel? _resolveExpandedRecord(dynamic expanded) {
+  if (expanded is RecordModel) {
+    return expanded;
+  }
+  if (expanded is List) {
+    for (final item in expanded) {
+      if (item is RecordModel) {
+        return item;
+      }
+    }
+  }
+  return null;
+}
+
+String? _sanitizeName(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) {
+    return null;
+  }
+  return trimmed;
+}
+
+DateTime? _tryParseDateTime(dynamic value) {
+  if (value == null) return null;
+  if (value is DateTime) return value.toLocal();
+  if (value is String && value.isNotEmpty) {
+    return DateTime.tryParse(value)?.toLocal();
+  }
+  return null;
+}

--- a/lib/pages/nav_bar_page.dart
+++ b/lib/pages/nav_bar_page.dart
@@ -3,8 +3,10 @@ import 'package:badminton_booking_app/pages/court/court_page.dart';
 import 'package:badminton_booking_app/pages/home/home_page.dart';
 import 'package:badminton_booking_app/pages/user/profile_page.dart';
 import 'package:badminton_booking_app/pages/social/social_page.dart';
+import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:curved_navigation_bar/curved_navigation_bar.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class NavBarPage extends StatefulWidget {
   const NavBarPage({super.key});
@@ -21,6 +23,10 @@ class _NavBarPageState extends State<NavBarPage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<UserManager>().loadMe(); // nạp cache lần đầu
+    });
     _pages = [
       HomePage(),
       SocialPage(),

--- a/lib/pages/social/create_post_page.dart
+++ b/lib/pages/social/create_post_page.dart
@@ -1,0 +1,171 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+
+import 'social_manager.dart';
+
+class CreatePostPage extends StatefulWidget {
+  const CreatePostPage({super.key});
+
+  @override
+  State<CreatePostPage> createState() => _CreatePostPageState();
+}
+
+class _CreatePostPageState extends State<CreatePostPage> {
+  final TextEditingController _contentController = TextEditingController();
+  final List<XFile> _selectedImages = [];
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImages() async {
+    final picker = ImagePicker();
+    try {
+      final images = await picker.pickMultiImage(imageQuality: 85);
+      if (images.isEmpty) return;
+      setState(() => _selectedImages.addAll(images));
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Không thể chọn ảnh: $error')),
+      );
+    }
+  }
+
+  void _removeImage(int index) {
+    setState(() => _selectedImages.removeAt(index));
+  }
+
+  Future<void> _submit() async {
+    final manager = context.read<SocialManager>();
+    final content = _contentController.text.trim();
+    if (content.isEmpty && _selectedImages.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Vui lòng nhập nội dung hoặc chọn ảnh.')),
+      );
+      return;
+    }
+
+    setState(() => _isSubmitting = true);
+    try {
+      final files = _selectedImages.map((image) => File(image.path)).toList();
+      await manager.createPost(content: content, images: files);
+      if (mounted) {
+        Navigator.of(context).pop(true);
+      }
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Đăng bài cộng đồng')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(20),
+          children: [
+            TextField(
+              controller: _contentController,
+              maxLines: 5,
+              decoration: const InputDecoration(
+                labelText: 'Chia sẻ điều gì đó...',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                ..._selectedImages.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final image = entry.value;
+                  return Stack(
+                    alignment: Alignment.topRight,
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(18),
+                        child: Image.file(
+                          File(image.path),
+                          width: 120,
+                          height: 120,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      Positioned(
+                        top: 4,
+                        right: 4,
+                        child: InkWell(
+                          onTap: () => _removeImage(index),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: cs.errorContainer,
+                              shape: BoxShape.circle,
+                            ),
+                            padding: const EdgeInsets.all(4),
+                            child: Icon(Icons.close,
+                                size: 18, color: cs.onErrorContainer),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                }).toList(),
+                GestureDetector(
+                  onTap: _pickImages,
+                  child: Container(
+                    width: 120,
+                    height: 120,
+                    decoration: BoxDecoration(
+                      color: cs.surfaceVariant.withOpacity(0.5),
+                      borderRadius: BorderRadius.circular(18),
+                      border: Border.all(color: cs.outlineVariant),
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: const [
+                        Icon(Icons.add_a_photo_outlined, size: 28),
+                        SizedBox(height: 8),
+                        Text('Thêm ảnh'),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 32),
+            FilledButton.icon(
+              onPressed: _isSubmitting ? null : _submit,
+              icon: _isSubmitting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2.5),
+                    )
+                  : const Icon(Icons.send),
+              label: Text(_isSubmitting ? 'Đang đăng...' : 'Đăng bài'),
+              style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(52)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/social/recruitment/recruitment_form_manager.dart
+++ b/lib/pages/social/recruitment/recruitment_form_manager.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../../models/recruitment_post.dart';
+import '../../../services/recruitment_service.dart';
+import '../../../utils/recruitment_dictionary.dart';
+
+class RecruitmentFormManager with ChangeNotifier {
+  RecruitmentFormManager()
+      : _service = RecruitmentService(),
+        noteController = TextEditingController(),
+        memberCountController = TextEditingController(text: '3') {
+    _memberCount = 3;
+    _selectedPlayStyleLabel = RecruitmentDictionary.playStyleLabels['doubles']!;
+    _selectedSkillLevelLabel =
+        RecruitmentDictionary.skillLevelLabels['Intermediate']!;
+  }
+
+  final RecruitmentService _service;
+
+  final TextEditingController noteController;
+  final TextEditingController memberCountController;
+
+  bool _hasBookedCourt = true;
+  bool _isLoadingCourts = false;
+  bool _isSubmitting = false;
+  DateTime _selectedDateTime = DateTime.now().add(const Duration(hours: 2));
+  List<BookedCourtOption> _bookedCourts = const [];
+  BookedCourtOption? _selectedCourt;
+  String? _courtMessage;
+  int _memberCount = 3;
+  String _selectedPlayStyleLabel = '';
+  String _selectedSkillLevelLabel = '';
+
+  bool get hasBookedCourt => _hasBookedCourt;
+  bool get isLoadingCourts => _isLoadingCourts;
+  bool get isSubmitting => _isSubmitting;
+  DateTime get selectedDateTime => _selectedDateTime;
+  List<BookedCourtOption> get bookedCourts => _bookedCourts;
+  BookedCourtOption? get selectedCourt => _selectedCourt;
+  String? get courtMessage => _courtMessage;
+  int get memberCount => _memberCount;
+  String get selectedPlayStyleLabel => _selectedPlayStyleLabel;
+  String get selectedSkillLevelLabel => _selectedSkillLevelLabel;
+
+  List<String> get playStyleOptions =>
+      RecruitmentDictionary.playStyleDisplayOptions();
+  List<String> get skillLevelOptions =>
+      RecruitmentDictionary.skillDisplayOptions();
+
+  Future<void> initialize() async {
+    await _loadBookedCourts();
+  }
+
+  Future<void> toggleHasBookedCourt(bool value) async {
+    _hasBookedCourt = value;
+    if (value) {
+      await _loadBookedCourts();
+    } else {
+      _selectedCourt = null;
+      _courtMessage = null;
+      notifyListeners();
+    }
+  }
+
+  Future<void> updateSelectedDateTime(DateTime value) async {
+    _selectedDateTime = value;
+    if (_hasBookedCourt) {
+      await _loadBookedCourts();
+    } else {
+      notifyListeners();
+    }
+  }
+
+  void updateSelectedCourt(String? bookingId) {
+    if (bookingId == null) {
+      _selectedCourt = null;
+    } else {
+      final matched =
+          _bookedCourts.where((court) => court.id == bookingId).toList();
+      if (matched.isNotEmpty) {
+        _selectedCourt = matched.first;
+      } else if (_bookedCourts.isNotEmpty) {
+        _selectedCourt = _bookedCourts.first;
+      } else {
+        _selectedCourt = null;
+      }
+    }
+    notifyListeners();
+  }
+
+  void updateMemberCount(int value) {
+    _memberCount = value < 1 ? 1 : value;
+    final normalizedText = _memberCount.toString();
+    if (memberCountController.text != normalizedText) {
+      memberCountController.text = normalizedText;
+      memberCountController.selection = TextSelection.fromPosition(
+        TextPosition(offset: normalizedText.length),
+      );
+    }
+    notifyListeners();
+  }
+
+  void selectPlayStyle(String label) {
+    _selectedPlayStyleLabel = label;
+    notifyListeners();
+  }
+
+  void selectSkillLevel(String label) {
+    _selectedSkillLevelLabel = label;
+    notifyListeners();
+  }
+
+  Future<RecruitmentPost> submit() async {
+    _isSubmitting = true;
+    notifyListeners();
+
+    try {
+      final result = await _service.createRecruitmentPost(
+        hasBookedCourt: _hasBookedCourt,
+        playTime: _selectedDateTime,
+        needMembers: _memberCount,
+        playStyleLabel: _selectedPlayStyleLabel,
+        skillLevelLabel: _selectedSkillLevelLabel,
+        note: noteController.text,
+        courtId: _selectedCourt?.courtId,
+        locationNote: _selectedCourt?.bookingView.courtLocation,
+      );
+      return result;
+    } finally {
+      _isSubmitting = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _loadBookedCourts() async {
+    _isLoadingCourts = true;
+    _courtMessage = null;
+    notifyListeners();
+
+    try {
+      final bookings = await _service.listMyBookingsForDate(_selectedDateTime);
+      _bookedCourts = bookings
+          .map((view) => BookedCourtOption(bookingView: view))
+          .toList(growable: false);
+
+      if (_bookedCourts.isEmpty) {
+        _selectedCourt = null;
+        _courtMessage =
+            'Bạn chưa có sân nào trong ngày ${_formatDate(_selectedDateTime)}';
+      } else {
+        _selectedCourt ??= _bookedCourts.first;
+      }
+    } on RecruitmentServiceException catch (error) {
+      _bookedCourts = const [];
+      _selectedCourt = null;
+      _courtMessage = error.message;
+    } finally {
+      _isLoadingCourts = false;
+      notifyListeners();
+    }
+  }
+
+  String _formatDate(DateTime dateTime) {
+    return '${dateTime.day.toString().padLeft(2, '0')}/${dateTime.month.toString().padLeft(2, '0')}/${dateTime.year}';
+  }
+
+  @override
+  void dispose() {
+    noteController.dispose();
+    memberCountController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/pages/social/recruitment/recruitment_form_manager.dart
+++ b/lib/pages/social/recruitment/recruitment_form_manager.dart
@@ -112,6 +112,12 @@ class RecruitmentFormManager with ChangeNotifier {
   }
 
   Future<RecruitmentPost> submit() async {
+    if (_hasBookedCourt && _selectedCourt == null) {
+      throw RecruitmentServiceException(
+        'Bạn chưa có sân trong ngày đã chọn. Vui lòng chọn lại thời gian hoặc tắt tùy chọn đã đặt sân.',
+      );
+    }
+
     _isSubmitting = true;
     notifyListeners();
 

--- a/lib/pages/social/recruitment/recruitment_page.dart
+++ b/lib/pages/social/recruitment/recruitment_page.dart
@@ -1,3 +1,4 @@
+import 'package:badminton_booking_app/pages/social/recruitment/recruitment_form_manager.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/court_info_section.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/intro_card.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/member_input_section.dart';
@@ -7,68 +8,17 @@ import 'package:badminton_booking_app/pages/social/recruitment/widgets/play_styl
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/skill_level_selector.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/submit_button.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
-class RecruitmentFormPage extends StatefulWidget {
+class RecruitmentFormPage extends StatelessWidget {
   const RecruitmentFormPage({super.key});
 
-  @override
-  State<RecruitmentFormPage> createState() => _RecruitmentFormPageState();
-}
-
-class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
-  // Controllers
-  final TextEditingController _noteController = TextEditingController();
-  late final TextEditingController _memberCountController;
-
-  // State chính
-  bool _hasBookedCourt = true;
-  int _memberCount = 3;
-  String _skillLevel = 'Trung bình khá';
-  String _playStyle = 'Đánh đôi';
-  String? _selectedCourt;
-  DateTime _selectedDateTime = DateTime.now().add(const Duration(hours: 2));
-
-  // Dữ liệu mẫu
-  final List<String> _availableCourts = const [
-    'Sân Quận 7 - Court A',
-    'Sân Quận 1 - Court B',
-    'Sân Phú Nhuận - Court C',
-  ];
-
-  final List<String> _playStyles = const [
-    'Đánh đơn',
-    'Đánh đôi',
-    'Linh hoạt',
-  ];
-
-  final List<String> _skillLevels = const [
-    'Mới chơi',
-    'Trung bình',
-    'Trung bình khá',
-    'Nâng cao',
-    'Chuyên nghiệp',
-  ];
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedCourt = _availableCourts.first;
-    _memberCountController =
-        TextEditingController(text: _memberCount.toString());
-  }
-
-  @override
-  void dispose() {
-    _noteController.dispose();
-    _memberCountController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _pickDateTime() async {
+  Future<void> _pickDateTime(BuildContext context) async {
+    final manager = context.read<RecruitmentFormManager>();
+    final initialDate = manager.selectedDateTime;
     final date = await showDatePicker(
       context: context,
-      initialDate: _selectedDateTime,
+      initialDate: initialDate,
       firstDate: DateTime.now(),
       lastDate: DateTime.now().add(const Duration(days: 30)),
     );
@@ -76,105 +26,122 @@ class _RecruitmentFormPageState extends State<RecruitmentFormPage> {
 
     final time = await showTimePicker(
       context: context,
-      initialTime: TimeOfDay.fromDateTime(_selectedDateTime),
+      initialTime: TimeOfDay.fromDateTime(initialDate),
     );
     if (time == null) return;
 
-    setState(() {
-      _selectedDateTime = DateTime(
-        date.year,
-        date.month,
-        date.day,
-        time.hour,
-        time.minute,
-      );
-    });
+    final newDateTime = DateTime(
+      date.year,
+      date.month,
+      date.day,
+      time.hour,
+      time.minute,
+    );
+    await manager.updateSelectedDateTime(newDateTime);
   }
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
+    return ChangeNotifierProvider(
+      create: (_) => RecruitmentFormManager()..initialize(),
+      child: Builder(
+        builder: (context) {
+          final manager = context.watch<RecruitmentFormManager>();
+          final cs = Theme.of(context).colorScheme;
+          final textTheme = Theme.of(context).textTheme;
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Tạo bài tuyển thành viên')),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              IntroCard(cs: cs, textTheme: textTheme),
-              const SizedBox(height: 24),
+          return Scaffold(
+            appBar: AppBar(title: const Text('Tạo bài tuyển thành viên')),
+            body: SafeArea(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    IntroCard(cs: cs, textTheme: textTheme),
+                    const SizedBox(height: 24),
 
-              // 🔘 Toggle
-              SwitchListTile.adaptive(
-                contentPadding: EdgeInsets.zero,
-                title: const Text('Tôi đã đặt sân trước'),
-                value: _hasBookedCourt,
-                onChanged: (value) => setState(() => _hasBookedCourt = value),
+                    SwitchListTile.adaptive(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Tôi đã đặt sân trước'),
+                      value: manager.hasBookedCourt,
+                      onChanged: (value) =>
+                          manager.toggleHasBookedCourt(value),
+                    ),
+                    const SizedBox(height: 16),
+
+                    AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 300),
+                      child: manager.hasBookedCourt
+                          ? manager.isLoadingCourts
+                              ? const Center(
+                                  child: Padding(
+                                    padding: EdgeInsets.all(24),
+                                    child: CircularProgressIndicator(),
+                                  ),
+                                )
+                              : CourtInfoSection(
+                                  selectedCourtId:
+                                      manager.selectedCourt?.id,
+                                  availableCourts: manager.bookedCourts,
+                                  selectedDateTime: manager.selectedDateTime,
+                                  onCourtChanged: manager.updateSelectedCourt,
+                                  onPickDateTime: () => _pickDateTime(context),
+                                  message: manager.courtMessage,
+                                )
+                          : const NoCourtInfoBox(),
+                    ),
+
+                    const SizedBox(height: 24),
+
+                    MemberInputSection(
+                      memberCount: manager.memberCount,
+                      controller: manager.memberCountController,
+                      onChanged: manager.updateMemberCount,
+                    ),
+                    const SizedBox(height: 24),
+
+                    PlayStyleSelector(
+                      playStyles: manager.playStyleOptions,
+                      selectedStyle: manager.selectedPlayStyleLabel,
+                      onChanged: manager.selectPlayStyle,
+                    ),
+                    const SizedBox(height: 24),
+
+                    SkillLevelSelector(
+                      skillLevels: manager.skillLevelOptions,
+                      selectedLevel: manager.selectedSkillLevelLabel,
+                      onChanged: manager.selectSkillLevel,
+                    ),
+                    const SizedBox(height: 24),
+
+                    NoteField(controller: manager.noteController),
+                    const SizedBox(height: 32),
+
+                    SubmitButton(
+                      isLoading: manager.isSubmitting,
+                      onSubmit: () async {
+                        try {
+                          final result = await manager.submit();
+                          if (context.mounted) {
+                            Navigator.of(context).pop(result);
+                          }
+                        } catch (error) {
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(error.toString()),
+                            ),
+                          );
+                        }
+                      },
+                    ),
+                  ],
+                ),
               ),
-              const SizedBox(height: 16),
-
-              // 🏸 Nếu đã đặt sân / chưa đặt sân
-              AnimatedSwitcher(
-                duration: const Duration(milliseconds: 300),
-                child: _hasBookedCourt
-                    ? CourtInfoSection(
-                        selectedCourt: _selectedCourt!,
-                        availableCourts: _availableCourts,
-                        selectedDateTime: _selectedDateTime,
-                        onCourtChanged: (v) =>
-                            setState(() => _selectedCourt = v),
-                        onPickDateTime: _pickDateTime,
-                      )
-                    : NoCourtInfoBox(),
-              ),
-
-              const SizedBox(height: 24),
-
-              // 👥 Nhập số lượng
-              MemberInputSection(
-                memberCount: _memberCount,
-                controller: _memberCountController,
-                onChanged: (val) => setState(() => _memberCount = val),
-              ),
-              const SizedBox(height: 24),
-
-              // 🏸 Lối chơi
-              PlayStyleSelector(
-                playStyles: _playStyles,
-                selectedStyle: _playStyle,
-                onChanged: (v) => setState(() => _playStyle = v),
-              ),
-              const SizedBox(height: 24),
-
-              // 💪 Trình độ
-              SkillLevelSelector(
-                skillLevels: _skillLevels,
-                selectedLevel: _skillLevel,
-                onChanged: (v) => setState(() => _skillLevel = v),
-              ),
-              const SizedBox(height: 24),
-
-              // 📝 Ghi chú
-              NoteField(controller: _noteController),
-              const SizedBox(height: 32),
-
-              // 🚀 Nút đăng
-              SubmitButton(onSubmit: () {
-                print('--- THÔNG TIN BÀI TUYỂN ---');
-                print('Đã đặt sân: $_hasBookedCourt');
-                print('Sân: $_selectedCourt');
-                print('Giờ đánh: $_selectedDateTime');
-                print('Số lượng: $_memberCount');
-                print('Lối chơi: $_playStyle');
-                print('Trình độ: $_skillLevel');
-                print('Ghi chú: ${_noteController.text}');
-              }),
-            ],
-          ),
-        ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/pages/social/recruitment/widgets/court_info_section.dart
+++ b/lib/pages/social/recruitment/widgets/court_info_section.dart
@@ -1,21 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-class CourtInfoSection extends StatelessWidget {
-  final String selectedCourt;
-  final List<String> availableCourts;
-  final DateTime selectedDateTime;
-  final ValueChanged<String> onCourtChanged;
-  final VoidCallback onPickDateTime;
+import '../../../../services/recruitment_service.dart';
 
+class CourtInfoSection extends StatelessWidget {
   const CourtInfoSection({
     super.key,
-    required this.selectedCourt,
+    required this.selectedCourtId,
     required this.availableCourts,
     required this.selectedDateTime,
     required this.onCourtChanged,
     required this.onPickDateTime,
+    this.message,
   });
+
+  final String? selectedCourtId;
+  final List<BookedCourtOption> availableCourts;
+  final DateTime selectedDateTime;
+  final ValueChanged<String?> onCourtChanged;
+  final VoidCallback onPickDateTime;
+  final String? message;
 
   @override
   Widget build(BuildContext context) {
@@ -27,15 +31,25 @@ class CourtInfoSection extends StatelessWidget {
       children: [
         Text('Thông tin sân đã đặt', style: textTheme.titleMedium),
         const SizedBox(height: 12),
-        DropdownButtonFormField<String>(
-          value: selectedCourt,
-          decoration: _inputDecoration(cs, 'Chọn sân đã đặt'),
-          items: availableCourts
-              .map(
-                  (court) => DropdownMenuItem(value: court, child: Text(court)))
-              .toList(),
-          onChanged: (v) => v != null ? onCourtChanged(v) : null,
-        ),
+        if (availableCourts.isEmpty)
+          _EmptyCourtMessage(message: message)
+        else
+          DropdownButtonFormField<String>(
+            value: selectedCourtId,
+            decoration: _inputDecoration(cs, 'Chọn sân đã đặt'),
+            items: availableCourts
+                .map(
+                  (court) => DropdownMenuItem(
+                    value: court.id,
+                    child: Text(
+                      court.displayName,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                )
+                .toList(),
+            onChanged: onCourtChanged,
+          ),
         const SizedBox(height: 16),
         GestureDetector(
           onTap: onPickDateTime,
@@ -62,6 +76,43 @@ class CourtInfoSection extends StatelessWidget {
       border: OutlineInputBorder(
         borderRadius: BorderRadius.circular(16),
         borderSide: BorderSide.none,
+      ),
+    );
+  }
+}
+
+class _EmptyCourtMessage extends StatelessWidget {
+  const _EmptyCourtMessage({this.message});
+
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final resolvedMessage = message ??
+        'Bạn chưa có sân trong ngày đã chọn. Vui lòng kiểm tra lại lịch đặt sân.';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: cs.surfaceVariant.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.info_outline, color: cs.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              resolvedMessage,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: cs.onSurfaceVariant),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/social/recruitment/widgets/court_info_section.dart
+++ b/lib/pages/social/recruitment/widgets/court_info_section.dart
@@ -38,16 +38,19 @@ class CourtInfoSection extends StatelessWidget {
             value: selectedCourtId,
             decoration: _inputDecoration(cs, 'Chọn sân đã đặt'),
             items: availableCourts
-                .map(
-                  (court) => DropdownMenuItem(
+                .map<DropdownMenuItem<String>>(
+                  (court) => DropdownMenuItem<String>(
                     value: court.id,
-                    child: Text(
-                      court.displayName,
-                      overflow: TextOverflow.ellipsis,
+                    child: Tooltip(
+                      message: court.displayName,
+                      child: Text(
+                        court.displayName,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     ),
                   ),
                 )
-                .toList(),
+                .toList(growable: false),
             onChanged: onCourtChanged,
           ),
         const SizedBox(height: 16),

--- a/lib/pages/social/recruitment/widgets/member_input_section.dart
+++ b/lib/pages/social/recruitment/widgets/member_input_section.dart
@@ -26,7 +26,6 @@ class MemberInputSection extends StatelessWidget {
               onPressed: () {
                 if (memberCount > 1) {
                   onChanged(memberCount - 1);
-                  controller.text = (memberCount - 1).toString();
                 }
               },
               icon: const Icon(Icons.remove_circle_outline),
@@ -56,7 +55,6 @@ class MemberInputSection extends StatelessWidget {
             IconButton(
               onPressed: () {
                 onChanged(memberCount + 1);
-                controller.text = (memberCount + 1).toString();
               },
               icon: const Icon(Icons.add_circle_outline),
             ),

--- a/lib/pages/social/recruitment/widgets/submit_button.dart
+++ b/lib/pages/social/recruitment/widgets/submit_button.dart
@@ -1,21 +1,29 @@
 import 'package:flutter/material.dart';
 
 class SubmitButton extends StatelessWidget {
-  final VoidCallback onSubmit;
-
   const SubmitButton({
     super.key,
     required this.onSubmit,
+    this.isLoading = false,
   });
+
+  final VoidCallback onSubmit;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
 
     return FilledButton.icon(
-      onPressed: onSubmit,
-      icon: const Icon(Icons.send_rounded),
-      label: const Text('Đăng bài tuyển thành viên'),
+      onPressed: isLoading ? null : onSubmit,
+      icon: isLoading
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2.5),
+            )
+          : const Icon(Icons.send_rounded),
+      label: Text(isLoading ? 'Đang đăng...' : 'Đăng bài tuyển thành viên'),
       style: FilledButton.styleFrom(
         minimumSize: const Size.fromHeight(54),
         textStyle: textTheme.titleMedium?.copyWith(

--- a/lib/pages/social/social_manager.dart
+++ b/lib/pages/social/social_manager.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import '../../models/community_post.dart';
+import '../../models/recruitment_post.dart';
+import '../../services/post_service.dart';
+import '../../services/recruitment_service.dart';
+
+class SocialManager with ChangeNotifier {
+  SocialManager()
+      : _postService = PostService(),
+        _recruitmentService = RecruitmentService();
+
+  final PostService _postService;
+  final RecruitmentService _recruitmentService;
+
+  bool _isLoadingPosts = false;
+  bool _isLoadingRecruitments = false;
+  bool _isSubmittingPost = false;
+
+  List<CommunityPost> _posts = const [];
+  List<RecruitmentPost> _recruitmentPosts = const [];
+
+  String? _postError;
+  String? _recruitmentError;
+
+  final Set<String> _joiningRecruitments = <String>{};
+
+  bool get isLoadingPosts => _isLoadingPosts;
+  bool get isLoadingRecruitments => _isLoadingRecruitments;
+  bool get isSubmittingPost => _isSubmittingPost;
+
+  List<CommunityPost> get posts => _posts;
+  List<RecruitmentPost> get recruitmentPosts => _recruitmentPosts;
+
+  String? get postError => _postError;
+  String? get recruitmentError => _recruitmentError;
+
+  bool isJoining(String recruitmentId) => _joiningRecruitments.contains(recruitmentId);
+
+  Future<void> loadInitial() async {
+    await Future.wait<void>([
+      refreshPosts(),
+      refreshRecruitments(),
+    ]);
+  }
+
+  Future<void> refreshPosts() async {
+    _isLoadingPosts = true;
+    _postError = null;
+    notifyListeners();
+
+    try {
+      final results = await _postService.fetchPosts();
+      _posts = results;
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+    } finally {
+      _isLoadingPosts = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshRecruitments() async {
+    _isLoadingRecruitments = true;
+    _recruitmentError = null;
+    notifyListeners();
+
+    try {
+      final results = await _recruitmentService.fetchActivePosts();
+      _recruitmentPosts = results;
+    } on RecruitmentServiceException catch (error) {
+      _recruitmentError = error.message;
+    } finally {
+      _isLoadingRecruitments = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> createPost({
+    required String content,
+    List<File> images = const [],
+  }) async {
+    _isSubmittingPost = true;
+    notifyListeners();
+
+    try {
+      final newPost = await _postService.createPost(
+        content: content,
+        images: images,
+      );
+      _posts = [newPost, ..._posts];
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _isSubmittingPost = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> joinRecruitment(String recruitmentId) async {
+    if (_joiningRecruitments.contains(recruitmentId)) {
+      return;
+    }
+
+    _joiningRecruitments.add(recruitmentId);
+    notifyListeners();
+
+    try {
+      final updated = await _recruitmentService.joinRecruitment(recruitmentId);
+      _recruitmentPosts = _recruitmentPosts
+          .map((post) => post.id == recruitmentId ? updated : post)
+          .toList(growable: false);
+    } finally {
+      _joiningRecruitments.remove(recruitmentId);
+      notifyListeners();
+    }
+  }
+}

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1,3 +1,4 @@
+import 'package:badminton_booking_app/components/create_post.dart';
 import 'package:badminton_booking_app/components/my_post.dart';
 import 'package:badminton_booking_app/components/recruitment_post_card.dart';
 import 'package:badminton_booking_app/models/community_post.dart';
@@ -6,6 +7,7 @@ import 'package:badminton_booking_app/pages/social/chat/chat_home_page.dart';
 import 'package:badminton_booking_app/pages/social/create_post_page.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/recruitment_page.dart';
 import 'package:badminton_booking_app/pages/social/social_manager.dart';
+import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -47,6 +49,9 @@ class _SocialPageState extends State<SocialPage> {
     final cs = Theme.of(context).colorScheme;
     final manager = context.watch<SocialManager>();
 
+    final userManager = context.watch<UserManager>();
+    final avatarUrl = userManager.avatarUrl;
+
     return Scaffold(
       backgroundColor: cs.surfaceVariant.withOpacity(0.3),
       appBar: AppBar(
@@ -55,6 +60,11 @@ class _SocialPageState extends State<SocialPage> {
           style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
         ),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.add_circle_outline),
+            tooltip: 'Đăng bài',
+            onPressed: () => _openCreatePost(context),
+          ),
           IconButton(
             icon: const Icon(Icons.group, size: 30),
             tooltip: 'Tin nhắn',
@@ -67,11 +77,6 @@ class _SocialPageState extends State<SocialPage> {
           const SizedBox(width: 6),
         ],
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => _openCreatePost(context),
-        icon: const Icon(Icons.add),
-        label: const Text('Đăng bài'),
-      ),
       body: SafeArea(
         child: RefreshIndicator(
           onRefresh: () => _refreshAll(manager),
@@ -81,6 +86,36 @@ class _SocialPageState extends State<SocialPage> {
                 child: Padding(
                   padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
                   child: _buildWelcomeCard(context),
+                ),
+              ),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
+                  child: CreatePostBar(
+                    // ấn vào ô nhập -> mở trang tạo post
+                    onCreatePost: () => _openCreatePost(context),
+
+                    // 3 action dưới—nếu chưa có picker thì cứ gọi trang tạo post luôn
+                    onPickPhoto: () => _openCreatePost(context),
+                    onInviteFriends: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const RecruitmentFormPage(),
+                        ),
+                      );
+                    },
+
+                    // Avatar (nếu có)
+                    avatarImageProvider:
+                        (avatarUrl != null && avatarUrl.isNotEmpty)
+                            ? NetworkImage(avatarUrl)
+                            : null, // hoặc để null
+
+                    // Tuỳ chỉnh giao diện
+                    hintText: 'Bạn đang nghĩ gì thế?',
+                    elevation: 5.0,
+                    // compact: true, // nếu muốn chỉ hiện 1 hàng (ẩn 3 action)
+                  ),
                 ),
               ),
               SliverToBoxAdapter(

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -159,6 +159,7 @@ class _SocialPageState extends State<SocialPage> {
             playStyle: post.playStyle,
             courtName: post.courtName,
             playTime: post.eventTime,
+            locationNote: post.locationNote,
             onJoin: () async {
               try {
                 await manager.joinRecruitment(post.id);

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -52,101 +52,172 @@ class _SocialPageState extends State<SocialPage> {
     final userManager = context.watch<UserManager>();
     final avatarUrl = userManager.avatarUrl;
 
-    return Scaffold(
-      backgroundColor: cs.surfaceVariant.withOpacity(0.3),
-      appBar: AppBar(
-        title: const Text(
-          'Cộng đồng cầu lông',
-          style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        backgroundColor: cs.surfaceVariant.withOpacity(0.3),
+        appBar: AppBar(
+          title: const Text(
+            'Cộng đồng cầu lông',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.add_circle_outline),
+              tooltip: 'Đăng bài',
+              onPressed: () => _openCreatePost(context),
+            ),
+            IconButton(
+              icon: const Icon(Icons.group, size: 30),
+              tooltip: 'Tin nhắn',
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => ChatHomePage()),
+                );
+              },
+            ),
+            const SizedBox(width: 6),
+          ],
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Posts'),
+              Tab(text: 'Recruitment'),
+            ],
+          ),
         ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.add_circle_outline),
-            tooltip: 'Đăng bài',
-            onPressed: () => _openCreatePost(context),
+        body: SafeArea(
+          child: TabBarView(
+            children: [
+              _buildPostsTab(context, manager, avatarUrl),
+              _buildRecruitmentTab(context, manager),
+            ],
           ),
-          IconButton(
-            icon: const Icon(Icons.group, size: 30),
-            tooltip: 'Tin nhắn',
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(builder: (_) => ChatHomePage()),
-              );
-            },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPostsTab(
+    BuildContext context,
+    SocialManager manager,
+    String? avatarUrl,
+  ) {
+    return RefreshIndicator(
+      onRefresh: manager.refreshPosts,
+      child: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
+              child: _buildCreatePostCard(context, avatarUrl),
+            ),
           ),
-          const SizedBox(width: 6),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Text(
+                'Bảng tin cộng đồng',
+                style: Theme.of(context)
+                    .textTheme
+                    .titleLarge
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 12)),
+          _buildCommunityPosts(manager),
+          const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
         ],
       ),
-      body: SafeArea(
-        child: RefreshIndicator(
-          onRefresh: () => _refreshAll(manager),
-          child: CustomScrollView(
-            slivers: [
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-                  child: _buildWelcomeCard(context),
-                ),
-              ),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
-                  child: CreatePostBar(
-                    // ấn vào ô nhập -> mở trang tạo post
-                    onCreatePost: () => _openCreatePost(context),
+    );
+  }
 
-                    // 3 action dưới—nếu chưa có picker thì cứ gọi trang tạo post luôn
-                    onPickPhoto: () => _openCreatePost(context),
-                    onInviteFriends: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (_) => const RecruitmentFormPage(),
-                        ),
-                      );
-                    },
-
-                    // Avatar (nếu có)
-                    avatarImageProvider:
-                        (avatarUrl != null && avatarUrl.isNotEmpty)
-                            ? NetworkImage(avatarUrl)
-                            : null, // hoặc để null
-
-                    // Tuỳ chỉnh giao diện
-                    hintText: 'Bạn đang nghĩ gì thế?',
-                    elevation: 5.0,
-                    // compact: true, // nếu muốn chỉ hiện 1 hàng (ẩn 3 action)
-                  ),
-                ),
-              ),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
-                  child: Text(
+  Widget _buildRecruitmentTab(BuildContext context, SocialManager manager) {
+    return RefreshIndicator(
+      onRefresh: manager.refreshRecruitments,
+      child: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildWelcomeCard(context),
+                  const SizedBox(height: 24),
+                  Text(
                     'Bài tuyển thành viên',
                     style: Theme.of(context)
                         .textTheme
                         .titleLarge
                         ?.copyWith(fontWeight: FontWeight.bold),
                   ),
-                ),
+                ],
               ),
-              _buildRecruitmentSection(manager),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 24, 20, 4),
-                  child: Text(
-                    'Bảng tin cộng đồng',
-                    style: Theme.of(context)
-                        .textTheme
-                        .titleLarge
-                        ?.copyWith(fontWeight: FontWeight.bold),
-                  ),
-                ),
-              ),
-              _buildCommunityPosts(manager),
-              const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
-            ],
+            ),
           ),
+          _buildRecruitmentSection(manager),
+          const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCreatePostCard(BuildContext context, String? avatarUrl) {
+    final cs = Theme.of(context).colorScheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 16,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Chia sẻ điều mới mẻ',
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                TextButton.icon(
+                  onPressed: () => _openCreatePost(context),
+                  icon: const Icon(Icons.edit_outlined),
+                  label: const Text('Viết bài'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            CreatePostBar(
+              onCreatePost: () => _openCreatePost(context),
+              onPickPhoto: () => _openCreatePost(context),
+              onInviteFriends: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const RecruitmentFormPage(),
+                  ),
+                );
+              },
+              avatarImageProvider:
+                  (avatarUrl != null && avatarUrl.isNotEmpty)
+                      ? NetworkImage(avatarUrl)
+                      : null,
+              hintText: 'Bạn đang nghĩ gì thế?',
+              elevation: 0,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1,51 +1,51 @@
 import 'package:badminton_booking_app/components/my_post.dart';
 import 'package:badminton_booking_app/components/recruitment_post_card.dart';
+import 'package:badminton_booking_app/models/community_post.dart';
+import 'package:badminton_booking_app/models/recruitment_post.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_home_page.dart';
+import 'package:badminton_booking_app/pages/social/create_post_page.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/recruitment_page.dart';
+import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-class SocialPage extends StatelessWidget {
-  SocialPage({super.key});
+class SocialPage extends StatefulWidget {
+  const SocialPage({super.key});
 
-  final DateTime _now = DateTime.now();
+  @override
+  State<SocialPage> createState() => _SocialPageState();
+}
 
-  final List<_RecruitmentPost> _recruitmentPosts = [
-    _RecruitmentPost(
-      hostName: 'Bảo Minh',
-      createdAt: DateTime.now().subtract(const Duration(minutes: 15)),
-      description:
-          'Cần 2 bạn trình trung bình khá đánh đôi giao lưu. Team rất vui tính.',
-      requiredPlayers: 4,
-      joinedPlayers: 2,
-      skillLevel: 'Trung bình khá',
-      courtName: 'Sân Quận 7 - Court A',
-      playTime: DateTime.now().add(const Duration(hours: 2)),
-    ),
-    _RecruitmentPost(
-      hostName: 'Ngọc Anh',
-      createdAt: DateTime.now().subtract(const Duration(hours: 1, minutes: 10)),
-      description:
-          'Tuyển gấp 1 nữ trình trung bình để đánh đôi cố định sáng chủ nhật hàng tuần.',
-      requiredPlayers: 4,
-      joinedPlayers: 3,
-      skillLevel: 'Trung bình',
-      courtName: 'Sân Phú Nhuận - Court C',
-      playTime: DateTime.now().add(const Duration(days: 1, hours: 10)),
-    ),
-    _RecruitmentPost(
-      hostName: 'Văn Hòa',
-      createdAt: DateTime.now().subtract(const Duration(hours: 3)),
-      description:
-          'Nhóm mình chưa có sân, cần tuyển 3 bạn trình nâng cao lập team đi đánh giải.',
-      requiredPlayers: 5,
-      joinedPlayers: 1,
-      skillLevel: 'Nâng cao',
-    ),
-  ];
+class _SocialPageState extends State<SocialPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<SocialManager>().loadInitial();
+    });
+  }
+
+  Future<void> _openCreatePost(BuildContext context) async {
+    final result = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(builder: (_) => const CreatePostPage()),
+    );
+    if (result == true && mounted) {
+      await context.read<SocialManager>().refreshPosts();
+    }
+  }
+
+  Future<void> _refreshAll(SocialManager manager) async {
+    await Future.wait([
+      manager.refreshPosts(),
+      manager.refreshRecruitments(),
+    ]);
+  }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final manager = context.watch<SocialManager>();
 
     return Scaffold(
       backgroundColor: cs.surfaceVariant.withOpacity(0.3),
@@ -67,81 +67,158 @@ class SocialPage extends StatelessWidget {
           const SizedBox(width: 6),
         ],
       ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _openCreatePost(context),
+        icon: const Icon(Icons.add),
+        label: const Text('Đăng bài'),
+      ),
       body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-                child: _buildWelcomeCard(context),
-              ),
-            ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
-                child: Text(
-                  'Bài tuyển thành viên',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleLarge
-                      ?.copyWith(fontWeight: FontWeight.bold),
+        child: RefreshIndicator(
+          onRefresh: () => _refreshAll(manager),
+          child: CustomScrollView(
+            slivers: [
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+                  child: _buildWelcomeCard(context),
                 ),
               ),
-            ),
-            SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (context, index) {
-                  final post = _recruitmentPosts[index];
-                  return RecruitmentPostCard(
-                    hostName: post.hostName,
-                    createdTime: post.createdAt,
-                    requiredPlayers: post.requiredPlayers,
-                    joinedPlayers: post.joinedPlayers,
-                    description: post.description,
-                    skillLevel: post.skillLevel,
-                    courtName: post.courtName,
-                    playTime: post.playTime,
-                    onJoin: () {},
-                  );
-                },
-                childCount: _recruitmentPosts.length,
-              ),
-            ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 24, 20, 4),
-                child: Text(
-                  'Bảng tin cộng đồng',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleLarge
-                      ?.copyWith(fontWeight: FontWeight.bold),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+                  child: Text(
+                    'Bài tuyển thành viên',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleLarge
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
                 ),
               ),
-            ),
-            SliverList(
-              delegate: SliverChildListDelegate.fixed([
-                MyPost(
-                  message: 'https://picsum.photos/seed/recruitment1/1200/600',
-                  userName: 'Bảo Minh',
-                  time: _now,
+              _buildRecruitmentSection(manager),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 24, 20, 4),
+                  child: Text(
+                    'Bảng tin cộng đồng',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleLarge
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
                 ),
-                MyPost(
-                  message:
-                      'Đánh giao hữu cuối tuần này ở Quận 2, ai rảnh thì join nhé!',
-                  userName: 'Ngọc Anh',
-                  time: _now.subtract(const Duration(hours: 5)),
-                ),
-                MyPost(
-                  message: 'https://picsum.photos/seed/recruitment2/1200/600',
-                  userName: 'Văn Hòa',
-                  time: _now.subtract(const Duration(hours: 9)),
-                ),
-              ]),
-            ),
-            SliverPadding(padding: const EdgeInsets.only(bottom: 100)),
-          ],
+              ),
+              _buildCommunityPosts(manager),
+              const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
+            ],
+          ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildRecruitmentSection(SocialManager manager) {
+    if (manager.isLoadingRecruitments && manager.recruitmentPosts.isEmpty) {
+      return const SliverToBoxAdapter(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 32),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
+    if (manager.recruitmentError != null && manager.recruitmentPosts.isEmpty) {
+      return SliverToBoxAdapter(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          child: _ErrorBox(message: manager.recruitmentError!),
+        ),
+      );
+    }
+
+    if (manager.recruitmentPosts.isEmpty) {
+      return const SliverToBoxAdapter(
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          child: Text('Chưa có bài tuyển nào. Hãy là người đầu tiên đăng bài!'),
+        ),
+      );
+    }
+
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) {
+          final RecruitmentPost post = manager.recruitmentPosts[index];
+          return RecruitmentPostCard(
+            hostName: post.authorName,
+            createdTime: post.createdAt,
+            requiredPlayers: post.requiredPlayers,
+            joinedPlayers: post.joinedPlayers,
+            description: post.description,
+            skillLevel: post.skillLevel,
+            playStyle: post.playStyle,
+            courtName: post.courtName,
+            playTime: post.eventTime,
+            onJoin: () async {
+              try {
+                await manager.joinRecruitment(post.id);
+              } catch (error) {
+                if (!context.mounted) return;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(error.toString())),
+                );
+              }
+            },
+            isJoined: post.isJoined,
+            isOwner: post.isOwner,
+            isJoinLoading: manager.isJoining(post.id),
+          );
+        },
+        childCount: manager.recruitmentPosts.length,
+      ),
+    );
+  }
+
+  Widget _buildCommunityPosts(SocialManager manager) {
+    if (manager.isLoadingPosts && manager.posts.isEmpty) {
+      return const SliverToBoxAdapter(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 32),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
+    if (manager.postError != null && manager.posts.isEmpty) {
+      return SliverToBoxAdapter(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          child: _ErrorBox(message: manager.postError!),
+        ),
+      );
+    }
+
+    if (manager.posts.isEmpty) {
+      return const SliverToBoxAdapter(
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          child: Text('Bảng tin đang trống. Đăng bài đầu tiên ngay nào!'),
+        ),
+      );
+    }
+
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) {
+          final CommunityPost post = manager.posts[index];
+          return MyPost(
+            content: post.content,
+            userName: post.authorName,
+            time: post.createdAt,
+            imageUrls: post.imageUrls,
+          );
+        },
+        childCount: manager.posts.length,
       ),
     );
   }
@@ -225,24 +302,35 @@ class SocialPage extends StatelessWidget {
   }
 }
 
-class _RecruitmentPost {
-  final String hostName;
-  final DateTime createdAt;
-  final int requiredPlayers;
-  final int joinedPlayers;
-  final String? skillLevel;
-  final String? description;
-  final String? courtName;
-  final DateTime? playTime;
+class _ErrorBox extends StatelessWidget {
+  const _ErrorBox({required this.message});
 
-  const _RecruitmentPost({
-    required this.hostName,
-    required this.createdAt,
-    required this.requiredPlayers,
-    required this.joinedPlayers,
-    this.skillLevel,
-    this.description,
-    this.courtName,
-    this.playTime,
-  });
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.errorContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.error_outline, color: cs.onErrorContainer),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              message,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: cs.onErrorContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/pages/user/user_manager.dart
+++ b/lib/pages/user/user_manager.dart
@@ -1,10 +1,10 @@
+// lib/pages/user/user_manager.dart
 import 'dart:io';
-
-import 'package:badminton_booking_app/models/user.dart';
-import 'package:badminton_booking_app/services/user_service.dart';
 import 'package:flutter/foundation.dart';
 
+import 'package:badminton_booking_app/models/user.dart';
 import 'package:badminton_booking_app/models/user_details.dart';
+import 'package:badminton_booking_app/services/user_service.dart';
 
 class UserManager with ChangeNotifier {
   late final UserDetailsService _userService;
@@ -13,21 +13,104 @@ class UserManager with ChangeNotifier {
     _userService = UserDetailsService();
   }
 
-  /// Trả về ID user hiện tại (hoặc null nếu chưa đăng nhập)
-  Future<String?> getCurrentUserId() async {
-    return _userService.getCurrentUserId();
+  // ====== CACHE & STATE ======
+  User? _currentUser;
+  UserDetails? _myDetails;
+  bool _isLoading = false;
+
+  // ====== GETTERS ĐỒNG BỘ (UI đọc trực tiếp) ======
+  User? get currentUser => _currentUser;
+  UserDetails? get myDetails => _myDetails;
+  String? get avatarUrl => _myDetails?.avatarUrl;
+  bool get isLoading => _isLoading;
+
+  // ====== HÀNH VI CHÍNH ======
+  /// Gọi khi app mở / sau đăng nhập (load user + user_details)
+  Future<void> loadMe() async {
+    if (_isLoading) return;
+    _isLoading = true;
+    notifyListeners();
+    try {
+      _currentUser = await _userService.getCurrentUser();
+      final uid = await _userService.getCurrentUserId();
+      _myDetails = (uid != null) ? await _userService.getByUserId(uid) : null;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 
-  Future<User?> getCurrentUser() async {
-    return _userService.getCurrentUser();
+  /// Bắt buộc load lại (không quan tâm đang loading)
+  Future<void> reloadMe() async {
+    _isLoading = true;
+    notifyListeners();
+    try {
+      _currentUser = await _userService.getCurrentUser();
+      final uid = await _userService.getCurrentUserId();
+      _myDetails = (uid != null) ? await _userService.getByUserId(uid) : null;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 
-  Future<UserDetails?> getByUserId(String userId) {
-    return _userService.getByUserId(userId);
+  /// Dọn cache khi đăng xuất
+  void clear() {
+    _currentUser = null;
+    _myDetails = null;
+    _isLoading = false;
+    notifyListeners();
   }
 
-  Future<String?> uploadAvatar(File file) {
-    return _userService.uploadAvatar(file);
+  /// Chỉ refresh phần user_details (khi biết chắc user còn đăng nhập)
+  Future<void> refreshMyDetails() async {
+    final uid = await _userService.getCurrentUserId();
+    if (uid == null) return;
+    _myDetails = await _userService.getByUserId(uid);
+    notifyListeners();
+  }
+
+  // ====== HÀM TIỆN ÍCH CHO UI (BACKWARD-COMPATIBLE) ======
+  Future<String?> getMyAvatarUrl() async {
+    // Nếu đã có cache thì trả ngay
+    if (avatarUrl != null && avatarUrl!.isNotEmpty) return avatarUrl;
+    // Không có cache: gọi service cũ
+    final uid = await _userService.getCurrentUserId();
+    if (uid == null) return null;
+    final details = await _userService.getByUserId(uid);
+    _myDetails = details;
+    notifyListeners();
+    return details?.avatarUrl;
+  }
+
+  // ====== CÁC API CŨ (GIỮ NGUYÊN CHO CODE KHÁC) ======
+  Future<String?> getCurrentUserId() async => _userService.getCurrentUserId();
+  Future<User?> getCurrentUser() async => _userService.getCurrentUser();
+  Future<UserDetails?> getByUserId(String userId) =>
+      _userService.getByUserId(userId);
+
+  Future<String?> uploadAvatar(File file) async {
+    final url = await _userService.uploadAvatar(file);
+    if (url != null) {
+      // Cập nhật cache để UI đổi ảnh ngay
+      if (_myDetails != null) {
+        _myDetails = _myDetails!.copyWith(avatarUrl: url);
+      } else {
+        // nếu chưa có record details, tạo tạm bản mới trong cache (tùy constructor của bạn)
+        _myDetails = UserDetails(
+          id: '', // hoặc null/khác tùy model
+          userId: _currentUser?.id ?? '',
+          fullname: _currentUser?.username,
+          avatarUrl: url,
+          level: null,
+          playStyle: const [],
+          gender: null,
+          birthday: null,
+        );
+      }
+      notifyListeners();
+    }
+    return url;
   }
 
   Future<UserDetails> updateMyDetails({
@@ -44,6 +127,7 @@ class UserManager with ChangeNotifier {
       gender: gender,
       birthday: birthday,
     );
+    _myDetails = updated; // sync cache
     notifyListeners();
     return updated;
   }

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -79,7 +79,7 @@ class PostService {
           'content': content.trim(),
           'is_active': true,
         },
-        files: files.isEmpty ? null : files,
+        files: files,
       );
 
       return CommunityPost.fromRecord(record, pocketBase);

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/community_post.dart';
+import 'pocketbase_client.dart';
+
+class PostServiceException implements Exception {
+  PostServiceException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class PostService {
+  static const String postsCollection = 'posts';
+
+  Future<List<CommunityPost>> fetchPosts({
+    int page = 1,
+    int perPage = 20,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+    try {
+      final result = await pocketBase.collection(postsCollection).getList(
+            page: page,
+            perPage: perPage,
+            sort: '-created',
+            expand: 'author',
+            filter: "is_active = true",
+          );
+
+      return result.items
+          .map((record) => CommunityPost.fromRecord(record, pocketBase))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientError(error));
+    } catch (_) {
+      throw PostServiceException(
+        'Không thể tải bài viết. Vui lòng thử lại sau.',
+      );
+    }
+  }
+
+  Future<CommunityPost> createPost({
+    required String content,
+    List<File> images = const [],
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+    final currentUserId = pocketBase.authStore.record?.id;
+    if (currentUserId == null) {
+      throw PostServiceException('Bạn cần đăng nhập để đăng bài viết.');
+    }
+
+    if (content.trim().isEmpty && images.isEmpty) {
+      throw PostServiceException(
+        'Vui lòng nhập nội dung hoặc chọn ít nhất một ảnh.',
+      );
+    }
+
+    final files = <http.MultipartFile>[];
+    for (final image in images) {
+      final bytes = await image.readAsBytes();
+      final filename = p.basename(image.path);
+      files.add(
+        http.MultipartFile.fromBytes(
+          'images',
+          bytes,
+          filename: filename,
+        ),
+      );
+    }
+
+    try {
+      final record = await pocketBase.collection(postsCollection).create(
+        body: {
+          'author': currentUserId,
+          'content': content.trim(),
+          'is_active': true,
+        },
+        files: files.isEmpty ? null : files,
+      );
+
+      return CommunityPost.fromRecord(record, pocketBase);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientError(error));
+    } catch (_) {
+      throw PostServiceException('Đăng bài viết thất bại. Vui lòng thử lại.');
+    }
+  }
+
+  String _mapClientError(ClientException error) {
+    if (error.response != null && error.response['message'] is String) {
+      return error.response['message'] as String;
+    }
+    return 'Có lỗi xảy ra. Vui lòng thử lại.';
+  }
+}

--- a/lib/services/recruitment_service.dart
+++ b/lib/services/recruitment_service.dart
@@ -1,0 +1,262 @@
+import 'package:badminton_booking_app/models/recruitment_post.dart';
+import 'package:badminton_booking_app/models/user_booking_view.dart';
+import 'package:badminton_booking_app/utils/recruitment_dictionary.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import 'pocketbase_client.dart';
+
+class RecruitmentServiceException implements Exception {
+  RecruitmentServiceException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class RecruitmentService {
+  static const String recruitmentPostsCollection = 'recruitment_posts';
+  static const String recruitmentApplicantsCollection = 'recruitment_applicants';
+  static const String bookingsCollection = 'court_bookings';
+
+  Future<List<RecruitmentPost>> fetchActivePosts({
+    int page = 1,
+    int perPage = 30,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+    final currentUserId = pocketBase.authStore.record?.id;
+
+    try {
+      final result = await pocketBase.collection(recruitmentPostsCollection).getList(
+            page: page,
+            perPage: perPage,
+            sort: '-created',
+            expand: 'author,court',
+            filter:
+                "is_active = true && (expires_at = '' || expires_at = null || expires_at >= '${DateTime.now().toUtc().toIso8601String()}')",
+          );
+
+      final applicantsMap = await _fetchApplicantsMap(
+        pocketBase: pocketBase,
+        recruitmentIds: result.items.map((e) => e.id).toList(growable: false),
+      );
+
+      return result.items
+          .map(
+            (record) => RecruitmentPost.fromRecord(
+              record: record,
+              pocketBase: pocketBase,
+              currentUserId: currentUserId,
+              applicants: applicantsMap[record.id] ?? const [],
+            ),
+          )
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (_) {
+      throw RecruitmentServiceException(
+        'Không thể tải bài tuyển thành viên. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<RecruitmentPost> joinRecruitment(String recruitmentId) async {
+    final pocketBase = await getPocketbaseInstance();
+    final currentUserId = pocketBase.authStore.record?.id;
+    if (currentUserId == null) {
+      throw RecruitmentServiceException('Bạn cần đăng nhập để tham gia.');
+    }
+
+    try {
+      await pocketBase.collection(recruitmentApplicantsCollection).create(
+        body: {
+          'recruitment': recruitmentId,
+          'user': currentUserId,
+        },
+      );
+    } on ClientException catch (error) {
+      if (error.statusCode == 400) {
+        throw RecruitmentServiceException('Bạn đã tham gia bài tuyển này.');
+      }
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (_) {
+      throw RecruitmentServiceException('Không thể tham gia bài tuyển.');
+    }
+
+    return getRecruitmentById(recruitmentId);
+  }
+
+  Future<RecruitmentPost> getRecruitmentById(String recruitmentId) async {
+    final pocketBase = await getPocketbaseInstance();
+    final currentUserId = pocketBase.authStore.record?.id;
+
+    try {
+      final record = await pocketBase
+          .collection(recruitmentPostsCollection)
+          .getOne(recruitmentId, expand: 'author,court');
+
+      final applicantsMap = await _fetchApplicantsMap(
+        pocketBase: pocketBase,
+        recruitmentIds: [recruitmentId],
+      );
+
+      return RecruitmentPost.fromRecord(
+        record: record,
+        pocketBase: pocketBase,
+        currentUserId: currentUserId,
+        applicants: applicantsMap[recruitmentId] ?? const [],
+      );
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (_) {
+      throw RecruitmentServiceException(
+        'Không thể tải thông tin bài tuyển. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<List<UserBookingView>> listMyBookingsForDate(DateTime date) async {
+    final pocketBase = await getPocketbaseInstance();
+    final currentUserId = pocketBase.authStore.record?.id;
+    if (currentUserId == null) {
+      throw RecruitmentServiceException('Bạn cần đăng nhập để kiểm tra sân.');
+    }
+
+    final dayStart = DateTime(date.year, date.month, date.day);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+    final escapedUserId = _escapeFilterValue(currentUserId);
+
+    final filter =
+        "user_id='$escapedUserId' && start_time < '${dayEnd.toUtc().toIso8601String()}' && end_time > '${dayStart.toUtc().toIso8601String()}' && status != 'cancelled' && status != 'expired'";
+
+    try {
+      final result = await pocketBase.collection(bookingsCollection).getList(
+            page: 1,
+            perPage: 200,
+            filter: filter,
+            expand: 'court_id,court_unit_id',
+          );
+
+      return result.items
+          .map((record) => UserBookingView.fromRecord(record, pocketBase))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (_) {
+      throw RecruitmentServiceException(
+        'Không thể kiểm tra lịch đặt sân. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<RecruitmentPost> createRecruitmentPost({
+    required bool hasBookedCourt,
+    required DateTime playTime,
+    required int needMembers,
+    required String playStyleLabel,
+    required String skillLevelLabel,
+    String? note,
+    String? courtId,
+    String? locationNote,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+    final currentUserId = pocketBase.authStore.record?.id;
+    if (currentUserId == null) {
+      throw RecruitmentServiceException('Bạn cần đăng nhập để đăng bài tuyển.');
+    }
+
+    try {
+      final record = await pocketBase.collection(recruitmentPostsCollection).create(
+        body: {
+          'author': currentUserId,
+          'content': note?.trim(),
+          'need_members': needMembers,
+          'play_style': RecruitmentDictionary.playStyleValueFromLabel(playStyleLabel),
+          'skill_level': RecruitmentDictionary.skillValueFromLabel(skillLevelLabel),
+          'event_time': playTime.toUtc().toIso8601String(),
+          'court': hasBookedCourt ? courtId : null,
+          'location_note': locationNote,
+          'is_active': true,
+        },
+      );
+
+      return RecruitmentPost.fromRecord(
+        record: record,
+        pocketBase: pocketBase,
+        currentUserId: currentUserId,
+      );
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (_) {
+      throw RecruitmentServiceException(
+        'Không thể đăng bài tuyển thành viên. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<Map<String, List<RecordModel>>> _fetchApplicantsMap({
+    required PocketBase pocketBase,
+    required List<String> recruitmentIds,
+  }) async {
+    if (recruitmentIds.isEmpty) {
+      return const {};
+    }
+
+    final filters = recruitmentIds
+        .map((id) => "recruitment='${_escapeFilterValue(id)}'")
+        .join(' || ');
+
+    try {
+      final result = await pocketBase.collection(recruitmentApplicantsCollection).getList(
+            page: 1,
+            perPage: 500,
+            filter: filters,
+          );
+
+      final map = <String, List<RecordModel>>{};
+      for (final record in result.items) {
+        final recruitmentId = (record.data['recruitment'] as String?) ?? '';
+        if (recruitmentId.isEmpty) continue;
+        map.putIfAbsent(recruitmentId, () => []).add(record);
+      }
+      return map;
+    } catch (_) {
+      return const {};
+    }
+  }
+
+  String _mapClientError(ClientException error) {
+    if (error.response != null && error.response['message'] is String) {
+      return error.response['message'] as String;
+    }
+    return 'Có lỗi xảy ra. Vui lòng thử lại.';
+  }
+
+  String _escapeFilterValue(String input) {
+    return input.replaceAll("'", "\\'");
+  }
+}
+
+class BookedCourtOption {
+  const BookedCourtOption({
+    required this.bookingView,
+  });
+
+  final UserBookingView bookingView;
+
+  String get id => bookingView.booking.id;
+
+  String get courtId => bookingView.booking.courtId;
+
+  String get displayName {
+    final name = bookingView.courtName ?? 'Sân chưa rõ';
+    final unit = bookingView.courtUnitLabel != null
+        ? ' - ${bookingView.courtUnitLabel}'
+        : '';
+    final start = bookingView.booking.startTime.toLocal();
+    final end = bookingView.booking.endTime.toLocal();
+    final timeLabel =
+        '${_twoDigits(start.hour)}:${_twoDigits(start.minute)} - ${_twoDigits(end.hour)}:${_twoDigits(end.minute)}';
+    return '$name$unit ($timeLabel)';
+  }
+
+  static String _twoDigits(int value) => value.toString().padLeft(2, '0');
+}

--- a/lib/utils/recruitment_dictionary.dart
+++ b/lib/utils/recruitment_dictionary.dart
@@ -1,0 +1,57 @@
+class RecruitmentDictionary {
+  RecruitmentDictionary._();
+
+  static const Map<String, String> playStyleLabels = {
+    'singles': 'Đánh đơn',
+    'doubles': 'Đánh đôi',
+    'mixed': 'Linh hoạt',
+  };
+
+  static const Map<String, String> skillLevelLabels = {
+    'Beginner': 'Mới chơi',
+    'Lower Intermediate': 'Trung bình yếu',
+    'Intermediate': 'Trung bình',
+    'Upper Intermediate': 'Trung bình khá',
+    'Advanced': 'Nâng cao',
+  };
+
+  static String playStyleLabelFromValue(String? value) {
+    if (value == null) {
+      return 'Không xác định';
+    }
+    return playStyleLabels[value] ?? value;
+  }
+
+  static String skillLabelFromValue(dynamic value) {
+    if (value == null) {
+      return 'Không xác định';
+    }
+    final key = value is String ? value : value.toString();
+    return skillLevelLabels[key] ?? key;
+  }
+
+  static String playStyleValueFromLabel(String label) {
+    return _reverseLookup(playStyleLabels, label) ?? 'mixed';
+  }
+
+  static String skillValueFromLabel(String label) {
+    return _reverseLookup(skillLevelLabels, label) ?? 'Intermediate';
+  }
+
+  static List<String> playStyleDisplayOptions() {
+    return playStyleLabels.values.toList(growable: false);
+  }
+
+  static List<String> skillDisplayOptions() {
+    return skillLevelLabels.values.toList(growable: false);
+  }
+
+  static String? _reverseLookup(Map<String, String> map, String label) {
+    for (final entry in map.entries) {
+      if (entry.value == label) {
+        return entry.key;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- connect the social feed to PocketBase via new manager/services and expose refresh/join behaviours in the UI
- allow composing community posts with multi-image uploads and render an Instagram-like carousel on the timeline
- refactor the recruitment form to verify booked courts, handle long court names, and surface backend-powered submissions

## Testing
- flutter test *(fails: Flutter CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690ce8492b18832bbe6e9617c10de259