### PR TITLE
Show user avatars and friendly names on social posts

### DIFF
--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -5,6 +5,7 @@ class RecruitmentPostCard extends StatelessWidget {
   final String hostName;
   final DateTime createdTime;
   final String? skillLevel;
+  final String? hostAvatarUrl;
   final int requiredPlayers;
   final int joinedPlayers;
   final String? description;
@@ -24,6 +25,7 @@ class RecruitmentPostCard extends StatelessWidget {
     required this.requiredPlayers,
     required this.joinedPlayers,
     this.skillLevel,
+    this.hostAvatarUrl,
     this.description,
     this.courtName,
     this.playTime,
@@ -158,14 +160,19 @@ class RecruitmentPostCard extends StatelessWidget {
       children: [
         CircleAvatar(
           radius: 26,
-          backgroundColor: cs.primary,
-          child: Text(
-            (hostName.isNotEmpty ? hostName[0] : '?').toUpperCase(),
-            style: textTheme.titleMedium?.copyWith(
-              color: cs.onPrimary,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
+          backgroundColor:
+              hostAvatarUrl == null ? cs.primary : Colors.transparent,
+          backgroundImage:
+              hostAvatarUrl != null ? NetworkImage(hostAvatarUrl!) : null,
+          child: hostAvatarUrl == null
+              ? Text(
+                  (hostName.isNotEmpty ? hostName[0] : '?').toUpperCase(),
+                  style: textTheme.titleMedium?.copyWith(
+                    color: cs.onPrimary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                )
+              : null,
         ),
         const SizedBox(width: 16),
         Expanded(

--- a/lib/models/community_post.dart
+++ b/lib/models/community_post.dart
@@ -32,11 +32,16 @@ class CommunityPost {
 
     final authorRecord = resolveExpandedRecord(record.expand?['author']);
     final authorData = authorRecord?.data;
-    final displayName = sanitizeDisplayName(
-      (authorData?['username'] as String?) ??
-          (authorData?['email'] as String?) ??
-          'Người dùng',
-    );
+    final authorId = (data['author'] as String?) ?? authorRecord?.id ?? '';
+    final isOwner =
+        authorId.isNotEmpty && authorId == pocketBase.authStore.record?.id;
+    final displayName = isOwner
+        ? 'Bạn'
+        : sanitizeDisplayName(
+            (authorData?['username'] as String?) ??
+                (authorData?['email'] as String?) ??
+                'Người dùng',
+          );
     final avatarUrl = resolveFileUrl(
       pocketBase,
       authorRecord,
@@ -45,7 +50,7 @@ class CommunityPost {
 
     return CommunityPost(
       id: record.id,
-      authorId: (data['author'] as String?) ?? authorRecord?.id ?? '',
+      authorId: authorId,
       authorName: displayName,
       authorAvatarUrl: avatarUrl,
       content: (data['content'] as String?)?.trim() ?? '',

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -1,11 +1,14 @@
 import 'package:badminton_booking_app/utils/recruitment_dictionary.dart';
 import 'package:pocketbase/pocketbase.dart';
 
+import '../utils/pocketbase_utils.dart';
+
 class RecruitmentPost {
   const RecruitmentPost({
     required this.id,
     required this.authorId,
     required this.authorName,
+    required this.authorAvatarUrl,
     required this.description,
     required this.requiredPlayers,
     required this.joinedPlayers,
@@ -30,12 +33,21 @@ class RecruitmentPost {
     final authorRecord = _resolveExpandedRecord(record.expand?['author']);
     final authorData = authorRecord?.data;
     final authorId = (data['author'] as String?) ?? authorRecord?.id ?? '';
-    final authorName = _sanitizeName(
-          (authorData?['username'] as String?) ??
-              (authorData?['email'] as String?),
-          // Bỏ fallback 'Người chơi' ở trong này
-        ) ??
-        'Người chơi';
+    final loggedInUserId = currentUserId ?? pocketBase.authStore.record?.id;
+    final isOwner = authorId == loggedInUserId;
+    final authorName = isOwner
+        ? 'Bạn'
+        : _sanitizeName(
+              (authorData?['username'] as String?) ??
+                  (authorData?['email'] as String?),
+              // Bỏ fallback 'Người chơi' ở trong này
+            ) ??
+            'Người chơi';
+    final authorAvatarUrl = resolveFileUrl(
+      pocketBase,
+      authorRecord,
+      authorData?['avatar'],
+    );
 
     final courtRecord = _resolveExpandedRecord(record.expand?['court']);
     final courtData = courtRecord?.data;
@@ -49,12 +61,13 @@ class RecruitmentPost {
         .toList();
 
     final joinedCount = applicantUserIds.length + 1; // tính cả chủ bài
-    final hasJoined = applicantUserIds.contains(currentUserId);
+    final hasJoined = applicantUserIds.contains(loggedInUserId);
 
     return RecruitmentPost(
       id: record.id,
       authorId: authorId,
       authorName: authorName,
+      authorAvatarUrl: authorAvatarUrl,
       description: (data['content'] as String?)?.trim() ?? '',
       requiredPlayers: (data['need_members'] as int?) ?? 0,
       joinedPlayers: joinedCount,
@@ -66,8 +79,8 @@ class RecruitmentPost {
       createdAt: DateTime.parse(data['created'] as String),
       eventTime: _tryParseDateTime(data['event_time']),
       courtName: courtName,
-      isJoined: hasJoined || authorId == currentUserId,
-      isOwner: authorId == currentUserId,
+      isJoined: hasJoined || authorId == loggedInUserId,
+      isOwner: isOwner,
       locationNote: (data['location_note'] as String?)?.trim(),
     );
   }
@@ -75,6 +88,7 @@ class RecruitmentPost {
   final String id;
   final String authorId;
   final String authorName;
+  final String? authorAvatarUrl;
   final String description;
   final int requiredPlayers;
   final int joinedPlayers;
@@ -90,11 +104,13 @@ class RecruitmentPost {
   RecruitmentPost copyWith({
     int? joinedPlayers,
     bool? isJoined,
+    String? authorAvatarUrl,
   }) {
     return RecruitmentPost(
       id: id,
       authorId: authorId,
       authorName: authorName,
+      authorAvatarUrl: authorAvatarUrl ?? this.authorAvatarUrl,
       description: description,
       requiredPlayers: requiredPlayers,
       joinedPlayers: joinedPlayers ?? this.joinedPlayers,

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -309,6 +309,7 @@ class _SocialPageState extends State<SocialPage> {
           return RecruitmentPostCard(
             hostName: post.authorName,
             createdTime: post.createdAt,
+            hostAvatarUrl: post.authorAvatarUrl,
             requiredPlayers: post.requiredPlayers,
             joinedPlayers: post.joinedPlayers,
             description: post.description,


### PR DESCRIPTION
## Summary
- personalize community posts by showing "Bạn" for the current user's posts and using the stored avatar
- enrich recruitment posts with avatar URLs, owner detection, and friendly display names
- update the recruitment post card UI to render host avatars alongside their names
