### PR TITLE
Add user avatars and interactions to community posts

### DIFF
--- a/lib/components/my_post.dart
+++ b/lib/components/my_post.dart
@@ -178,25 +178,42 @@ class _MyPostState extends State<MyPost> {
         ),
 
         // Likes (optional)
-        if ((widget.likesCount ?? 0) > 0)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Text(
-              '${widget.likesCount} lượt thích',
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
-            ),
-          ),
+        Row(
+          children: [
+            // Likes
+            if ((widget.likesCount ?? 0) > 0)
+              Padding(
+                padding: const EdgeInsets.only(left: 12, right: 4),
+                child: Text(
+                  '${widget.likesCount} lượt thích',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+              ),
 
-        if ((widget.commentsCount ?? 0) > 0)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
-            child: Text(
-              '${widget.commentsCount} bình luận',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-          ),
+            // Dot separator — chỉ hiện khi có likes và comments
+            if ((widget.likesCount ?? 0) > 0 && (widget.commentsCount ?? 0) > 0)
+              Padding(
+                padding: const EdgeInsets.only(left: 12, right: 4),
+                child: Icon(
+                  Icons.circle,
+                  size: 5,
+                  color: Theme.of(context).hintColor,
+                ),
+              ),
+
+            // Comments
+            if ((widget.commentsCount ?? 0) > 0)
+              Padding(
+                padding: const EdgeInsets.only(left: 12, right: 4),
+                child: Text(
+                  '${widget.commentsCount} bình luận',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+          ],
+        ),
 
         // Caption: Username + content (like Instagram)
         if (widget.content.trim().isNotEmpty) ...[

--- a/lib/components/my_post.dart
+++ b/lib/components/my_post.dart
@@ -7,18 +7,21 @@ class MyPost extends StatefulWidget {
     required this.userName,
     required this.time,
     this.imageUrls = const [],
+    this.avatarUrl,
     this.onLikePressed,
     this.onCommentPressed,
     this.onSharePressed,
     this.onSavePressed,
     this.isLiked = false,
     this.likesCount,
+    this.commentsCount,
   });
 
   final String content;
   final String userName;
   final DateTime time;
   final List<String> imageUrls;
+  final String? avatarUrl;
 
   // Actions
   final VoidCallback? onLikePressed;
@@ -29,6 +32,7 @@ class MyPost extends StatefulWidget {
   // UI state (optional)
   final bool isLiked;
   final int? likesCount;
+  final int? commentsCount;
 
   @override
   State<MyPost> createState() => _MyPostState();
@@ -37,13 +41,11 @@ class MyPost extends StatefulWidget {
 class _MyPostState extends State<MyPost> {
   late final PageController _pageController;
   int _currentIndex = 0;
-  late bool _liked;
 
   @override
   void initState() {
     super.initState();
     _pageController = PageController();
-    _liked = widget.isLiked;
   }
 
   @override
@@ -69,16 +71,22 @@ class _MyPostState extends State<MyPost> {
             children: [
               CircleAvatar(
                 radius: 20,
-                backgroundColor: cs.primary,
-                child: Text(
-                  widget.userName.isNotEmpty
-                      ? widget.userName[0].toUpperCase()
-                      : 'U',
-                  style: TextStyle(
-                    color: cs.onPrimary,
-                    fontWeight: FontWeight.w800,
-                  ),
-                ),
+                backgroundColor:
+                    widget.avatarUrl == null ? cs.primary : Colors.transparent,
+                backgroundImage: widget.avatarUrl != null
+                    ? NetworkImage(widget.avatarUrl!)
+                    : null,
+                child: widget.avatarUrl == null
+                    ? Text(
+                        widget.userName.isNotEmpty
+                            ? widget.userName[0].toUpperCase()
+                            : 'U',
+                        style: TextStyle(
+                          color: cs.onPrimary,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      )
+                    : null,
               ),
               const SizedBox(width: 10),
               Expanded(
@@ -135,14 +143,13 @@ class _MyPostState extends State<MyPost> {
             children: [
               IconButton(
                 onPressed: () {
-                  setState(() => _liked = !_liked);
                   widget.onLikePressed?.call();
                 },
                 icon: Icon(
-                  _liked ? Icons.favorite : Icons.favorite_border,
+                  widget.isLiked ? Icons.favorite : Icons.favorite_border,
                   size: 30,
                 ),
-                color: _liked ? Colors.red : cs.onSurface,
+                color: widget.isLiked ? Colors.red : cs.onSurface,
               ),
               IconButton(
                 onPressed: widget.onCommentPressed,
@@ -179,6 +186,15 @@ class _MyPostState extends State<MyPost> {
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     fontWeight: FontWeight.w700,
                   ),
+            ),
+          ),
+
+        if ((widget.commentsCount ?? 0) > 0)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+            child: Text(
+              '${widget.commentsCount} bình luận',
+              style: Theme.of(context).textTheme.bodyMedium,
             ),
           ),
 

--- a/lib/components/post_comments_sheet.dart
+++ b/lib/components/post_comments_sheet.dart
@@ -72,6 +72,7 @@ class _PostCommentsSheetState extends State<PostCommentsSheet> {
     final media = MediaQuery.of(context);
     final height = media.size.height * 0.65;
     final bottomInset = media.viewInsets.bottom;
+    final cs = Theme.of(context).colorScheme;
 
     return SafeArea(
       top: false,
@@ -80,13 +81,15 @@ class _PostCommentsSheetState extends State<PostCommentsSheet> {
         builder: (context, _) {
           final comments = widget.manager.commentsFor(widget.postId);
           final isLoading = widget.manager.isLoadingComments(widget.postId);
-          final isSubmitting = widget.manager.isSubmittingComment(widget.postId);
+          final isSubmitting =
+              widget.manager.isSubmittingComment(widget.postId);
 
           return Container(
             padding: EdgeInsets.fromLTRB(16, 12, 16, 12 + bottomInset),
             decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.surface,
-              borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(20)),
             ),
             child: SizedBox(
               height: height,
@@ -106,7 +109,8 @@ class _PostCommentsSheetState extends State<PostCommentsSheet> {
                     child: isLoading
                         ? const Center(child: CircularProgressIndicator())
                         : comments.isEmpty
-                            ? const Center(child: Text('Chưa có bình luận nào.'))
+                            ? const Center(
+                                child: Text('Chưa có bình luận nào.'))
                             : ListView.separated(
                                 padding: EdgeInsets.zero,
                                 itemCount: comments.length,
@@ -141,9 +145,14 @@ class _PostCommentsSheetState extends State<PostCommentsSheet> {
                             ? const SizedBox(
                                 height: 18,
                                 width: 18,
-                                child: CircularProgressIndicator(strokeWidth: 2.2),
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2.2),
                               )
-                            : const Icon(Icons.send_rounded, size: 20),
+                            : Icon(
+                                Icons.send_rounded,
+                                size: 20,
+                                color: cs.onPrimary,
+                              ),
                       ),
                     ],
                   ),

--- a/lib/components/post_comments_sheet.dart
+++ b/lib/components/post_comments_sheet.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+
+import '../models/post_comment.dart';
+import '../pages/social/social_manager.dart';
+
+class PostCommentsSheet extends StatefulWidget {
+  const PostCommentsSheet({
+    super.key,
+    required this.postId,
+    required this.manager,
+  });
+
+  final String postId;
+  final SocialManager manager;
+
+  @override
+  State<PostCommentsSheet> createState() => _PostCommentsSheetState();
+}
+
+class _PostCommentsSheetState extends State<PostCommentsSheet> {
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _loadComments();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadComments() async {
+    try {
+      await widget.manager.loadComments(widget.postId, forceRefresh: true);
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    }
+  }
+
+  Future<void> _submit() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) {
+      return;
+    }
+
+    try {
+      await widget.manager.addComment(widget.postId, text);
+      if (!mounted) return;
+      _controller.clear();
+      _focusNode.requestFocus();
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final media = MediaQuery.of(context);
+    final height = media.size.height * 0.65;
+    final bottomInset = media.viewInsets.bottom;
+
+    return SafeArea(
+      top: false,
+      child: AnimatedBuilder(
+        animation: widget.manager,
+        builder: (context, _) {
+          final comments = widget.manager.commentsFor(widget.postId);
+          final isLoading = widget.manager.isLoadingComments(widget.postId);
+          final isSubmitting = widget.manager.isSubmittingComment(widget.postId);
+
+          return Container(
+            padding: EdgeInsets.fromLTRB(16, 12, 16, 12 + bottomInset),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+            ),
+            child: SizedBox(
+              height: height,
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                children: [
+                  Container(
+                    width: 40,
+                    height: 4,
+                    margin: const EdgeInsets.only(bottom: 12),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.outlineVariant,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  Expanded(
+                    child: isLoading
+                        ? const Center(child: CircularProgressIndicator())
+                        : comments.isEmpty
+                            ? const Center(child: Text('Chưa có bình luận nào.'))
+                            : ListView.separated(
+                                padding: EdgeInsets.zero,
+                                itemCount: comments.length,
+                                separatorBuilder: (_, __) =>
+                                    const Divider(height: 16),
+                                itemBuilder: (_, index) {
+                                  final comment = comments[index];
+                                  return _CommentTile(comment: comment);
+                                },
+                              ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _controller,
+                          focusNode: _focusNode,
+                          textInputAction: TextInputAction.send,
+                          onSubmitted: (_) => _submit(),
+                          decoration: const InputDecoration(
+                            hintText: 'Viết bình luận...',
+                            border: OutlineInputBorder(),
+                            isDense: true,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      ElevatedButton(
+                        onPressed: isSubmitting ? null : _submit,
+                        child: isSubmitting
+                            ? const SizedBox(
+                                height: 18,
+                                width: 18,
+                                child: CircularProgressIndicator(strokeWidth: 2.2),
+                              )
+                            : const Icon(Icons.send_rounded, size: 20),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CommentTile extends StatelessWidget {
+  const _CommentTile({required this.comment});
+
+  final PostComment comment;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CircleAvatar(
+          radius: 18,
+          backgroundColor:
+              comment.authorAvatarUrl == null ? cs.primary : Colors.transparent,
+          backgroundImage: comment.authorAvatarUrl != null
+              ? NetworkImage(comment.authorAvatarUrl!)
+              : null,
+          child: comment.authorAvatarUrl == null
+              ? Text(
+                  comment.authorName.isNotEmpty
+                      ? comment.authorName[0].toUpperCase()
+                      : 'U',
+                  style: TextStyle(
+                    color: cs.onPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                )
+              : null,
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                comment.authorName,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 4),
+              Text(comment.content),
+              const SizedBox(height: 6),
+              Text(
+                _timeAgo(comment.createdAt),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _timeAgo(DateTime t) {
+    final diff = DateTime.now().difference(t);
+    if (diff.inMinutes < 1) return 'Vừa xong';
+    if (diff.inMinutes < 60) return '${diff.inMinutes} phút trước';
+    if (diff.inHours < 24) return '${diff.inHours} giờ trước';
+    if (diff.inDays < 7) return '${diff.inDays} ngày trước';
+    final weeks = (diff.inDays / 7).floor();
+    if (weeks < 5) return '$weeks tuần trước';
+    final months = (diff.inDays / 30).floor();
+    if (months < 12) return '$months tháng trước';
+    final years = (diff.inDays / 365).floor();
+    return '$years năm trước';
+  }
+}

--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -5,6 +5,7 @@ class RecruitmentPostCard extends StatelessWidget {
   final String hostName;
   final DateTime createdTime;
   final String? skillLevel;
+  final String? hostAvatarUrl;
   final int requiredPlayers;
   final int joinedPlayers;
   final String? description;
@@ -24,6 +25,7 @@ class RecruitmentPostCard extends StatelessWidget {
     required this.requiredPlayers,
     required this.joinedPlayers,
     this.skillLevel,
+    this.hostAvatarUrl,
     this.description,
     this.courtName,
     this.playTime,
@@ -158,14 +160,19 @@ class RecruitmentPostCard extends StatelessWidget {
       children: [
         CircleAvatar(
           radius: 26,
-          backgroundColor: cs.primary,
-          child: Text(
-            (hostName.isNotEmpty ? hostName[0] : '?').toUpperCase(),
-            style: textTheme.titleMedium?.copyWith(
-              color: cs.onPrimary,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
+          backgroundColor:
+              hostAvatarUrl == null ? cs.primary : Colors.transparent,
+          backgroundImage:
+              hostAvatarUrl != null ? NetworkImage(hostAvatarUrl!) : null,
+          child: hostAvatarUrl == null
+              ? Text(
+                  (hostName.isNotEmpty ? hostName[0] : '?').toUpperCase(),
+                  style: textTheme.titleMedium?.copyWith(
+                    color: cs.onPrimary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                )
+              : null,
         ),
         const SizedBox(width: 16),
         Expanded(

--- a/lib/models/community_post.dart
+++ b/lib/models/community_post.dart
@@ -32,11 +32,16 @@ class CommunityPost {
 
     final authorRecord = resolveExpandedRecord(record.expand?['author']);
     final authorData = authorRecord?.data;
-    final displayName = sanitizeDisplayName(
-      (authorData?['username'] as String?) ??
-          (authorData?['email'] as String?) ??
-          'Người dùng',
-    );
+    final authorId = (data['author'] as String?) ?? authorRecord?.id ?? '';
+    final isOwner =
+        authorId.isNotEmpty && authorId == pocketBase.authStore.record?.id;
+    final displayName = isOwner
+        ? 'Bạn'
+        : sanitizeDisplayName(
+            (authorData?['username'] as String?) ??
+                (authorData?['email'] as String?) ??
+                'Người dùng',
+          );
     final avatarUrl = resolveFileUrl(
       pocketBase,
       authorRecord,
@@ -45,7 +50,7 @@ class CommunityPost {
 
     return CommunityPost(
       id: record.id,
-      authorId: (data['author'] as String?) ?? authorRecord?.id ?? '',
+      authorId: authorId,
       authorName: displayName,
       authorAvatarUrl: avatarUrl,
       content: (data['content'] as String?)?.trim() ?? '',

--- a/lib/models/community_post.dart
+++ b/lib/models/community_post.dart
@@ -1,15 +1,22 @@
 import 'package:pocketbase/pocketbase.dart';
 
+import '../utils/pocketbase_utils.dart';
+
 class CommunityPost {
   const CommunityPost({
     required this.id,
     required this.authorId,
     required this.authorName,
+    required this.authorAvatarUrl,
     required this.content,
     required this.imageUrls,
     required this.isActive,
     required this.createdAt,
     required this.updatedAt,
+    this.likesCount = 0,
+    this.isLiked = false,
+    this.likeRecordId,
+    this.commentsCount = 0,
   });
 
   factory CommunityPost.fromRecord(RecordModel record, PocketBase pocketBase) {
@@ -23,18 +30,24 @@ class CommunityPost {
       imageUrls.add(url);
     }
 
-    final authorRecord = _resolveExpandedRecord(record.expand?['author']);
+    final authorRecord = resolveExpandedRecord(record.expand?['author']);
     final authorData = authorRecord?.data;
-    final displayName = _sanitizeName(
+    final displayName = sanitizeDisplayName(
       (authorData?['username'] as String?) ??
           (authorData?['email'] as String?) ??
           'Người dùng',
+    );
+    final avatarUrl = resolveFileUrl(
+      pocketBase,
+      authorRecord,
+      authorData?['avatar'],
     );
 
     return CommunityPost(
       id: record.id,
       authorId: (data['author'] as String?) ?? authorRecord?.id ?? '',
       authorName: displayName,
+      authorAvatarUrl: avatarUrl,
       content: (data['content'] as String?)?.trim() ?? '',
       imageUrls: imageUrls,
       isActive: data['is_active'] == true,
@@ -46,13 +59,52 @@ class CommunityPost {
   final String id;
   final String authorId;
   final String authorName;
+  final String? authorAvatarUrl;
   final String content;
   final List<String> imageUrls;
   final bool isActive;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final int likesCount;
+  final bool isLiked;
+  final String? likeRecordId;
+  final int commentsCount;
 
   bool get hasImages => imageUrls.isNotEmpty;
+
+  CommunityPost copyWith({
+    String? id,
+    String? authorId,
+    String? authorName,
+    String? authorAvatarUrl,
+    String? content,
+    List<String>? imageUrls,
+    bool? isActive,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    int? likesCount,
+    bool? isLiked,
+    Object? likeRecordId = _unset,
+    int? commentsCount,
+  }) {
+    return CommunityPost(
+      id: id ?? this.id,
+      authorId: authorId ?? this.authorId,
+      authorName: authorName ?? this.authorName,
+      authorAvatarUrl: authorAvatarUrl ?? this.authorAvatarUrl,
+      content: content ?? this.content,
+      imageUrls: imageUrls ?? this.imageUrls,
+      isActive: isActive ?? this.isActive,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      likesCount: likesCount ?? this.likesCount,
+      isLiked: isLiked ?? this.isLiked,
+      likeRecordId: likeRecordId == _unset
+          ? this.likeRecordId
+          : likeRecordId as String?,
+      commentsCount: commentsCount ?? this.commentsCount,
+    );
+  }
 }
 
 List<String> _normalizeFileList(dynamic value) {
@@ -69,24 +121,4 @@ List<String> _normalizeFileList(dynamic value) {
   return const [];
 }
 
-RecordModel? _resolveExpandedRecord(dynamic expanded) {
-  if (expanded is RecordModel) {
-    return expanded;
-  }
-  if (expanded is List) {
-    for (final item in expanded) {
-      if (item is RecordModel) {
-        return item;
-      }
-    }
-  }
-  return null;
-}
-
-String _sanitizeName(String? value) {
-  final trimmed = value?.trim();
-  if (trimmed == null || trimmed.isEmpty) {
-    return 'Người dùng';
-  }
-  return trimmed;
-}
+const Object _unset = Object();

--- a/lib/models/post_comment.dart
+++ b/lib/models/post_comment.dart
@@ -1,0 +1,47 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../utils/pocketbase_utils.dart';
+
+class PostComment {
+  const PostComment({
+    required this.id,
+    required this.postId,
+    required this.authorId,
+    required this.authorName,
+    required this.authorAvatarUrl,
+    required this.content,
+    required this.createdAt,
+  });
+
+  factory PostComment.fromRecord(RecordModel record, PocketBase pocketBase) {
+    final data = record.data;
+    final authorRecord = resolveExpandedRecord(record.expand?['author']);
+    final authorData = authorRecord?.data;
+
+    return PostComment(
+      id: record.id,
+      postId: (data['post'] as String?) ?? '',
+      authorId: (data['author'] as String?) ?? authorRecord?.id ?? '',
+      authorName: sanitizeDisplayName(
+        (authorData?['username'] as String?) ??
+            (authorData?['email'] as String?) ??
+            'Người dùng',
+      ),
+      authorAvatarUrl: resolveFileUrl(
+        pocketBase,
+        authorRecord,
+        authorData?['avatar'],
+      ),
+      content: (data['content'] as String?)?.trim() ?? '',
+      createdAt: DateTime.parse(data['created'] as String),
+    );
+  }
+
+  final String id;
+  final String postId;
+  final String authorId;
+  final String authorName;
+  final String? authorAvatarUrl;
+  final String content;
+  final DateTime createdAt;
+}

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -1,11 +1,14 @@
 import 'package:badminton_booking_app/utils/recruitment_dictionary.dart';
 import 'package:pocketbase/pocketbase.dart';
 
+import '../utils/pocketbase_utils.dart';
+
 class RecruitmentPost {
   const RecruitmentPost({
     required this.id,
     required this.authorId,
     required this.authorName,
+    required this.authorAvatarUrl,
     required this.description,
     required this.requiredPlayers,
     required this.joinedPlayers,
@@ -30,12 +33,21 @@ class RecruitmentPost {
     final authorRecord = _resolveExpandedRecord(record.expand?['author']);
     final authorData = authorRecord?.data;
     final authorId = (data['author'] as String?) ?? authorRecord?.id ?? '';
-    final authorName = _sanitizeName(
-          (authorData?['username'] as String?) ??
-              (authorData?['email'] as String?),
-          // Bỏ fallback 'Người chơi' ở trong này
-        ) ??
-        'Người chơi';
+    final loggedInUserId = currentUserId ?? pocketBase.authStore.record?.id;
+    final isOwner = authorId == loggedInUserId;
+    final authorName = isOwner
+        ? 'Bạn'
+        : _sanitizeName(
+              (authorData?['username'] as String?) ??
+                  (authorData?['email'] as String?),
+              // Bỏ fallback 'Người chơi' ở trong này
+            ) ??
+            'Người chơi';
+    final authorAvatarUrl = resolveFileUrl(
+      pocketBase,
+      authorRecord,
+      authorData?['avatar'],
+    );
 
     final courtRecord = _resolveExpandedRecord(record.expand?['court']);
     final courtData = courtRecord?.data;
@@ -49,12 +61,13 @@ class RecruitmentPost {
         .toList();
 
     final joinedCount = applicantUserIds.length + 1; // tính cả chủ bài
-    final hasJoined = applicantUserIds.contains(currentUserId);
+    final hasJoined = applicantUserIds.contains(loggedInUserId);
 
     return RecruitmentPost(
       id: record.id,
       authorId: authorId,
       authorName: authorName,
+      authorAvatarUrl: authorAvatarUrl,
       description: (data['content'] as String?)?.trim() ?? '',
       requiredPlayers: (data['need_members'] as int?) ?? 0,
       joinedPlayers: joinedCount,
@@ -66,8 +79,8 @@ class RecruitmentPost {
       createdAt: DateTime.parse(data['created'] as String),
       eventTime: _tryParseDateTime(data['event_time']),
       courtName: courtName,
-      isJoined: hasJoined || authorId == currentUserId,
-      isOwner: authorId == currentUserId,
+      isJoined: hasJoined || authorId == loggedInUserId,
+      isOwner: isOwner,
       locationNote: (data['location_note'] as String?)?.trim(),
     );
   }
@@ -75,6 +88,7 @@ class RecruitmentPost {
   final String id;
   final String authorId;
   final String authorName;
+  final String? authorAvatarUrl;
   final String description;
   final int requiredPlayers;
   final int joinedPlayers;
@@ -90,11 +104,13 @@ class RecruitmentPost {
   RecruitmentPost copyWith({
     int? joinedPlayers,
     bool? isJoined,
+    String? authorAvatarUrl,
   }) {
     return RecruitmentPost(
       id: id,
       authorId: authorId,
       authorName: authorName,
+      authorAvatarUrl: authorAvatarUrl ?? this.authorAvatarUrl,
       description: description,
       requiredPlayers: requiredPlayers,
       joinedPlayers: joinedPlayers ?? this.joinedPlayers,

--- a/lib/pages/social/post_manager.dart
+++ b/lib/pages/social/post_manager.dart
@@ -1,0 +1,515 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../../models/community_post.dart';
+import '../../models/post_comment.dart';
+import '../../services/post_service.dart';
+import '../../services/pocketbase_client.dart';
+
+class PostManager extends ChangeNotifier {
+  PostManager() : _postService = PostService() {
+    _initializeRealtime();
+  }
+
+  final PostService _postService;
+
+  bool _isDisposed = false;
+  bool _isLoadingPosts = false;
+  bool _isSubmittingPost = false;
+
+  List<CommunityPost> _posts = const [];
+  String? _postError;
+
+  final Set<String> _likingPosts = <String>{};
+  final Set<String> _loadingComments = <String>{};
+  final Set<String> _submittingComments = <String>{};
+  final Set<String> _loadedComments = <String>{};
+  final Map<String, List<PostComment>> _postComments =
+      <String, List<PostComment>>{};
+
+  UnsubscribeFunc? _postsUnsubscribe;
+  UnsubscribeFunc? _likesUnsubscribe;
+  UnsubscribeFunc? _commentsUnsubscribe;
+
+  bool get isLoadingPosts => _isLoadingPosts;
+  bool get isSubmittingPost => _isSubmittingPost;
+
+  List<CommunityPost> get posts => _posts;
+  String? get postError => _postError;
+
+  bool isLikingPost(String postId) => _likingPosts.contains(postId);
+  bool isLoadingComments(String postId) => _loadingComments.contains(postId);
+  bool isSubmittingComment(String postId) =>
+      _submittingComments.contains(postId);
+  List<PostComment> commentsFor(String postId) =>
+      _postComments[postId] ?? const <PostComment>[];
+
+  Future<void> refreshPosts() async {
+    _isLoadingPosts = true;
+    _postError = null;
+    notifyListeners();
+
+    try {
+      final results = await _postService.fetchPosts();
+      _posts = results;
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+    } finally {
+      _isLoadingPosts = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> createPost({
+    required String content,
+    List<File> images = const [],
+  }) async {
+    _isSubmittingPost = true;
+    notifyListeners();
+
+    try {
+      final newPost = await _postService.createPost(
+        content: content,
+        images: images,
+      );
+      _posts = [newPost, ..._posts];
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _isSubmittingPost = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> toggleLike(String postId) async {
+    final index = _posts.indexWhere((post) => post.id == postId);
+    if (index == -1 || _likingPosts.contains(postId)) {
+      return;
+    }
+
+    final post = _posts[index];
+    _likingPosts.add(postId);
+    notifyListeners();
+
+    try {
+      if (post.isLiked) {
+        await _postService.unlikePost(
+          postId: postId,
+          likeRecordId: post.likeRecordId,
+        );
+        final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
+        final updated = post.copyWith(
+          isLiked: false,
+          likesCount: newCount,
+          likeRecordId: null,
+        );
+        _updatePostAt(index, updated);
+      } else {
+        final likeRecordId = await _postService.likePost(postId);
+        final updated = post.copyWith(
+          isLiked: true,
+          likesCount: post.likesCount + 1,
+          likeRecordId: likeRecordId,
+        );
+        _updatePostAt(index, updated);
+      }
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _likingPosts.remove(postId);
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadComments(String postId, {bool forceRefresh = false}) async {
+    if (_loadingComments.contains(postId)) {
+      return;
+    }
+
+    if (!forceRefresh && _loadedComments.contains(postId)) {
+      return;
+    }
+
+    _loadingComments.add(postId);
+    notifyListeners();
+
+    try {
+      final comments = await _postService.fetchComments(postId);
+      _postComments[postId] = comments;
+      _loadedComments.add(postId);
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _loadingComments.remove(postId);
+      notifyListeners();
+    }
+  }
+
+  Future<void> addComment(String postId, String content) async {
+    if (_submittingComments.contains(postId)) {
+      return;
+    }
+
+    _submittingComments.add(postId);
+    notifyListeners();
+
+    try {
+      final comment = await _postService.createComment(
+        postId: postId,
+        content: content,
+      );
+
+      final comments = List<PostComment>.from(commentsFor(postId))
+        ..add(comment);
+      _postComments[postId] = comments;
+
+      final index = _posts.indexWhere((post) => post.id == postId);
+      if (index != -1) {
+        final post = _posts[index];
+        final updated =
+            post.copyWith(commentsCount: post.commentsCount + 1);
+        _updatePostAt(index, updated);
+      }
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _submittingComments.remove(postId);
+      notifyListeners();
+    }
+  }
+
+  void _initializeRealtime() {
+    unawaited(_setupPostsRealtime());
+    unawaited(_setupLikesRealtime());
+    unawaited(_setupCommentsRealtime());
+  }
+
+  Future<void> _setupPostsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _postsUnsubscribe;
+      _postsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _postsUnsubscribe =
+          await pocketBase.collection(PostService.postsCollection).subscribe(
+                '*',
+                _handlePostRealtimeEvent,
+                expand: 'author',
+              );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to initialize posts realtime subscription: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _setupLikesRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _likesUnsubscribe;
+      _likesUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _likesUnsubscribe = await pocketBase
+          .collection(PostService.postLikesCollection)
+          .subscribe('*', _handlePostLikeEvent);
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to initialize likes realtime subscription: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _setupCommentsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _commentsUnsubscribe;
+      _commentsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _commentsUnsubscribe = await pocketBase
+          .collection(PostService.postCommentsCollection)
+          .subscribe(
+        '*',
+        _handlePostCommentEvent,
+        expand: 'author',
+      );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint(
+            'Failed to initialize comments realtime subscription: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _handlePostRealtimeEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    try {
+      switch (event.action) {
+        case 'delete':
+          _removePost(record.id);
+          break;
+        case 'create':
+        case 'update':
+          final isActive = record.data['is_active'] != false;
+          if (!isActive) {
+            _removePost(record.id);
+            break;
+          }
+
+          final pocketBase = await getPocketbaseInstance();
+          final post =
+              await _postService.recordToCommunityPost(record, pocketBase);
+          final index = _posts.indexWhere((existing) => existing.id == post.id);
+          if (index == -1) {
+            _posts = [post, ..._posts];
+          } else {
+            _updatePostAt(index, post);
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process post realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> _handlePostLikeEvent(RecordSubscriptionEvent event) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    final postId = _extractRelationId(record, 'post');
+    if (postId == null) {
+      return;
+    }
+
+    final index = _posts.indexWhere((post) => post.id == postId);
+    if (index == -1) {
+      return;
+    }
+
+    final post = _posts[index];
+
+    try {
+      final pocketBase = await getPocketbaseInstance();
+      final currentUserId = pocketBase.authStore.record?.id;
+      final likeUserId = _extractRelationId(record, 'user');
+
+      switch (event.action) {
+        case 'create':
+          final updated = post.copyWith(
+            likesCount: post.likesCount + 1,
+            isLiked: currentUserId != null && currentUserId == likeUserId
+                ? true
+                : post.isLiked,
+            likeRecordId:
+                currentUserId != null && currentUserId == likeUserId
+                    ? record.id
+                    : post.likeRecordId,
+          );
+          _updatePostAt(index, updated);
+          break;
+        case 'delete':
+          final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
+          final updated = post.copyWith(
+            likesCount: newCount,
+            isLiked: currentUserId != null && currentUserId == likeUserId
+                ? false
+                : post.isLiked,
+            likeRecordId:
+                currentUserId != null && currentUserId == likeUserId
+                    ? null
+                    : post.likeRecordId,
+          );
+          _updatePostAt(index, updated);
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process like realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> _handlePostCommentEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    final postId = _extractRelationId(record, 'post');
+    if (postId == null) {
+      return;
+    }
+
+    final index = _posts.indexWhere((post) => post.id == postId);
+    if (index == -1) {
+      return;
+    }
+
+    final post = _posts[index];
+
+    try {
+      final pocketBase = await getPocketbaseInstance();
+      final hasLoadedComments = _loadedComments.contains(postId);
+      PostComment? updatedComment;
+      if (event.action != 'delete') {
+        updatedComment = PostComment.fromRecord(record, pocketBase);
+      }
+
+      switch (event.action) {
+        case 'create':
+          final newCount = post.commentsCount + 1;
+          _updatePostAt(index, post.copyWith(commentsCount: newCount));
+          if (hasLoadedComments && updatedComment != null) {
+            final comments = List<PostComment>.from(commentsFor(postId))
+              ..add(updatedComment);
+            _postComments[postId] = comments;
+          }
+          break;
+        case 'update':
+          if (hasLoadedComments && updatedComment != null) {
+            final comments = List<PostComment>.from(commentsFor(postId));
+            final commentIndex =
+                comments.indexWhere((comment) => comment.id == record.id);
+            if (commentIndex != -1) {
+              comments[commentIndex] = updatedComment;
+              _postComments[postId] = comments;
+            }
+          }
+          break;
+        case 'delete':
+          final newCount = post.commentsCount > 0
+              ? post.commentsCount - 1
+              : post.commentsCount;
+          _updatePostAt(index, post.copyWith(commentsCount: newCount));
+          if (hasLoadedComments) {
+            final comments = List<PostComment>.from(commentsFor(postId))
+              ..removeWhere((comment) => comment.id == record.id);
+            _postComments[postId] = comments;
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process comment realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  void _updatePostAt(int index, CommunityPost updated) {
+    final posts = List<CommunityPost>.from(_posts);
+    posts[index] = updated;
+    _posts = posts;
+  }
+
+  void _removePost(String postId) {
+    final previousLength = _posts.length;
+    _posts = _posts.where((post) => post.id != postId).toList(growable: false);
+    if (previousLength != _posts.length) {
+      _postComments.remove(postId);
+    }
+  }
+
+  String? _extractRelationId(RecordModel record, String field) {
+    final dataValue = record.data[field];
+    if (dataValue is String && dataValue.isNotEmpty) {
+      return dataValue;
+    }
+
+    final expanded = record.expand?[field];
+    if (expanded is RecordModel) {
+      return expanded.id;
+    }
+    if (expanded is List && expanded.isNotEmpty) {
+      final first = expanded.first;
+      if (first is RecordModel) {
+        return first.id;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    final unsubList = [
+      _postsUnsubscribe,
+      _likesUnsubscribe,
+      _commentsUnsubscribe,
+    ];
+    for (final unsub in unsubList) {
+      if (unsub != null) {
+        unawaited(unsub());
+      }
+    }
+    _postsUnsubscribe = null;
+    _likesUnsubscribe = null;
+    _commentsUnsubscribe = null;
+    super.dispose();
+  }
+}

--- a/lib/pages/social/post_manager.dart
+++ b/lib/pages/social/post_manager.dart
@@ -97,26 +97,19 @@ class PostManager extends ChangeNotifier {
 
     try {
       if (post.isLiked) {
+        // chỉ call API, không update _posts
         await _postService.unlikePost(
           postId: postId,
           likeRecordId: post.likeRecordId,
         );
-        final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
-        final updated = post.copyWith(
-          isLiked: false,
-          likesCount: newCount,
-          likeRecordId: null,
-        );
-        _updatePostAt(index, updated);
       } else {
-        final likeRecordId = await _postService.likePost(postId);
-        final updated = post.copyWith(
-          isLiked: true,
-          likesCount: post.likesCount + 1,
-          likeRecordId: likeRecordId,
-        );
-        _updatePostAt(index, updated);
+        await _postService.likePost(postId);
+        // không cần trả về likeRecordId ở đây nữa,
+        // realtime sẽ set lại chính xác
       }
+      // Realtime _handlePostLikeEvent sẽ:
+      // - tăng/giảm likesCount
+      // - set isLiked & likeRecordId đúng cho user hiện tại
     } on PostServiceException catch (error) {
       _postError = error.message;
       rethrow;
@@ -160,22 +153,15 @@ class PostManager extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final comment = await _postService.createComment(
+      // Chỉ gọi API, KHÔNG đụng vào _postComments hay _posts nữa
+      await _postService.createComment(
         postId: postId,
         content: content,
       );
 
-      final comments = List<PostComment>.from(commentsFor(postId))
-        ..add(comment);
-      _postComments[postId] = comments;
-
-      final index = _posts.indexWhere((post) => post.id == postId);
-      if (index != -1) {
-        final post = _posts[index];
-        final updated =
-            post.copyWith(commentsCount: post.commentsCount + 1);
-        _updatePostAt(index, updated);
-      }
+      // Realtime "create" sẽ tự:
+      // - tăng commentsCount trong _handlePostCommentEvent
+      // - thêm PostComment vào _postComments nếu chưa tồn tại
     } on PostServiceException catch (error) {
       _postError = error.message;
       rethrow;
@@ -249,10 +235,10 @@ class PostManager extends ChangeNotifier {
       _commentsUnsubscribe = await pocketBase
           .collection(PostService.postCommentsCollection)
           .subscribe(
-        '*',
-        _handlePostCommentEvent,
-        expand: 'author',
-      );
+            '*',
+            _handlePostCommentEvent,
+            expand: 'author',
+          );
     } catch (error, stackTrace) {
       if (kDebugMode) {
         debugPrint(
@@ -346,10 +332,9 @@ class PostManager extends ChangeNotifier {
             isLiked: currentUserId != null && currentUserId == likeUserId
                 ? true
                 : post.isLiked,
-            likeRecordId:
-                currentUserId != null && currentUserId == likeUserId
-                    ? record.id
-                    : post.likeRecordId,
+            likeRecordId: currentUserId != null && currentUserId == likeUserId
+                ? record.id
+                : post.likeRecordId,
           );
           _updatePostAt(index, updated);
           break;
@@ -360,10 +345,9 @@ class PostManager extends ChangeNotifier {
             isLiked: currentUserId != null && currentUserId == likeUserId
                 ? false
                 : post.isLiked,
-            likeRecordId:
-                currentUserId != null && currentUserId == likeUserId
-                    ? null
-                    : post.likeRecordId,
+            likeRecordId: currentUserId != null && currentUserId == likeUserId
+                ? null
+                : post.likeRecordId,
           );
           _updatePostAt(index, updated);
           break;
@@ -418,10 +402,17 @@ class PostManager extends ChangeNotifier {
         case 'create':
           final newCount = post.commentsCount + 1;
           _updatePostAt(index, post.copyWith(commentsCount: newCount));
+
           if (hasLoadedComments && updatedComment != null) {
-            final comments = List<PostComment>.from(commentsFor(postId))
-              ..add(updatedComment);
-            _postComments[postId] = comments;
+            final comments = List<PostComment>.from(commentsFor(postId));
+
+            final alreadyExists = comments
+                .any((c) => c.id == updatedComment!.id); // kiểm tra trùng
+
+            if (!alreadyExists) {
+              comments.add(updatedComment!);
+              _postComments[postId] = comments;
+            }
           }
           break;
         case 'update':
@@ -476,21 +467,35 @@ class PostManager extends ChangeNotifier {
   }
 
   String? _extractRelationId(RecordModel record, String field) {
-    final dataValue = record.data[field];
+    // 1. Lấy thẳng id từ data nếu có
+    final Object? dataValue = record.data[field];
     if (dataValue is String && dataValue.isNotEmpty) {
       return dataValue;
     }
 
-    final expanded = record.expand?[field];
+    // 2. Lấy từ expand (map có thể null)
+    final expandMap = record.expand;
+    if (expandMap == null) {
+      return null;
+    }
+
+    final Object? expanded = expandMap[field];
+
+    // Trường hợp expand là 1 RecordModel
     if (expanded is RecordModel) {
       return expanded.id;
     }
-    if (expanded is List && expanded.isNotEmpty) {
-      final first = expanded.first;
-      if (first is RecordModel) {
-        return first.id;
+
+    // Trường hợp expand là list RecordModel
+    if (expanded is List) {
+      if (expanded.isNotEmpty) {
+        final first = expanded.first;
+        if (first is RecordModel) {
+          return first.id;
+        }
       }
     }
+
     return null;
   }
 

--- a/lib/pages/social/recruitment_manager.dart
+++ b/lib/pages/social/recruitment_manager.dart
@@ -1,0 +1,290 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../../models/recruitment_post.dart';
+import '../../services/pocketbase_client.dart';
+import '../../services/recruitment_service.dart';
+
+class RecruitmentManager extends ChangeNotifier {
+  RecruitmentManager() : _service = RecruitmentService() {
+    _initializeRealtime();
+  }
+
+  final RecruitmentService _service;
+
+  bool _isDisposed = false;
+  bool _isLoadingRecruitments = false;
+
+  List<RecruitmentPost> _recruitmentPosts = const [];
+  String? _recruitmentError;
+
+  final Set<String> _joiningRecruitments = <String>{};
+
+  UnsubscribeFunc? _postsUnsubscribe;
+  UnsubscribeFunc? _applicantsUnsubscribe;
+
+  bool get isLoadingRecruitments => _isLoadingRecruitments;
+  List<RecruitmentPost> get recruitmentPosts => _recruitmentPosts;
+  String? get recruitmentError => _recruitmentError;
+
+  bool isJoining(String recruitmentId) =>
+      _joiningRecruitments.contains(recruitmentId);
+
+  Future<void> refreshRecruitments() async {
+    _isLoadingRecruitments = true;
+    _recruitmentError = null;
+    notifyListeners();
+
+    try {
+      final results = await _service.fetchActivePosts();
+      _recruitmentPosts = results;
+    } on RecruitmentServiceException catch (error) {
+      _recruitmentError = error.message;
+    } finally {
+      _isLoadingRecruitments = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> joinRecruitment(String recruitmentId) async {
+    if (_joiningRecruitments.contains(recruitmentId)) {
+      return;
+    }
+
+    _joiningRecruitments.add(recruitmentId);
+    notifyListeners();
+
+    try {
+      final updated = await _service.joinRecruitment(recruitmentId);
+      _recruitmentPosts = _recruitmentPosts
+          .map((post) => post.id == recruitmentId ? updated : post)
+          .toList(growable: false);
+    } finally {
+      _joiningRecruitments.remove(recruitmentId);
+      notifyListeners();
+    }
+  }
+
+  void _initializeRealtime() {
+    unawaited(_setupRecruitmentPostsRealtime());
+    unawaited(_setupRecruitmentApplicantsRealtime());
+  }
+
+  Future<void> _setupRecruitmentPostsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _postsUnsubscribe;
+      _postsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _postsUnsubscribe = await pocketBase
+          .collection(RecruitmentService.recruitmentPostsCollection)
+          .subscribe(
+        '*',
+        _handleRecruitmentPostEvent,
+        expand: 'author,court',
+      );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint(
+            'Failed to initialize recruitment posts realtime: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _setupRecruitmentApplicantsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _applicantsUnsubscribe;
+      _applicantsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _applicantsUnsubscribe = await pocketBase
+          .collection(RecruitmentService.recruitmentApplicantsCollection)
+          .subscribe(
+        '*',
+        _handleRecruitmentApplicantEvent,
+        expand: 'user,recruitment',
+      );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint(
+            'Failed to initialize recruitment applicants realtime: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _handleRecruitmentPostEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    try {
+      switch (event.action) {
+        case 'delete':
+          _removeRecruitment(record.id);
+          break;
+        case 'create':
+        case 'update':
+          final isActive = record.data['is_active'] != false;
+          if (!isActive) {
+            _removeRecruitment(record.id);
+            break;
+          }
+          final updated = await _service.getRecruitmentById(record.id);
+          final index =
+              _recruitmentPosts.indexWhere((item) => item.id == updated.id);
+          if (index == -1) {
+            _recruitmentPosts = [updated, ..._recruitmentPosts];
+          } else {
+            final posts = List<RecruitmentPost>.from(_recruitmentPosts);
+            posts[index] = updated;
+            _recruitmentPosts = posts;
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process recruitment realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> _handleRecruitmentApplicantEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    final recruitmentId = _extractRelationId(record, 'recruitment');
+    if (recruitmentId == null) {
+      return;
+    }
+
+    final index =
+        _recruitmentPosts.indexWhere((post) => post.id == recruitmentId);
+    if (index == -1) {
+      return;
+    }
+
+    final recruitment = _recruitmentPosts[index];
+
+    try {
+      final pocketBase = await getPocketbaseInstance();
+      final currentUserId = pocketBase.authStore.record?.id;
+      final applicantUserId = _extractRelationId(record, 'user');
+
+      switch (event.action) {
+        case 'create':
+          final updated = recruitment.copyWith(
+            joinedPlayers: recruitment.joinedPlayers + 1,
+            isJoined: recruitment.isJoined ||
+                (currentUserId != null && currentUserId == applicantUserId),
+          );
+          _replaceRecruitmentAt(index, updated);
+          break;
+        case 'delete':
+          final newCount = recruitment.joinedPlayers > 1
+              ? recruitment.joinedPlayers - 1
+              : recruitment.joinedPlayers;
+          final updated = recruitment.copyWith(
+            joinedPlayers: newCount,
+            isJoined: currentUserId != null && currentUserId == applicantUserId
+                ? recruitment.isOwner
+                : recruitment.isJoined,
+          );
+          _replaceRecruitmentAt(index, updated);
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process applicant realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  void _replaceRecruitmentAt(int index, RecruitmentPost updated) {
+    final posts = List<RecruitmentPost>.from(_recruitmentPosts);
+    posts[index] = updated;
+    _recruitmentPosts = posts;
+  }
+
+  void _removeRecruitment(String recruitmentId) {
+    _recruitmentPosts = _recruitmentPosts
+        .where((post) => post.id != recruitmentId)
+        .toList(growable: false);
+  }
+
+  String? _extractRelationId(RecordModel record, String field) {
+    final dataValue = record.data[field];
+    if (dataValue is String && dataValue.isNotEmpty) {
+      return dataValue;
+    }
+
+    final expanded = record.expand?[field];
+    if (expanded is RecordModel) {
+      return expanded.id;
+    }
+    if (expanded is List && expanded.isNotEmpty) {
+      final first = expanded.first;
+      if (first is RecordModel) {
+        return first.id;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    final unsubList = [
+      _postsUnsubscribe,
+      _applicantsUnsubscribe,
+    ];
+    for (final unsub in unsubList) {
+      if (unsub != null) {
+        unawaited(unsub());
+      }
+    }
+    _postsUnsubscribe = null;
+    _applicantsUnsubscribe = null;
+    super.dispose();
+  }
+}

--- a/lib/pages/social/recruitment_manager.dart
+++ b/lib/pages/social/recruitment_manager.dart
@@ -85,14 +85,13 @@ class RecruitmentManager extends ChangeNotifier {
       _postsUnsubscribe = await pocketBase
           .collection(RecruitmentService.recruitmentPostsCollection)
           .subscribe(
-        '*',
-        _handleRecruitmentPostEvent,
-        expand: 'author,court',
-      );
+            '*',
+            _handleRecruitmentPostEvent,
+            expand: 'author,court',
+          );
     } catch (error, stackTrace) {
       if (kDebugMode) {
-        debugPrint(
-            'Failed to initialize recruitment posts realtime: $error');
+        debugPrint('Failed to initialize recruitment posts realtime: $error');
         debugPrint(stackTrace.toString());
       }
     }
@@ -111,10 +110,10 @@ class RecruitmentManager extends ChangeNotifier {
       _applicantsUnsubscribe = await pocketBase
           .collection(RecruitmentService.recruitmentApplicantsCollection)
           .subscribe(
-        '*',
-        _handleRecruitmentApplicantEvent,
-        expand: 'user,recruitment',
-      );
+            '*',
+            _handleRecruitmentApplicantEvent,
+            expand: 'user,recruitment',
+          );
     } catch (error, stackTrace) {
       if (kDebugMode) {
         debugPrint(
@@ -253,21 +252,35 @@ class RecruitmentManager extends ChangeNotifier {
   }
 
   String? _extractRelationId(RecordModel record, String field) {
-    final dataValue = record.data[field];
+    // 1. Lấy thẳng id từ data nếu có
+    final Object? dataValue = record.data[field];
     if (dataValue is String && dataValue.isNotEmpty) {
       return dataValue;
     }
 
-    final expanded = record.expand?[field];
+    // 2. Lấy từ expand (map có thể null)
+    final expandMap = record.expand;
+    if (expandMap == null) {
+      return null;
+    }
+
+    final Object? expanded = expandMap[field];
+
+    // Trường hợp expand là 1 RecordModel
     if (expanded is RecordModel) {
       return expanded.id;
     }
-    if (expanded is List && expanded.isNotEmpty) {
-      final first = expanded.first;
-      if (first is RecordModel) {
-        return first.id;
+
+    // Trường hợp expand là list RecordModel
+    if (expanded is List) {
+      if (expanded.isNotEmpty) {
+        final first = expanded.first;
+        if (first is RecordModel) {
+          return first.id;
+        }
       }
     }
+
     return null;
   }
 

--- a/lib/pages/social/social_manager.dart
+++ b/lib/pages/social/social_manager.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 
 import '../../models/community_post.dart';
+import '../../models/post_comment.dart';
 import '../../models/recruitment_post.dart';
 import '../../services/post_service.dart';
 import '../../services/recruitment_service.dart';
@@ -26,6 +27,11 @@ class SocialManager with ChangeNotifier {
   String? _recruitmentError;
 
   final Set<String> _joiningRecruitments = <String>{};
+  final Set<String> _likingPosts = <String>{};
+  final Set<String> _loadingComments = <String>{};
+  final Set<String> _submittingComments = <String>{};
+  final Set<String> _loadedComments = <String>{};
+  final Map<String, List<PostComment>> _postComments = <String, List<PostComment>>{};
 
   bool get isLoadingPosts => _isLoadingPosts;
   bool get isLoadingRecruitments => _isLoadingRecruitments;
@@ -38,6 +44,11 @@ class SocialManager with ChangeNotifier {
   String? get recruitmentError => _recruitmentError;
 
   bool isJoining(String recruitmentId) => _joiningRecruitments.contains(recruitmentId);
+  bool isLikingPost(String postId) => _likingPosts.contains(postId);
+  bool isLoadingComments(String postId) => _loadingComments.contains(postId);
+  bool isSubmittingComment(String postId) => _submittingComments.contains(postId);
+  List<PostComment> commentsFor(String postId) =>
+      _postComments[postId] ?? const <PostComment>[];
 
   Future<void> loadInitial() async {
     await Future.wait<void>([
@@ -100,6 +111,104 @@ class SocialManager with ChangeNotifier {
     }
   }
 
+  Future<void> toggleLike(String postId) async {
+    final index = _posts.indexWhere((post) => post.id == postId);
+    if (index == -1 || _likingPosts.contains(postId)) {
+      return;
+    }
+
+    final post = _posts[index];
+    _likingPosts.add(postId);
+    notifyListeners();
+
+    try {
+      if (post.isLiked) {
+        await _postService.unlikePost(
+          postId: postId,
+          likeRecordId: post.likeRecordId,
+        );
+        final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
+        final updated = post.copyWith(
+          isLiked: false,
+          likesCount: newCount,
+          likeRecordId: null,
+        );
+        _updatePostAt(index, updated);
+      } else {
+        final likeRecordId = await _postService.likePost(postId);
+        final updated = post.copyWith(
+          isLiked: true,
+          likesCount: post.likesCount + 1,
+          likeRecordId: likeRecordId,
+        );
+        _updatePostAt(index, updated);
+      }
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _likingPosts.remove(postId);
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadComments(String postId, {bool forceRefresh = false}) async {
+    if (_loadingComments.contains(postId)) {
+      return;
+    }
+
+    if (!forceRefresh && _loadedComments.contains(postId)) {
+      return;
+    }
+
+    _loadingComments.add(postId);
+    notifyListeners();
+
+    try {
+      final comments = await _postService.fetchComments(postId);
+      _postComments[postId] = comments;
+      _loadedComments.add(postId);
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _loadingComments.remove(postId);
+      notifyListeners();
+    }
+  }
+
+  Future<void> addComment(String postId, String content) async {
+    if (_submittingComments.contains(postId)) {
+      return;
+    }
+
+    _submittingComments.add(postId);
+    notifyListeners();
+
+    try {
+      final comment = await _postService.createComment(
+        postId: postId,
+        content: content,
+      );
+
+      final comments = List<PostComment>.from(commentsFor(postId))..add(comment);
+      _postComments[postId] = comments;
+
+      final index = _posts.indexWhere((post) => post.id == postId);
+      if (index != -1) {
+        final post = _posts[index];
+        final updated = post.copyWith(commentsCount: post.commentsCount + 1);
+        _updatePostAt(index, updated);
+      }
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _submittingComments.remove(postId);
+      notifyListeners();
+    }
+  }
+
   Future<void> joinRecruitment(String recruitmentId) async {
     if (_joiningRecruitments.contains(recruitmentId)) {
       return;
@@ -117,5 +226,11 @@ class SocialManager with ChangeNotifier {
       _joiningRecruitments.remove(recruitmentId);
       notifyListeners();
     }
+  }
+
+  void _updatePostAt(int index, CommunityPost updated) {
+    final posts = List<CommunityPost>.from(_posts);
+    posts[index] = updated;
+    _posts = posts;
   }
 }

--- a/lib/pages/social/social_manager.dart
+++ b/lib/pages/social/social_manager.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
 import 'dart:io';
 
+import 'package:badminton_booking_app/services/pocketbase_client.dart';
 import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
 
 import '../../models/community_post.dart';
 import '../../models/post_comment.dart';
@@ -11,10 +14,15 @@ import '../../services/recruitment_service.dart';
 class SocialManager with ChangeNotifier {
   SocialManager()
       : _postService = PostService(),
-        _recruitmentService = RecruitmentService();
+        _recruitmentService = RecruitmentService() {
+    _initializeRealtime();
+  }
 
   final PostService _postService;
   final RecruitmentService _recruitmentService;
+  // use if RecordSubscription isn't present in your SDK
+  UnsubscribeFunc? _postsUnsubscribe;
+  bool _isDisposed = false;
 
   bool _isLoadingPosts = false;
   bool _isLoadingRecruitments = false;
@@ -31,7 +39,8 @@ class SocialManager with ChangeNotifier {
   final Set<String> _loadingComments = <String>{};
   final Set<String> _submittingComments = <String>{};
   final Set<String> _loadedComments = <String>{};
-  final Map<String, List<PostComment>> _postComments = <String, List<PostComment>>{};
+  final Map<String, List<PostComment>> _postComments =
+      <String, List<PostComment>>{};
 
   bool get isLoadingPosts => _isLoadingPosts;
   bool get isLoadingRecruitments => _isLoadingRecruitments;
@@ -43,10 +52,12 @@ class SocialManager with ChangeNotifier {
   String? get postError => _postError;
   String? get recruitmentError => _recruitmentError;
 
-  bool isJoining(String recruitmentId) => _joiningRecruitments.contains(recruitmentId);
+  bool isJoining(String recruitmentId) =>
+      _joiningRecruitments.contains(recruitmentId);
   bool isLikingPost(String postId) => _likingPosts.contains(postId);
   bool isLoadingComments(String postId) => _loadingComments.contains(postId);
-  bool isSubmittingComment(String postId) => _submittingComments.contains(postId);
+  bool isSubmittingComment(String postId) =>
+      _submittingComments.contains(postId);
   List<PostComment> commentsFor(String postId) =>
       _postComments[postId] ?? const <PostComment>[];
 
@@ -55,6 +66,35 @@ class SocialManager with ChangeNotifier {
       refreshPosts(),
       refreshRecruitments(),
     ]);
+  }
+
+  void _initializeRealtime() {
+    unawaited(_setupPostsRealtime());
+  }
+
+  Future<void> _setupPostsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      // Hủy subscription cũ (nếu có)
+      final oldUnsub = _postsUnsubscribe;
+      _postsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub(); // gọi function
+      }
+
+      _postsUnsubscribe =
+          await pocketBase.collection(PostService.postsCollection).subscribe(
+                '*',
+                _handlePostRealtimeEvent,
+                expand: 'author', // string, không phải List
+              );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to initialize posts realtime subscription: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
   }
 
   Future<void> refreshPosts() async {
@@ -191,7 +231,8 @@ class SocialManager with ChangeNotifier {
         content: content,
       );
 
-      final comments = List<PostComment>.from(commentsFor(postId))..add(comment);
+      final comments = List<PostComment>.from(commentsFor(postId))
+        ..add(comment);
       _postComments[postId] = comments;
 
       final index = _posts.indexWhere((post) => post.id == postId);
@@ -232,5 +273,72 @@ class SocialManager with ChangeNotifier {
     final posts = List<CommunityPost>.from(_posts);
     posts[index] = updated;
     _posts = posts;
+  }
+
+  Future<void> _handlePostRealtimeEvent(RecordSubscriptionEvent event) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    try {
+      switch (event.action) {
+        case 'delete':
+          _removePost(record.id);
+          break;
+        case 'create':
+        case 'update':
+          final isActive = record.data['is_active'] != false;
+          if (!isActive) {
+            _removePost(record.id);
+            break;
+          }
+
+          final pocketBase = await getPocketbaseInstance();
+          final post =
+              await _postService.recordToCommunityPost(record, pocketBase);
+          final index = _posts.indexWhere((existing) => existing.id == post.id);
+          if (index == -1) {
+            _posts = [post, ..._posts];
+          } else {
+            _updatePostAt(index, post);
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  void _removePost(String postId) {
+    final previousLength = _posts.length;
+    _posts = _posts.where((post) => post.id != postId).toList(growable: false);
+    if (previousLength != _posts.length) {
+      _postComments.remove(postId);
+    }
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    final unsub = _postsUnsubscribe;
+    _postsUnsubscribe = null;
+    if (unsub != null) {
+      unawaited(unsub()); // gọi function để unsubscribe
+    }
+    super.dispose();
   }
 }

--- a/lib/pages/social/social_manager.dart
+++ b/lib/pages/social/social_manager.dart
@@ -1,344 +1,96 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:badminton_booking_app/services/pocketbase_client.dart';
 import 'package:flutter/foundation.dart';
-import 'package:pocketbase/pocketbase.dart';
 
 import '../../models/community_post.dart';
 import '../../models/post_comment.dart';
 import '../../models/recruitment_post.dart';
-import '../../services/post_service.dart';
-import '../../services/recruitment_service.dart';
+import 'post_manager.dart';
+import 'recruitment_manager.dart';
 
 class SocialManager with ChangeNotifier {
   SocialManager()
-      : _postService = PostService(),
-        _recruitmentService = RecruitmentService() {
-    _initializeRealtime();
+      : postManager = PostManager(),
+        recruitmentManager = RecruitmentManager() {
+    _postManagerListener = _propagateChanges;
+    _recruitmentManagerListener = _propagateChanges;
+    postManager.addListener(_postManagerListener);
+    recruitmentManager.addListener(_recruitmentManagerListener);
   }
 
-  final PostService _postService;
-  final RecruitmentService _recruitmentService;
-  // use if RecordSubscription isn't present in your SDK
-  UnsubscribeFunc? _postsUnsubscribe;
+  final PostManager postManager;
+  final RecruitmentManager recruitmentManager;
+
+  late final VoidCallback _postManagerListener;
+  late final VoidCallback _recruitmentManagerListener;
   bool _isDisposed = false;
-
-  bool _isLoadingPosts = false;
-  bool _isLoadingRecruitments = false;
-  bool _isSubmittingPost = false;
-
-  List<CommunityPost> _posts = const [];
-  List<RecruitmentPost> _recruitmentPosts = const [];
-
-  String? _postError;
-  String? _recruitmentError;
-
-  final Set<String> _joiningRecruitments = <String>{};
-  final Set<String> _likingPosts = <String>{};
-  final Set<String> _loadingComments = <String>{};
-  final Set<String> _submittingComments = <String>{};
-  final Set<String> _loadedComments = <String>{};
-  final Map<String, List<PostComment>> _postComments =
-      <String, List<PostComment>>{};
-
-  bool get isLoadingPosts => _isLoadingPosts;
-  bool get isLoadingRecruitments => _isLoadingRecruitments;
-  bool get isSubmittingPost => _isSubmittingPost;
-
-  List<CommunityPost> get posts => _posts;
-  List<RecruitmentPost> get recruitmentPosts => _recruitmentPosts;
-
-  String? get postError => _postError;
-  String? get recruitmentError => _recruitmentError;
-
-  bool isJoining(String recruitmentId) =>
-      _joiningRecruitments.contains(recruitmentId);
-  bool isLikingPost(String postId) => _likingPosts.contains(postId);
-  bool isLoadingComments(String postId) => _loadingComments.contains(postId);
-  bool isSubmittingComment(String postId) =>
-      _submittingComments.contains(postId);
-  List<PostComment> commentsFor(String postId) =>
-      _postComments[postId] ?? const <PostComment>[];
 
   Future<void> loadInitial() async {
     await Future.wait<void>([
-      refreshPosts(),
-      refreshRecruitments(),
+      postManager.refreshPosts(),
+      recruitmentManager.refreshRecruitments(),
     ]);
   }
 
-  void _initializeRealtime() {
-    unawaited(_setupPostsRealtime());
-  }
+  bool get isLoadingPosts => postManager.isLoadingPosts;
+  bool get isLoadingRecruitments =>
+      recruitmentManager.isLoadingRecruitments;
+  bool get isSubmittingPost => postManager.isSubmittingPost;
 
-  Future<void> _setupPostsRealtime() async {
-    try {
-      final pocketBase = await getPocketbaseInstance();
+  List<CommunityPost> get posts => postManager.posts;
+  List<RecruitmentPost> get recruitmentPosts =>
+      recruitmentManager.recruitmentPosts;
 
-      // Hủy subscription cũ (nếu có)
-      final oldUnsub = _postsUnsubscribe;
-      _postsUnsubscribe = null;
-      if (oldUnsub != null) {
-        await oldUnsub(); // gọi function
-      }
+  String? get postError => postManager.postError;
+  String? get recruitmentError => recruitmentManager.recruitmentError;
 
-      _postsUnsubscribe =
-          await pocketBase.collection(PostService.postsCollection).subscribe(
-                '*',
-                _handlePostRealtimeEvent,
-                expand: 'author', // string, không phải List
-              );
-    } catch (error, stackTrace) {
-      if (kDebugMode) {
-        debugPrint('Failed to initialize posts realtime subscription: $error');
-        debugPrint(stackTrace.toString());
-      }
-    }
-  }
+  bool isJoining(String recruitmentId) =>
+      recruitmentManager.isJoining(recruitmentId);
+  bool isLikingPost(String postId) => postManager.isLikingPost(postId);
+  bool isLoadingComments(String postId) =>
+      postManager.isLoadingComments(postId);
+  bool isSubmittingComment(String postId) =>
+      postManager.isSubmittingComment(postId);
+  List<PostComment> commentsFor(String postId) =>
+      postManager.commentsFor(postId);
 
-  Future<void> refreshPosts() async {
-    _isLoadingPosts = true;
-    _postError = null;
-    notifyListeners();
-
-    try {
-      final results = await _postService.fetchPosts();
-      _posts = results;
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-    } finally {
-      _isLoadingPosts = false;
-      notifyListeners();
-    }
-  }
-
-  Future<void> refreshRecruitments() async {
-    _isLoadingRecruitments = true;
-    _recruitmentError = null;
-    notifyListeners();
-
-    try {
-      final results = await _recruitmentService.fetchActivePosts();
-      _recruitmentPosts = results;
-    } on RecruitmentServiceException catch (error) {
-      _recruitmentError = error.message;
-    } finally {
-      _isLoadingRecruitments = false;
-      notifyListeners();
-    }
-  }
+  Future<void> refreshPosts() => postManager.refreshPosts();
+  Future<void> refreshRecruitments() =>
+      recruitmentManager.refreshRecruitments();
 
   Future<void> createPost({
     required String content,
     List<File> images = const [],
   }) async {
-    _isSubmittingPost = true;
-    notifyListeners();
-
-    try {
-      final newPost = await _postService.createPost(
-        content: content,
-        images: images,
-      );
-      _posts = [newPost, ..._posts];
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-      rethrow;
-    } finally {
-      _isSubmittingPost = false;
-      notifyListeners();
-    }
+    await postManager.createPost(content: content, images: images);
   }
 
-  Future<void> toggleLike(String postId) async {
-    final index = _posts.indexWhere((post) => post.id == postId);
-    if (index == -1 || _likingPosts.contains(postId)) {
-      return;
-    }
+  Future<void> toggleLike(String postId) => postManager.toggleLike(postId);
 
-    final post = _posts[index];
-    _likingPosts.add(postId);
-    notifyListeners();
+  Future<void> loadComments(String postId, {bool forceRefresh = false}) =>
+      postManager.loadComments(postId, forceRefresh: forceRefresh);
 
-    try {
-      if (post.isLiked) {
-        await _postService.unlikePost(
-          postId: postId,
-          likeRecordId: post.likeRecordId,
-        );
-        final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
-        final updated = post.copyWith(
-          isLiked: false,
-          likesCount: newCount,
-          likeRecordId: null,
-        );
-        _updatePostAt(index, updated);
-      } else {
-        final likeRecordId = await _postService.likePost(postId);
-        final updated = post.copyWith(
-          isLiked: true,
-          likesCount: post.likesCount + 1,
-          likeRecordId: likeRecordId,
-        );
-        _updatePostAt(index, updated);
-      }
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-      rethrow;
-    } finally {
-      _likingPosts.remove(postId);
-      notifyListeners();
-    }
-  }
+  Future<void> addComment(String postId, String content) =>
+      postManager.addComment(postId, content);
 
-  Future<void> loadComments(String postId, {bool forceRefresh = false}) async {
-    if (_loadingComments.contains(postId)) {
-      return;
-    }
+  Future<void> joinRecruitment(String recruitmentId) =>
+      recruitmentManager.joinRecruitment(recruitmentId);
 
-    if (!forceRefresh && _loadedComments.contains(postId)) {
-      return;
-    }
-
-    _loadingComments.add(postId);
-    notifyListeners();
-
-    try {
-      final comments = await _postService.fetchComments(postId);
-      _postComments[postId] = comments;
-      _loadedComments.add(postId);
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-      rethrow;
-    } finally {
-      _loadingComments.remove(postId);
-      notifyListeners();
-    }
-  }
-
-  Future<void> addComment(String postId, String content) async {
-    if (_submittingComments.contains(postId)) {
-      return;
-    }
-
-    _submittingComments.add(postId);
-    notifyListeners();
-
-    try {
-      final comment = await _postService.createComment(
-        postId: postId,
-        content: content,
-      );
-
-      final comments = List<PostComment>.from(commentsFor(postId))
-        ..add(comment);
-      _postComments[postId] = comments;
-
-      final index = _posts.indexWhere((post) => post.id == postId);
-      if (index != -1) {
-        final post = _posts[index];
-        final updated = post.copyWith(commentsCount: post.commentsCount + 1);
-        _updatePostAt(index, updated);
-      }
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-      rethrow;
-    } finally {
-      _submittingComments.remove(postId);
-      notifyListeners();
-    }
-  }
-
-  Future<void> joinRecruitment(String recruitmentId) async {
-    if (_joiningRecruitments.contains(recruitmentId)) {
-      return;
-    }
-
-    _joiningRecruitments.add(recruitmentId);
-    notifyListeners();
-
-    try {
-      final updated = await _recruitmentService.joinRecruitment(recruitmentId);
-      _recruitmentPosts = _recruitmentPosts
-          .map((post) => post.id == recruitmentId ? updated : post)
-          .toList(growable: false);
-    } finally {
-      _joiningRecruitments.remove(recruitmentId);
-      notifyListeners();
-    }
-  }
-
-  void _updatePostAt(int index, CommunityPost updated) {
-    final posts = List<CommunityPost>.from(_posts);
-    posts[index] = updated;
-    _posts = posts;
-  }
-
-  Future<void> _handlePostRealtimeEvent(RecordSubscriptionEvent event) async {
+  void _propagateChanges() {
     if (_isDisposed) {
       return;
     }
-
-    final record = event.record;
-    if (record == null) {
-      return;
-    }
-
-    try {
-      switch (event.action) {
-        case 'delete':
-          _removePost(record.id);
-          break;
-        case 'create':
-        case 'update':
-          final isActive = record.data['is_active'] != false;
-          if (!isActive) {
-            _removePost(record.id);
-            break;
-          }
-
-          final pocketBase = await getPocketbaseInstance();
-          final post =
-              await _postService.recordToCommunityPost(record, pocketBase);
-          final index = _posts.indexWhere((existing) => existing.id == post.id);
-          if (index == -1) {
-            _posts = [post, ..._posts];
-          } else {
-            _updatePostAt(index, post);
-          }
-          break;
-        default:
-          break;
-      }
-    } catch (error, stackTrace) {
-      if (kDebugMode) {
-        debugPrint('Failed to process realtime event: $error');
-        debugPrint(stackTrace.toString());
-      }
-    } finally {
-      if (!_isDisposed) {
-        notifyListeners();
-      }
-    }
-  }
-
-  void _removePost(String postId) {
-    final previousLength = _posts.length;
-    _posts = _posts.where((post) => post.id != postId).toList(growable: false);
-    if (previousLength != _posts.length) {
-      _postComments.remove(postId);
-    }
+    notifyListeners();
   }
 
   @override
   void dispose() {
     _isDisposed = true;
-    final unsub = _postsUnsubscribe;
-    _postsUnsubscribe = null;
-    if (unsub != null) {
-      unawaited(unsub()); // gọi function để unsubscribe
-    }
+    postManager.removeListener(_postManagerListener);
+    recruitmentManager.removeListener(_recruitmentManagerListener);
+    postManager.dispose();
+    recruitmentManager.dispose();
     super.dispose();
   }
 }

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -309,6 +309,7 @@ class _SocialPageState extends State<SocialPage> {
           return RecruitmentPostCard(
             hostName: post.authorName,
             createdTime: post.createdAt,
+            hostAvatarUrl: post.authorAvatarUrl,
             requiredPlayers: post.requiredPlayers,
             joinedPlayers: post.joinedPlayers,
             description: post.description,

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:badminton_booking_app/components/create_post.dart';
 import 'package:badminton_booking_app/components/my_post.dart';
+import 'package:badminton_booking_app/components/post_comments_sheet.dart';
 import 'package:badminton_booking_app/components/recruitment_post_card.dart';
 import 'package:badminton_booking_app/models/community_post.dart';
 import 'package:badminton_booking_app/models/recruitment_post.dart';
@@ -42,6 +45,37 @@ class _SocialPageState extends State<SocialPage> {
       manager.refreshPosts(),
       manager.refreshRecruitments(),
     ]);
+  }
+
+  void _handleLikePressed(
+    BuildContext context,
+    SocialManager manager,
+    CommunityPost post,
+  ) {
+    unawaited(
+      manager.toggleLike(post.id).catchError((error) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error.toString())),
+        );
+      }),
+    );
+  }
+
+  Future<void> _openCommentsSheet(
+    BuildContext context,
+    SocialManager manager,
+    CommunityPost post,
+  ) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => PostCommentsSheet(
+        postId: post.id,
+        manager: manager,
+      ),
+    );
   }
 
   @override
@@ -340,6 +374,14 @@ class _SocialPageState extends State<SocialPage> {
             userName: post.authorName,
             time: post.createdAt,
             imageUrls: post.imageUrls,
+            avatarUrl: post.authorAvatarUrl,
+            isLiked: post.isLiked,
+            likesCount: post.likesCount,
+            commentsCount: post.commentsCount,
+            onLikePressed: () =>
+                _handleLikePressed(context, manager, post),
+            onCommentPressed: () =>
+                _openCommentsSheet(context, manager, post),
           );
         },
         childCount: manager.posts.length,

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -116,7 +116,7 @@ class _SocialPageState extends State<SocialPage> {
           ],
           bottom: TabBar(
             tabs: [
-              Tab(text: 'Posts'),
+              Tab(text: 'Community'),
               Tab(text: 'Recruitment'),
             ],
             // Chữ tab đang chọn
@@ -379,10 +379,8 @@ class _SocialPageState extends State<SocialPage> {
             isLiked: post.isLiked,
             likesCount: post.likesCount,
             commentsCount: post.commentsCount,
-            onLikePressed: () =>
-                _handleLikePressed(context, manager, post),
-            onCommentPressed: () =>
-                _openCommentsSheet(context, manager, post),
+            onLikePressed: () => _handleLikePressed(context, manager, post),
+            onCommentPressed: () => _openCommentsSheet(context, manager, post),
           );
         },
         childCount: manager.posts.length,

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:pocketbase/pocketbase.dart';
 
 import '../models/community_post.dart';
+import '../models/post_comment.dart';
 import 'pocketbase_client.dart';
 
 class PostServiceException implements Exception {
@@ -16,6 +17,8 @@ class PostServiceException implements Exception {
 
 class PostService {
   static const String postsCollection = 'posts';
+  static const String postLikesCollection = 'post_likes';
+  static const String postCommentsCollection = 'post_comments';
 
   Future<List<CommunityPost>> fetchPosts({
     int page = 1,
@@ -31,9 +34,16 @@ class PostService {
             filter: "is_active = true",
           );
 
-      return result.items
+      final posts = result.items
           .map((record) => CommunityPost.fromRecord(record, pocketBase))
           .toList(growable: false);
+
+      final updatedPosts = await Future.wait(
+        posts.map((post) => _attachPostMeta(post, pocketBase)),
+        eagerError: false,
+      );
+
+      return updatedPosts;
     } on ClientException catch (error) {
       throw PostServiceException(_mapClientError(error));
     } catch (_) {
@@ -90,10 +100,196 @@ class PostService {
     }
   }
 
+  Future<String> likePost(String postId) async {
+    final pocketBase = await getPocketbaseInstance();
+    final userId = pocketBase.authStore.record?.id;
+    if (userId == null) {
+      throw PostServiceException('Bạn cần đăng nhập để thích bài viết.');
+    }
+
+    final existing = await _findExistingLike(
+      pocketBase,
+      postId: postId,
+      userId: userId,
+    );
+    if (existing != null) {
+      return existing.id;
+    }
+
+    try {
+      final record = await pocketBase.collection(postLikesCollection).create(
+        body: {
+          'post': postId,
+          'user': userId,
+        },
+      );
+      return record.id;
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientError(error));
+    } catch (_) {
+      throw PostServiceException('Không thể thích bài viết.');
+    }
+  }
+
+  Future<void> unlikePost({
+    required String postId,
+    String? likeRecordId,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+    final userId = pocketBase.authStore.record?.id;
+    if (userId == null) {
+      throw PostServiceException('Bạn cần đăng nhập để bỏ thích bài viết.');
+    }
+
+    final recordId = likeRecordId ??
+        (await _findExistingLike(
+          pocketBase,
+          postId: postId,
+          userId: userId,
+        ))?.id;
+
+    if (recordId == null) {
+      throw PostServiceException('Bạn chưa thích bài viết này.');
+    }
+
+    try {
+      await pocketBase.collection(postLikesCollection).delete(recordId);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientError(error));
+    } catch (_) {
+      throw PostServiceException('Không thể bỏ thích bài viết.');
+    }
+  }
+
+  Future<List<PostComment>> fetchComments(String postId) async {
+    final pocketBase = await getPocketbaseInstance();
+    try {
+      final result = await pocketBase.collection(postCommentsCollection).getFullList(
+            filter: 'post = "$postId"',
+            expand: 'author',
+            sort: 'created',
+          );
+      return result
+          .map((record) => PostComment.fromRecord(record, pocketBase))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientError(error));
+    } catch (_) {
+      throw PostServiceException('Không thể tải bình luận.');
+    }
+  }
+
+  Future<PostComment> createComment({
+    required String postId,
+    required String content,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+    final userId = pocketBase.authStore.record?.id;
+    if (userId == null) {
+      throw PostServiceException('Bạn cần đăng nhập để bình luận.');
+    }
+
+    if (content.trim().isEmpty) {
+      throw PostServiceException('Vui lòng nhập nội dung bình luận.');
+    }
+
+    try {
+      final record = await pocketBase.collection(postCommentsCollection).create(
+        body: {
+          'post': postId,
+          'author': userId,
+          'content': content.trim(),
+        },
+        expand: 'author',
+      );
+      return PostComment.fromRecord(record, pocketBase);
+    } on ClientException catch (error) {
+      throw PostServiceException(_mapClientError(error));
+    } catch (_) {
+      throw PostServiceException('Không thể gửi bình luận.');
+    }
+  }
+
   String _mapClientError(ClientException error) {
     if (error.response != null && error.response['message'] is String) {
       return error.response['message'] as String;
     }
     return 'Có lỗi xảy ra. Vui lòng thử lại.';
+  }
+
+  Future<CommunityPost> _attachPostMeta(
+    CommunityPost post,
+    PocketBase pocketBase,
+  ) async {
+    try {
+      final userId = pocketBase.authStore.record?.id;
+
+      final likesFuture = pocketBase.collection(postLikesCollection).getList(
+            page: 1,
+            perPage: userId != null ? 200 : 1,
+            filter: 'post = "${post.id}"',
+          );
+      final commentsFuture = pocketBase.collection(postCommentsCollection).getList(
+            page: 1,
+            perPage: 1,
+            filter: 'post = "${post.id}"',
+          );
+
+      final likesResult = await likesFuture;
+      final commentsResult = await commentsFuture;
+
+      bool isLiked = false;
+      String? likeRecordId = post.likeRecordId;
+
+      if (userId != null) {
+        for (final like in likesResult.items) {
+          final likeUser = like.data['user'];
+          if (likeUser == userId) {
+            isLiked = true;
+            likeRecordId = like.id;
+            break;
+          }
+        }
+
+        if (!isLiked && likesResult.totalItems > likesResult.items.length) {
+          final existing = await _findExistingLike(
+            pocketBase,
+            postId: post.id,
+            userId: userId,
+          );
+          if (existing != null) {
+            isLiked = true;
+            likeRecordId = existing.id;
+          }
+        }
+      }
+
+      return post.copyWith(
+        likesCount: likesResult.totalItems,
+        isLiked: isLiked,
+        likeRecordId: likeRecordId,
+        commentsCount: commentsResult.totalItems,
+      );
+    } catch (_) {
+      return post;
+    }
+  }
+
+  Future<RecordModel?> _findExistingLike(
+    PocketBase pocketBase, {
+    required String postId,
+    required String userId,
+  }) async {
+    try {
+      final record = await pocketBase.collection(postLikesCollection).getFirstListItem(
+            'post = "$postId" && user = "$userId"',
+          );
+      return record;
+    } on ClientException catch (error) {
+      if (error.statusCode == 404) {
+        return null;
+      }
+      rethrow;
+    }
   }
 }

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -146,7 +146,8 @@ class PostService {
           pocketBase,
           postId: postId,
           userId: userId,
-        ))?.id;
+        ))
+            ?.id;
 
     if (recordId == null) {
       throw PostServiceException('Bạn chưa thích bài viết này.');
@@ -164,11 +165,12 @@ class PostService {
   Future<List<PostComment>> fetchComments(String postId) async {
     final pocketBase = await getPocketbaseInstance();
     try {
-      final result = await pocketBase.collection(postCommentsCollection).getFullList(
-            filter: 'post = "$postId"',
-            expand: 'author',
-            sort: 'created',
-          );
+      final result =
+          await pocketBase.collection(postCommentsCollection).getFullList(
+                filter: 'post = "$postId"',
+                expand: 'author',
+                sort: 'created',
+              );
       return result
           .map((record) => PostComment.fromRecord(record, pocketBase))
           .toList(growable: false);
@@ -177,6 +179,34 @@ class PostService {
     } catch (_) {
       throw PostServiceException('Không thể tải bình luận.');
     }
+  }
+
+  Future<CommunityPost?> fetchPostById(String id) async {
+    final pocketBase = await getPocketbaseInstance();
+    try {
+      final record = await pocketBase.collection(postsCollection).getOne(
+            id,
+            expand: 'author',
+          );
+      return recordToCommunityPost(record, pocketBase);
+    } on ClientException catch (error) {
+      if (error.statusCode == 404) {
+        return null;
+      }
+      throw PostServiceException(_mapClientError(error));
+    } catch (_) {
+      throw PostServiceException(
+        'Không thể tải bài viết. Vui lòng thử lại sau.',
+      );
+    }
+  }
+
+  Future<CommunityPost> recordToCommunityPost(
+    RecordModel record,
+    PocketBase pocketBase,
+  ) async {
+    final post = CommunityPost.fromRecord(record, pocketBase);
+    return _attachPostMeta(post, pocketBase);
   }
 
   Future<PostComment> createComment({
@@ -229,11 +259,12 @@ class PostService {
             perPage: userId != null ? 200 : 1,
             filter: 'post = "${post.id}"',
           );
-      final commentsFuture = pocketBase.collection(postCommentsCollection).getList(
-            page: 1,
-            perPage: 1,
-            filter: 'post = "${post.id}"',
-          );
+      final commentsFuture =
+          pocketBase.collection(postCommentsCollection).getList(
+                page: 1,
+                perPage: 1,
+                filter: 'post = "${post.id}"',
+              );
 
       final likesResult = await likesFuture;
       final commentsResult = await commentsFuture;
@@ -281,9 +312,10 @@ class PostService {
     required String userId,
   }) async {
     try {
-      final record = await pocketBase.collection(postLikesCollection).getFirstListItem(
-            'post = "$postId" && user = "$userId"',
-          );
+      final record =
+          await pocketBase.collection(postLikesCollection).getFirstListItem(
+                'post = "$postId" && user = "$userId"',
+              );
       return record;
     } on ClientException catch (error) {
       if (error.statusCode == 404) {

--- a/lib/utils/pocketbase_utils.dart
+++ b/lib/utils/pocketbase_utils.dart
@@ -1,0 +1,37 @@
+import 'package:pocketbase/pocketbase.dart';
+
+RecordModel? resolveExpandedRecord(dynamic expanded) {
+  if (expanded is RecordModel) {
+    return expanded;
+  }
+  if (expanded is List) {
+    for (final item in expanded) {
+      if (item is RecordModel) {
+        return item;
+      }
+    }
+  }
+  return null;
+}
+
+String sanitizeDisplayName(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) {
+    return 'Người dùng';
+  }
+  return trimmed;
+}
+
+String? resolveFileUrl(
+  PocketBase pocketBase,
+  RecordModel? record,
+  dynamic fileName,
+) {
+  if (record == null) {
+    return null;
+  }
+  if (fileName is! String || fileName.isEmpty) {
+    return null;
+  }
+  return pocketBase.files.getUrl(record, fileName).toString();
+}


### PR DESCRIPTION
## Summary
- show post author avatars and expose like/comment counts in the community feed
- implement PocketBase services for liking, unliking, and commenting on posts and surface them via the social manager
- add a comments bottom sheet that lets users read and submit comments on posts

## Testing
- not run (environment missing `flutter`/`dart` tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691331ba2090832bad9b367ce0206a32)