### PR TITLE
Add realtime updates for social posts and recruitment

### DIFF
--- a/lib/pages/social/post_manager.dart
+++ b/lib/pages/social/post_manager.dart
@@ -1,0 +1,515 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../../models/community_post.dart';
+import '../../models/post_comment.dart';
+import '../../services/post_service.dart';
+import '../../services/pocketbase_client.dart';
+
+class PostManager extends ChangeNotifier {
+  PostManager() : _postService = PostService() {
+    _initializeRealtime();
+  }
+
+  final PostService _postService;
+
+  bool _isDisposed = false;
+  bool _isLoadingPosts = false;
+  bool _isSubmittingPost = false;
+
+  List<CommunityPost> _posts = const [];
+  String? _postError;
+
+  final Set<String> _likingPosts = <String>{};
+  final Set<String> _loadingComments = <String>{};
+  final Set<String> _submittingComments = <String>{};
+  final Set<String> _loadedComments = <String>{};
+  final Map<String, List<PostComment>> _postComments =
+      <String, List<PostComment>>{};
+
+  UnsubscribeFunc? _postsUnsubscribe;
+  UnsubscribeFunc? _likesUnsubscribe;
+  UnsubscribeFunc? _commentsUnsubscribe;
+
+  bool get isLoadingPosts => _isLoadingPosts;
+  bool get isSubmittingPost => _isSubmittingPost;
+
+  List<CommunityPost> get posts => _posts;
+  String? get postError => _postError;
+
+  bool isLikingPost(String postId) => _likingPosts.contains(postId);
+  bool isLoadingComments(String postId) => _loadingComments.contains(postId);
+  bool isSubmittingComment(String postId) =>
+      _submittingComments.contains(postId);
+  List<PostComment> commentsFor(String postId) =>
+      _postComments[postId] ?? const <PostComment>[];
+
+  Future<void> refreshPosts() async {
+    _isLoadingPosts = true;
+    _postError = null;
+    notifyListeners();
+
+    try {
+      final results = await _postService.fetchPosts();
+      _posts = results;
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+    } finally {
+      _isLoadingPosts = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> createPost({
+    required String content,
+    List<File> images = const [],
+  }) async {
+    _isSubmittingPost = true;
+    notifyListeners();
+
+    try {
+      final newPost = await _postService.createPost(
+        content: content,
+        images: images,
+      );
+      _posts = [newPost, ..._posts];
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _isSubmittingPost = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> toggleLike(String postId) async {
+    final index = _posts.indexWhere((post) => post.id == postId);
+    if (index == -1 || _likingPosts.contains(postId)) {
+      return;
+    }
+
+    final post = _posts[index];
+    _likingPosts.add(postId);
+    notifyListeners();
+
+    try {
+      if (post.isLiked) {
+        await _postService.unlikePost(
+          postId: postId,
+          likeRecordId: post.likeRecordId,
+        );
+        final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
+        final updated = post.copyWith(
+          isLiked: false,
+          likesCount: newCount,
+          likeRecordId: null,
+        );
+        _updatePostAt(index, updated);
+      } else {
+        final likeRecordId = await _postService.likePost(postId);
+        final updated = post.copyWith(
+          isLiked: true,
+          likesCount: post.likesCount + 1,
+          likeRecordId: likeRecordId,
+        );
+        _updatePostAt(index, updated);
+      }
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _likingPosts.remove(postId);
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadComments(String postId, {bool forceRefresh = false}) async {
+    if (_loadingComments.contains(postId)) {
+      return;
+    }
+
+    if (!forceRefresh && _loadedComments.contains(postId)) {
+      return;
+    }
+
+    _loadingComments.add(postId);
+    notifyListeners();
+
+    try {
+      final comments = await _postService.fetchComments(postId);
+      _postComments[postId] = comments;
+      _loadedComments.add(postId);
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _loadingComments.remove(postId);
+      notifyListeners();
+    }
+  }
+
+  Future<void> addComment(String postId, String content) async {
+    if (_submittingComments.contains(postId)) {
+      return;
+    }
+
+    _submittingComments.add(postId);
+    notifyListeners();
+
+    try {
+      final comment = await _postService.createComment(
+        postId: postId,
+        content: content,
+      );
+
+      final comments = List<PostComment>.from(commentsFor(postId))
+        ..add(comment);
+      _postComments[postId] = comments;
+
+      final index = _posts.indexWhere((post) => post.id == postId);
+      if (index != -1) {
+        final post = _posts[index];
+        final updated =
+            post.copyWith(commentsCount: post.commentsCount + 1);
+        _updatePostAt(index, updated);
+      }
+    } on PostServiceException catch (error) {
+      _postError = error.message;
+      rethrow;
+    } finally {
+      _submittingComments.remove(postId);
+      notifyListeners();
+    }
+  }
+
+  void _initializeRealtime() {
+    unawaited(_setupPostsRealtime());
+    unawaited(_setupLikesRealtime());
+    unawaited(_setupCommentsRealtime());
+  }
+
+  Future<void> _setupPostsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _postsUnsubscribe;
+      _postsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _postsUnsubscribe =
+          await pocketBase.collection(PostService.postsCollection).subscribe(
+                '*',
+                _handlePostRealtimeEvent,
+                expand: 'author',
+              );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to initialize posts realtime subscription: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _setupLikesRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _likesUnsubscribe;
+      _likesUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _likesUnsubscribe = await pocketBase
+          .collection(PostService.postLikesCollection)
+          .subscribe('*', _handlePostLikeEvent);
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to initialize likes realtime subscription: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _setupCommentsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _commentsUnsubscribe;
+      _commentsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _commentsUnsubscribe = await pocketBase
+          .collection(PostService.postCommentsCollection)
+          .subscribe(
+        '*',
+        _handlePostCommentEvent,
+        expand: 'author',
+      );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint(
+            'Failed to initialize comments realtime subscription: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _handlePostRealtimeEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    try {
+      switch (event.action) {
+        case 'delete':
+          _removePost(record.id);
+          break;
+        case 'create':
+        case 'update':
+          final isActive = record.data['is_active'] != false;
+          if (!isActive) {
+            _removePost(record.id);
+            break;
+          }
+
+          final pocketBase = await getPocketbaseInstance();
+          final post =
+              await _postService.recordToCommunityPost(record, pocketBase);
+          final index = _posts.indexWhere((existing) => existing.id == post.id);
+          if (index == -1) {
+            _posts = [post, ..._posts];
+          } else {
+            _updatePostAt(index, post);
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process post realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> _handlePostLikeEvent(RecordSubscriptionEvent event) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    final postId = _extractRelationId(record, 'post');
+    if (postId == null) {
+      return;
+    }
+
+    final index = _posts.indexWhere((post) => post.id == postId);
+    if (index == -1) {
+      return;
+    }
+
+    final post = _posts[index];
+
+    try {
+      final pocketBase = await getPocketbaseInstance();
+      final currentUserId = pocketBase.authStore.record?.id;
+      final likeUserId = _extractRelationId(record, 'user');
+
+      switch (event.action) {
+        case 'create':
+          final updated = post.copyWith(
+            likesCount: post.likesCount + 1,
+            isLiked: currentUserId != null && currentUserId == likeUserId
+                ? true
+                : post.isLiked,
+            likeRecordId:
+                currentUserId != null && currentUserId == likeUserId
+                    ? record.id
+                    : post.likeRecordId,
+          );
+          _updatePostAt(index, updated);
+          break;
+        case 'delete':
+          final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
+          final updated = post.copyWith(
+            likesCount: newCount,
+            isLiked: currentUserId != null && currentUserId == likeUserId
+                ? false
+                : post.isLiked,
+            likeRecordId:
+                currentUserId != null && currentUserId == likeUserId
+                    ? null
+                    : post.likeRecordId,
+          );
+          _updatePostAt(index, updated);
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process like realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> _handlePostCommentEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    final postId = _extractRelationId(record, 'post');
+    if (postId == null) {
+      return;
+    }
+
+    final index = _posts.indexWhere((post) => post.id == postId);
+    if (index == -1) {
+      return;
+    }
+
+    final post = _posts[index];
+
+    try {
+      final pocketBase = await getPocketbaseInstance();
+      final hasLoadedComments = _loadedComments.contains(postId);
+      PostComment? updatedComment;
+      if (event.action != 'delete') {
+        updatedComment = PostComment.fromRecord(record, pocketBase);
+      }
+
+      switch (event.action) {
+        case 'create':
+          final newCount = post.commentsCount + 1;
+          _updatePostAt(index, post.copyWith(commentsCount: newCount));
+          if (hasLoadedComments && updatedComment != null) {
+            final comments = List<PostComment>.from(commentsFor(postId))
+              ..add(updatedComment);
+            _postComments[postId] = comments;
+          }
+          break;
+        case 'update':
+          if (hasLoadedComments && updatedComment != null) {
+            final comments = List<PostComment>.from(commentsFor(postId));
+            final commentIndex =
+                comments.indexWhere((comment) => comment.id == record.id);
+            if (commentIndex != -1) {
+              comments[commentIndex] = updatedComment;
+              _postComments[postId] = comments;
+            }
+          }
+          break;
+        case 'delete':
+          final newCount = post.commentsCount > 0
+              ? post.commentsCount - 1
+              : post.commentsCount;
+          _updatePostAt(index, post.copyWith(commentsCount: newCount));
+          if (hasLoadedComments) {
+            final comments = List<PostComment>.from(commentsFor(postId))
+              ..removeWhere((comment) => comment.id == record.id);
+            _postComments[postId] = comments;
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process comment realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  void _updatePostAt(int index, CommunityPost updated) {
+    final posts = List<CommunityPost>.from(_posts);
+    posts[index] = updated;
+    _posts = posts;
+  }
+
+  void _removePost(String postId) {
+    final previousLength = _posts.length;
+    _posts = _posts.where((post) => post.id != postId).toList(growable: false);
+    if (previousLength != _posts.length) {
+      _postComments.remove(postId);
+    }
+  }
+
+  String? _extractRelationId(RecordModel record, String field) {
+    final dataValue = record.data[field];
+    if (dataValue is String && dataValue.isNotEmpty) {
+      return dataValue;
+    }
+
+    final expanded = record.expand?[field];
+    if (expanded is RecordModel) {
+      return expanded.id;
+    }
+    if (expanded is List && expanded.isNotEmpty) {
+      final first = expanded.first;
+      if (first is RecordModel) {
+        return first.id;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    final unsubList = [
+      _postsUnsubscribe,
+      _likesUnsubscribe,
+      _commentsUnsubscribe,
+    ];
+    for (final unsub in unsubList) {
+      if (unsub != null) {
+        unawaited(unsub());
+      }
+    }
+    _postsUnsubscribe = null;
+    _likesUnsubscribe = null;
+    _commentsUnsubscribe = null;
+    super.dispose();
+  }
+}

--- a/lib/pages/social/post_manager.dart
+++ b/lib/pages/social/post_manager.dart
@@ -97,26 +97,19 @@ class PostManager extends ChangeNotifier {
 
     try {
       if (post.isLiked) {
+        // chỉ call API, không update _posts
         await _postService.unlikePost(
           postId: postId,
           likeRecordId: post.likeRecordId,
         );
-        final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
-        final updated = post.copyWith(
-          isLiked: false,
-          likesCount: newCount,
-          likeRecordId: null,
-        );
-        _updatePostAt(index, updated);
       } else {
-        final likeRecordId = await _postService.likePost(postId);
-        final updated = post.copyWith(
-          isLiked: true,
-          likesCount: post.likesCount + 1,
-          likeRecordId: likeRecordId,
-        );
-        _updatePostAt(index, updated);
+        await _postService.likePost(postId);
+        // không cần trả về likeRecordId ở đây nữa,
+        // realtime sẽ set lại chính xác
       }
+      // Realtime _handlePostLikeEvent sẽ:
+      // - tăng/giảm likesCount
+      // - set isLiked & likeRecordId đúng cho user hiện tại
     } on PostServiceException catch (error) {
       _postError = error.message;
       rethrow;
@@ -160,22 +153,15 @@ class PostManager extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final comment = await _postService.createComment(
+      // Chỉ gọi API, KHÔNG đụng vào _postComments hay _posts nữa
+      await _postService.createComment(
         postId: postId,
         content: content,
       );
 
-      final comments = List<PostComment>.from(commentsFor(postId))
-        ..add(comment);
-      _postComments[postId] = comments;
-
-      final index = _posts.indexWhere((post) => post.id == postId);
-      if (index != -1) {
-        final post = _posts[index];
-        final updated =
-            post.copyWith(commentsCount: post.commentsCount + 1);
-        _updatePostAt(index, updated);
-      }
+      // Realtime "create" sẽ tự:
+      // - tăng commentsCount trong _handlePostCommentEvent
+      // - thêm PostComment vào _postComments nếu chưa tồn tại
     } on PostServiceException catch (error) {
       _postError = error.message;
       rethrow;
@@ -249,10 +235,10 @@ class PostManager extends ChangeNotifier {
       _commentsUnsubscribe = await pocketBase
           .collection(PostService.postCommentsCollection)
           .subscribe(
-        '*',
-        _handlePostCommentEvent,
-        expand: 'author',
-      );
+            '*',
+            _handlePostCommentEvent,
+            expand: 'author',
+          );
     } catch (error, stackTrace) {
       if (kDebugMode) {
         debugPrint(
@@ -346,10 +332,9 @@ class PostManager extends ChangeNotifier {
             isLiked: currentUserId != null && currentUserId == likeUserId
                 ? true
                 : post.isLiked,
-            likeRecordId:
-                currentUserId != null && currentUserId == likeUserId
-                    ? record.id
-                    : post.likeRecordId,
+            likeRecordId: currentUserId != null && currentUserId == likeUserId
+                ? record.id
+                : post.likeRecordId,
           );
           _updatePostAt(index, updated);
           break;
@@ -360,10 +345,9 @@ class PostManager extends ChangeNotifier {
             isLiked: currentUserId != null && currentUserId == likeUserId
                 ? false
                 : post.isLiked,
-            likeRecordId:
-                currentUserId != null && currentUserId == likeUserId
-                    ? null
-                    : post.likeRecordId,
+            likeRecordId: currentUserId != null && currentUserId == likeUserId
+                ? null
+                : post.likeRecordId,
           );
           _updatePostAt(index, updated);
           break;
@@ -418,10 +402,17 @@ class PostManager extends ChangeNotifier {
         case 'create':
           final newCount = post.commentsCount + 1;
           _updatePostAt(index, post.copyWith(commentsCount: newCount));
+
           if (hasLoadedComments && updatedComment != null) {
-            final comments = List<PostComment>.from(commentsFor(postId))
-              ..add(updatedComment);
-            _postComments[postId] = comments;
+            final comments = List<PostComment>.from(commentsFor(postId));
+
+            final alreadyExists = comments
+                .any((c) => c.id == updatedComment!.id); // kiểm tra trùng
+
+            if (!alreadyExists) {
+              comments.add(updatedComment!);
+              _postComments[postId] = comments;
+            }
           }
           break;
         case 'update':
@@ -476,21 +467,35 @@ class PostManager extends ChangeNotifier {
   }
 
   String? _extractRelationId(RecordModel record, String field) {
-    final dataValue = record.data[field];
+    // 1. Lấy thẳng id từ data nếu có
+    final Object? dataValue = record.data[field];
     if (dataValue is String && dataValue.isNotEmpty) {
       return dataValue;
     }
 
-    final expanded = record.expand?[field];
+    // 2. Lấy từ expand (map có thể null)
+    final expandMap = record.expand;
+    if (expandMap == null) {
+      return null;
+    }
+
+    final Object? expanded = expandMap[field];
+
+    // Trường hợp expand là 1 RecordModel
     if (expanded is RecordModel) {
       return expanded.id;
     }
-    if (expanded is List && expanded.isNotEmpty) {
-      final first = expanded.first;
-      if (first is RecordModel) {
-        return first.id;
+
+    // Trường hợp expand là list RecordModel
+    if (expanded is List) {
+      if (expanded.isNotEmpty) {
+        final first = expanded.first;
+        if (first is RecordModel) {
+          return first.id;
+        }
       }
     }
+
     return null;
   }
 

--- a/lib/pages/social/recruitment_manager.dart
+++ b/lib/pages/social/recruitment_manager.dart
@@ -1,0 +1,290 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../../models/recruitment_post.dart';
+import '../../services/pocketbase_client.dart';
+import '../../services/recruitment_service.dart';
+
+class RecruitmentManager extends ChangeNotifier {
+  RecruitmentManager() : _service = RecruitmentService() {
+    _initializeRealtime();
+  }
+
+  final RecruitmentService _service;
+
+  bool _isDisposed = false;
+  bool _isLoadingRecruitments = false;
+
+  List<RecruitmentPost> _recruitmentPosts = const [];
+  String? _recruitmentError;
+
+  final Set<String> _joiningRecruitments = <String>{};
+
+  UnsubscribeFunc? _postsUnsubscribe;
+  UnsubscribeFunc? _applicantsUnsubscribe;
+
+  bool get isLoadingRecruitments => _isLoadingRecruitments;
+  List<RecruitmentPost> get recruitmentPosts => _recruitmentPosts;
+  String? get recruitmentError => _recruitmentError;
+
+  bool isJoining(String recruitmentId) =>
+      _joiningRecruitments.contains(recruitmentId);
+
+  Future<void> refreshRecruitments() async {
+    _isLoadingRecruitments = true;
+    _recruitmentError = null;
+    notifyListeners();
+
+    try {
+      final results = await _service.fetchActivePosts();
+      _recruitmentPosts = results;
+    } on RecruitmentServiceException catch (error) {
+      _recruitmentError = error.message;
+    } finally {
+      _isLoadingRecruitments = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> joinRecruitment(String recruitmentId) async {
+    if (_joiningRecruitments.contains(recruitmentId)) {
+      return;
+    }
+
+    _joiningRecruitments.add(recruitmentId);
+    notifyListeners();
+
+    try {
+      final updated = await _service.joinRecruitment(recruitmentId);
+      _recruitmentPosts = _recruitmentPosts
+          .map((post) => post.id == recruitmentId ? updated : post)
+          .toList(growable: false);
+    } finally {
+      _joiningRecruitments.remove(recruitmentId);
+      notifyListeners();
+    }
+  }
+
+  void _initializeRealtime() {
+    unawaited(_setupRecruitmentPostsRealtime());
+    unawaited(_setupRecruitmentApplicantsRealtime());
+  }
+
+  Future<void> _setupRecruitmentPostsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _postsUnsubscribe;
+      _postsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _postsUnsubscribe = await pocketBase
+          .collection(RecruitmentService.recruitmentPostsCollection)
+          .subscribe(
+        '*',
+        _handleRecruitmentPostEvent,
+        expand: 'author,court',
+      );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint(
+            'Failed to initialize recruitment posts realtime: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _setupRecruitmentApplicantsRealtime() async {
+    try {
+      final pocketBase = await getPocketbaseInstance();
+
+      final oldUnsub = _applicantsUnsubscribe;
+      _applicantsUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _applicantsUnsubscribe = await pocketBase
+          .collection(RecruitmentService.recruitmentApplicantsCollection)
+          .subscribe(
+        '*',
+        _handleRecruitmentApplicantEvent,
+        expand: 'user,recruitment',
+      );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint(
+            'Failed to initialize recruitment applicants realtime: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _handleRecruitmentPostEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    try {
+      switch (event.action) {
+        case 'delete':
+          _removeRecruitment(record.id);
+          break;
+        case 'create':
+        case 'update':
+          final isActive = record.data['is_active'] != false;
+          if (!isActive) {
+            _removeRecruitment(record.id);
+            break;
+          }
+          final updated = await _service.getRecruitmentById(record.id);
+          final index =
+              _recruitmentPosts.indexWhere((item) => item.id == updated.id);
+          if (index == -1) {
+            _recruitmentPosts = [updated, ..._recruitmentPosts];
+          } else {
+            final posts = List<RecruitmentPost>.from(_recruitmentPosts);
+            posts[index] = updated;
+            _recruitmentPosts = posts;
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process recruitment realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> _handleRecruitmentApplicantEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) {
+      return;
+    }
+
+    final record = event.record;
+    if (record == null) {
+      return;
+    }
+
+    final recruitmentId = _extractRelationId(record, 'recruitment');
+    if (recruitmentId == null) {
+      return;
+    }
+
+    final index =
+        _recruitmentPosts.indexWhere((post) => post.id == recruitmentId);
+    if (index == -1) {
+      return;
+    }
+
+    final recruitment = _recruitmentPosts[index];
+
+    try {
+      final pocketBase = await getPocketbaseInstance();
+      final currentUserId = pocketBase.authStore.record?.id;
+      final applicantUserId = _extractRelationId(record, 'user');
+
+      switch (event.action) {
+        case 'create':
+          final updated = recruitment.copyWith(
+            joinedPlayers: recruitment.joinedPlayers + 1,
+            isJoined: recruitment.isJoined ||
+                (currentUserId != null && currentUserId == applicantUserId),
+          );
+          _replaceRecruitmentAt(index, updated);
+          break;
+        case 'delete':
+          final newCount = recruitment.joinedPlayers > 1
+              ? recruitment.joinedPlayers - 1
+              : recruitment.joinedPlayers;
+          final updated = recruitment.copyWith(
+            joinedPlayers: newCount,
+            isJoined: currentUserId != null && currentUserId == applicantUserId
+                ? recruitment.isOwner
+                : recruitment.isJoined,
+          );
+          _replaceRecruitmentAt(index, updated);
+          break;
+        default:
+          break;
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to process applicant realtime event: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  void _replaceRecruitmentAt(int index, RecruitmentPost updated) {
+    final posts = List<RecruitmentPost>.from(_recruitmentPosts);
+    posts[index] = updated;
+    _recruitmentPosts = posts;
+  }
+
+  void _removeRecruitment(String recruitmentId) {
+    _recruitmentPosts = _recruitmentPosts
+        .where((post) => post.id != recruitmentId)
+        .toList(growable: false);
+  }
+
+  String? _extractRelationId(RecordModel record, String field) {
+    final dataValue = record.data[field];
+    if (dataValue is String && dataValue.isNotEmpty) {
+      return dataValue;
+    }
+
+    final expanded = record.expand?[field];
+    if (expanded is RecordModel) {
+      return expanded.id;
+    }
+    if (expanded is List && expanded.isNotEmpty) {
+      final first = expanded.first;
+      if (first is RecordModel) {
+        return first.id;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    final unsubList = [
+      _postsUnsubscribe,
+      _applicantsUnsubscribe,
+    ];
+    for (final unsub in unsubList) {
+      if (unsub != null) {
+        unawaited(unsub());
+      }
+    }
+    _postsUnsubscribe = null;
+    _applicantsUnsubscribe = null;
+    super.dispose();
+  }
+}

--- a/lib/pages/social/recruitment_manager.dart
+++ b/lib/pages/social/recruitment_manager.dart
@@ -85,14 +85,13 @@ class RecruitmentManager extends ChangeNotifier {
       _postsUnsubscribe = await pocketBase
           .collection(RecruitmentService.recruitmentPostsCollection)
           .subscribe(
-        '*',
-        _handleRecruitmentPostEvent,
-        expand: 'author,court',
-      );
+            '*',
+            _handleRecruitmentPostEvent,
+            expand: 'author,court',
+          );
     } catch (error, stackTrace) {
       if (kDebugMode) {
-        debugPrint(
-            'Failed to initialize recruitment posts realtime: $error');
+        debugPrint('Failed to initialize recruitment posts realtime: $error');
         debugPrint(stackTrace.toString());
       }
     }
@@ -111,10 +110,10 @@ class RecruitmentManager extends ChangeNotifier {
       _applicantsUnsubscribe = await pocketBase
           .collection(RecruitmentService.recruitmentApplicantsCollection)
           .subscribe(
-        '*',
-        _handleRecruitmentApplicantEvent,
-        expand: 'user,recruitment',
-      );
+            '*',
+            _handleRecruitmentApplicantEvent,
+            expand: 'user,recruitment',
+          );
     } catch (error, stackTrace) {
       if (kDebugMode) {
         debugPrint(
@@ -253,21 +252,35 @@ class RecruitmentManager extends ChangeNotifier {
   }
 
   String? _extractRelationId(RecordModel record, String field) {
-    final dataValue = record.data[field];
+    // 1. Lấy thẳng id từ data nếu có
+    final Object? dataValue = record.data[field];
     if (dataValue is String && dataValue.isNotEmpty) {
       return dataValue;
     }
 
-    final expanded = record.expand?[field];
+    // 2. Lấy từ expand (map có thể null)
+    final expandMap = record.expand;
+    if (expandMap == null) {
+      return null;
+    }
+
+    final Object? expanded = expandMap[field];
+
+    // Trường hợp expand là 1 RecordModel
     if (expanded is RecordModel) {
       return expanded.id;
     }
-    if (expanded is List && expanded.isNotEmpty) {
-      final first = expanded.first;
-      if (first is RecordModel) {
-        return first.id;
+
+    // Trường hợp expand là list RecordModel
+    if (expanded is List) {
+      if (expanded.isNotEmpty) {
+        final first = expanded.first;
+        if (first is RecordModel) {
+          return first.id;
+        }
       }
     }
+
     return null;
   }
 

--- a/lib/pages/social/social_manager.dart
+++ b/lib/pages/social/social_manager.dart
@@ -1,344 +1,96 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:badminton_booking_app/services/pocketbase_client.dart';
 import 'package:flutter/foundation.dart';
-import 'package:pocketbase/pocketbase.dart';
 
 import '../../models/community_post.dart';
 import '../../models/post_comment.dart';
 import '../../models/recruitment_post.dart';
-import '../../services/post_service.dart';
-import '../../services/recruitment_service.dart';
+import 'post_manager.dart';
+import 'recruitment_manager.dart';
 
 class SocialManager with ChangeNotifier {
   SocialManager()
-      : _postService = PostService(),
-        _recruitmentService = RecruitmentService() {
-    _initializeRealtime();
+      : postManager = PostManager(),
+        recruitmentManager = RecruitmentManager() {
+    _postManagerListener = _propagateChanges;
+    _recruitmentManagerListener = _propagateChanges;
+    postManager.addListener(_postManagerListener);
+    recruitmentManager.addListener(_recruitmentManagerListener);
   }
 
-  final PostService _postService;
-  final RecruitmentService _recruitmentService;
-  // use if RecordSubscription isn't present in your SDK
-  UnsubscribeFunc? _postsUnsubscribe;
+  final PostManager postManager;
+  final RecruitmentManager recruitmentManager;
+
+  late final VoidCallback _postManagerListener;
+  late final VoidCallback _recruitmentManagerListener;
   bool _isDisposed = false;
-
-  bool _isLoadingPosts = false;
-  bool _isLoadingRecruitments = false;
-  bool _isSubmittingPost = false;
-
-  List<CommunityPost> _posts = const [];
-  List<RecruitmentPost> _recruitmentPosts = const [];
-
-  String? _postError;
-  String? _recruitmentError;
-
-  final Set<String> _joiningRecruitments = <String>{};
-  final Set<String> _likingPosts = <String>{};
-  final Set<String> _loadingComments = <String>{};
-  final Set<String> _submittingComments = <String>{};
-  final Set<String> _loadedComments = <String>{};
-  final Map<String, List<PostComment>> _postComments =
-      <String, List<PostComment>>{};
-
-  bool get isLoadingPosts => _isLoadingPosts;
-  bool get isLoadingRecruitments => _isLoadingRecruitments;
-  bool get isSubmittingPost => _isSubmittingPost;
-
-  List<CommunityPost> get posts => _posts;
-  List<RecruitmentPost> get recruitmentPosts => _recruitmentPosts;
-
-  String? get postError => _postError;
-  String? get recruitmentError => _recruitmentError;
-
-  bool isJoining(String recruitmentId) =>
-      _joiningRecruitments.contains(recruitmentId);
-  bool isLikingPost(String postId) => _likingPosts.contains(postId);
-  bool isLoadingComments(String postId) => _loadingComments.contains(postId);
-  bool isSubmittingComment(String postId) =>
-      _submittingComments.contains(postId);
-  List<PostComment> commentsFor(String postId) =>
-      _postComments[postId] ?? const <PostComment>[];
 
   Future<void> loadInitial() async {
     await Future.wait<void>([
-      refreshPosts(),
-      refreshRecruitments(),
+      postManager.refreshPosts(),
+      recruitmentManager.refreshRecruitments(),
     ]);
   }
 
-  void _initializeRealtime() {
-    unawaited(_setupPostsRealtime());
-  }
+  bool get isLoadingPosts => postManager.isLoadingPosts;
+  bool get isLoadingRecruitments =>
+      recruitmentManager.isLoadingRecruitments;
+  bool get isSubmittingPost => postManager.isSubmittingPost;
 
-  Future<void> _setupPostsRealtime() async {
-    try {
-      final pocketBase = await getPocketbaseInstance();
+  List<CommunityPost> get posts => postManager.posts;
+  List<RecruitmentPost> get recruitmentPosts =>
+      recruitmentManager.recruitmentPosts;
 
-      // Hủy subscription cũ (nếu có)
-      final oldUnsub = _postsUnsubscribe;
-      _postsUnsubscribe = null;
-      if (oldUnsub != null) {
-        await oldUnsub(); // gọi function
-      }
+  String? get postError => postManager.postError;
+  String? get recruitmentError => recruitmentManager.recruitmentError;
 
-      _postsUnsubscribe =
-          await pocketBase.collection(PostService.postsCollection).subscribe(
-                '*',
-                _handlePostRealtimeEvent,
-                expand: 'author', // string, không phải List
-              );
-    } catch (error, stackTrace) {
-      if (kDebugMode) {
-        debugPrint('Failed to initialize posts realtime subscription: $error');
-        debugPrint(stackTrace.toString());
-      }
-    }
-  }
+  bool isJoining(String recruitmentId) =>
+      recruitmentManager.isJoining(recruitmentId);
+  bool isLikingPost(String postId) => postManager.isLikingPost(postId);
+  bool isLoadingComments(String postId) =>
+      postManager.isLoadingComments(postId);
+  bool isSubmittingComment(String postId) =>
+      postManager.isSubmittingComment(postId);
+  List<PostComment> commentsFor(String postId) =>
+      postManager.commentsFor(postId);
 
-  Future<void> refreshPosts() async {
-    _isLoadingPosts = true;
-    _postError = null;
-    notifyListeners();
-
-    try {
-      final results = await _postService.fetchPosts();
-      _posts = results;
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-    } finally {
-      _isLoadingPosts = false;
-      notifyListeners();
-    }
-  }
-
-  Future<void> refreshRecruitments() async {
-    _isLoadingRecruitments = true;
-    _recruitmentError = null;
-    notifyListeners();
-
-    try {
-      final results = await _recruitmentService.fetchActivePosts();
-      _recruitmentPosts = results;
-    } on RecruitmentServiceException catch (error) {
-      _recruitmentError = error.message;
-    } finally {
-      _isLoadingRecruitments = false;
-      notifyListeners();
-    }
-  }
+  Future<void> refreshPosts() => postManager.refreshPosts();
+  Future<void> refreshRecruitments() =>
+      recruitmentManager.refreshRecruitments();
 
   Future<void> createPost({
     required String content,
     List<File> images = const [],
   }) async {
-    _isSubmittingPost = true;
-    notifyListeners();
-
-    try {
-      final newPost = await _postService.createPost(
-        content: content,
-        images: images,
-      );
-      _posts = [newPost, ..._posts];
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-      rethrow;
-    } finally {
-      _isSubmittingPost = false;
-      notifyListeners();
-    }
+    await postManager.createPost(content: content, images: images);
   }
 
-  Future<void> toggleLike(String postId) async {
-    final index = _posts.indexWhere((post) => post.id == postId);
-    if (index == -1 || _likingPosts.contains(postId)) {
-      return;
-    }
+  Future<void> toggleLike(String postId) => postManager.toggleLike(postId);
 
-    final post = _posts[index];
-    _likingPosts.add(postId);
-    notifyListeners();
+  Future<void> loadComments(String postId, {bool forceRefresh = false}) =>
+      postManager.loadComments(postId, forceRefresh: forceRefresh);
 
-    try {
-      if (post.isLiked) {
-        await _postService.unlikePost(
-          postId: postId,
-          likeRecordId: post.likeRecordId,
-        );
-        final newCount = post.likesCount > 0 ? post.likesCount - 1 : 0;
-        final updated = post.copyWith(
-          isLiked: false,
-          likesCount: newCount,
-          likeRecordId: null,
-        );
-        _updatePostAt(index, updated);
-      } else {
-        final likeRecordId = await _postService.likePost(postId);
-        final updated = post.copyWith(
-          isLiked: true,
-          likesCount: post.likesCount + 1,
-          likeRecordId: likeRecordId,
-        );
-        _updatePostAt(index, updated);
-      }
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-      rethrow;
-    } finally {
-      _likingPosts.remove(postId);
-      notifyListeners();
-    }
-  }
+  Future<void> addComment(String postId, String content) =>
+      postManager.addComment(postId, content);
 
-  Future<void> loadComments(String postId, {bool forceRefresh = false}) async {
-    if (_loadingComments.contains(postId)) {
-      return;
-    }
+  Future<void> joinRecruitment(String recruitmentId) =>
+      recruitmentManager.joinRecruitment(recruitmentId);
 
-    if (!forceRefresh && _loadedComments.contains(postId)) {
-      return;
-    }
-
-    _loadingComments.add(postId);
-    notifyListeners();
-
-    try {
-      final comments = await _postService.fetchComments(postId);
-      _postComments[postId] = comments;
-      _loadedComments.add(postId);
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-      rethrow;
-    } finally {
-      _loadingComments.remove(postId);
-      notifyListeners();
-    }
-  }
-
-  Future<void> addComment(String postId, String content) async {
-    if (_submittingComments.contains(postId)) {
-      return;
-    }
-
-    _submittingComments.add(postId);
-    notifyListeners();
-
-    try {
-      final comment = await _postService.createComment(
-        postId: postId,
-        content: content,
-      );
-
-      final comments = List<PostComment>.from(commentsFor(postId))
-        ..add(comment);
-      _postComments[postId] = comments;
-
-      final index = _posts.indexWhere((post) => post.id == postId);
-      if (index != -1) {
-        final post = _posts[index];
-        final updated = post.copyWith(commentsCount: post.commentsCount + 1);
-        _updatePostAt(index, updated);
-      }
-    } on PostServiceException catch (error) {
-      _postError = error.message;
-      rethrow;
-    } finally {
-      _submittingComments.remove(postId);
-      notifyListeners();
-    }
-  }
-
-  Future<void> joinRecruitment(String recruitmentId) async {
-    if (_joiningRecruitments.contains(recruitmentId)) {
-      return;
-    }
-
-    _joiningRecruitments.add(recruitmentId);
-    notifyListeners();
-
-    try {
-      final updated = await _recruitmentService.joinRecruitment(recruitmentId);
-      _recruitmentPosts = _recruitmentPosts
-          .map((post) => post.id == recruitmentId ? updated : post)
-          .toList(growable: false);
-    } finally {
-      _joiningRecruitments.remove(recruitmentId);
-      notifyListeners();
-    }
-  }
-
-  void _updatePostAt(int index, CommunityPost updated) {
-    final posts = List<CommunityPost>.from(_posts);
-    posts[index] = updated;
-    _posts = posts;
-  }
-
-  Future<void> _handlePostRealtimeEvent(RecordSubscriptionEvent event) async {
+  void _propagateChanges() {
     if (_isDisposed) {
       return;
     }
-
-    final record = event.record;
-    if (record == null) {
-      return;
-    }
-
-    try {
-      switch (event.action) {
-        case 'delete':
-          _removePost(record.id);
-          break;
-        case 'create':
-        case 'update':
-          final isActive = record.data['is_active'] != false;
-          if (!isActive) {
-            _removePost(record.id);
-            break;
-          }
-
-          final pocketBase = await getPocketbaseInstance();
-          final post =
-              await _postService.recordToCommunityPost(record, pocketBase);
-          final index = _posts.indexWhere((existing) => existing.id == post.id);
-          if (index == -1) {
-            _posts = [post, ..._posts];
-          } else {
-            _updatePostAt(index, post);
-          }
-          break;
-        default:
-          break;
-      }
-    } catch (error, stackTrace) {
-      if (kDebugMode) {
-        debugPrint('Failed to process realtime event: $error');
-        debugPrint(stackTrace.toString());
-      }
-    } finally {
-      if (!_isDisposed) {
-        notifyListeners();
-      }
-    }
-  }
-
-  void _removePost(String postId) {
-    final previousLength = _posts.length;
-    _posts = _posts.where((post) => post.id != postId).toList(growable: false);
-    if (previousLength != _posts.length) {
-      _postComments.remove(postId);
-    }
+    notifyListeners();
   }
 
   @override
   void dispose() {
     _isDisposed = true;
-    final unsub = _postsUnsubscribe;
-    _postsUnsubscribe = null;
-    if (unsub != null) {
-      unawaited(unsub()); // gọi function để unsubscribe
-    }
+    postManager.removeListener(_postManagerListener);
+    recruitmentManager.removeListener(_recruitmentManagerListener);
+    postManager.dispose();
+    recruitmentManager.dispose();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- split the previous `SocialManager` into dedicated `PostManager` and `RecruitmentManager` classes so the orchestration layer is easier to debug
- add realtime listeners for post likes/comments and recruitment posts/applicants to keep the social feed fresh automatically
- wire the new managers through `SocialManager` so the existing widgets keep working with the richer realtime data

## Testing
- Not run (Flutter SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165cd5ba60832ba8165a319ba5dbdb)