### PR TITLE
Implement friend and chat flows

### DIFF
--- a/lib/components/chat_bubble.dart
+++ b/lib/components/chat_bubble.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
+
 import '../models/chat_message.dart';
 
 class ChatBubble extends StatelessWidget {
   final ChatMessage message;
   final bool showAvatar;
   final bool showSeen;
+  final String? peerInitial;
+  final String? peerAvatarUrl;
 
   const ChatBubble({
     super.key,
     required this.message,
     this.showAvatar = false,
     this.showSeen = false,
+    this.peerInitial,
+    this.peerAvatarUrl,
   });
 
   @override
@@ -39,7 +44,14 @@ class ChatBubble extends StatelessWidget {
                 child: CircleAvatar(
                   radius: 16,
                   backgroundColor: cs.primary,
-                  child: const Text('NM', style: TextStyle(fontSize: 12)),
+                  backgroundImage:
+                      peerAvatarUrl != null ? NetworkImage(peerAvatarUrl!) : null,
+                  child: peerAvatarUrl == null
+                      ? Text(
+                          (peerInitial ?? '?').toUpperCase(),
+                          style: const TextStyle(fontSize: 12),
+                        )
+                      : null,
                 ),
               ),
               const SizedBox(width: 8),
@@ -78,7 +90,7 @@ class ChatBubble extends StatelessWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Text(
-                            message.time,
+                            message.timeLabel,
                             style: Theme.of(context)
                                 .textTheme
                                 .labelSmall

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
+import 'package:badminton_booking_app/pages/social/chat/chat_manager.dart';
+import 'package:badminton_booking_app/pages/social/chat/friend_manager.dart';
 import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:flutter/material.dart';
@@ -24,6 +26,8 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => UserManager()),
         ChangeNotifierProvider(create: (_) => CourtManager()),
         ChangeNotifierProvider(create: (_) => SocialManager()),
+        ChangeNotifierProvider(create: (_) => FriendManager()),
+        ChangeNotifierProvider(create: (_) => ChatManager()),
       ],
       child: const MyApp(),
     ),

--- a/lib/models/chat_contact.dart
+++ b/lib/models/chat_contact.dart
@@ -7,6 +7,7 @@ class ChatContact {
     required this.name,
     required this.avatarText,
     this.avatarUrl,
+    this.roomId,
     this.statusMessage,
     this.lastMessage,
     this.lastMessageTimeLabel,
@@ -18,6 +19,7 @@ class ChatContact {
   final String name;
   final String avatarText;
   final String? avatarUrl;
+  final String? roomId;
   final String? statusMessage;
   final String? lastMessage;
   final String? lastMessageTimeLabel;
@@ -25,4 +27,30 @@ class ChatContact {
   final bool isOnline;
 
   bool get hasUnreadMessages => unreadCount > 0;
+
+  ChatContact copyWith({
+    String? id,
+    String? name,
+    String? avatarText,
+    String? avatarUrl,
+    String? roomId,
+    String? statusMessage,
+    String? lastMessage,
+    String? lastMessageTimeLabel,
+    int? unreadCount,
+    bool? isOnline,
+  }) {
+    return ChatContact(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      avatarText: avatarText ?? this.avatarText,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      roomId: roomId ?? this.roomId,
+      statusMessage: statusMessage ?? this.statusMessage,
+      lastMessage: lastMessage ?? this.lastMessage,
+      lastMessageTimeLabel: lastMessageTimeLabel ?? this.lastMessageTimeLabel,
+      unreadCount: unreadCount ?? this.unreadCount,
+      isOnline: isOnline ?? this.isOnline,
+    );
+  }
 }

--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -1,15 +1,48 @@
-class ChatMessage {
-  final String id;
-  final String author;
-  final String content;
-  final String time;
-  final bool isMe;
+import 'package:intl/intl.dart';
+import 'package:meta/meta.dart';
+import 'package:pocketbase/pocketbase.dart';
 
+@immutable
+class ChatMessage {
   const ChatMessage({
     required this.id,
-    required this.author,
+    required this.roomId,
+    required this.senderId,
     required this.content,
-    required this.time,
+    required this.createdAt,
     required this.isMe,
+    this.isRead = false,
+    this.readAt,
   });
+
+  final String id;
+  final String roomId;
+  final String senderId;
+  final String content;
+  final DateTime createdAt;
+  final bool isMe;
+  final bool isRead;
+  final DateTime? readAt;
+
+  String get timeLabel => DateFormat.Hm().format(createdAt.toLocal());
+
+  factory ChatMessage.fromRecord(
+    RecordModel record,
+    String currentUserId,
+  ) {
+    final createdAt = DateTime.tryParse(record.getStringValue('created')) ??
+        DateTime.now();
+    final readAt = DateTime.tryParse(record.getStringValue('read_at'));
+
+    return ChatMessage(
+      id: record.id,
+      roomId: record.getStringValue('chat'),
+      senderId: record.getStringValue('sender'),
+      content: record.getStringValue('content'),
+      createdAt: createdAt,
+      isMe: record.getStringValue('sender') == currentUserId,
+      isRead: record.getBoolValue('is_read'),
+      readAt: readAt,
+    );
+  }
 }

--- a/lib/models/chat_room.dart
+++ b/lib/models/chat_room.dart
@@ -1,0 +1,97 @@
+import 'package:intl/intl.dart';
+import 'package:meta/meta.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/chat_contact.dart';
+import 'user_summary.dart';
+
+@immutable
+class ChatRoom {
+  const ChatRoom({
+    required this.id,
+    required this.userAId,
+    required this.userBId,
+    this.lastMessage,
+    this.lastMessageAt,
+    this.lastSender,
+    this.userA,
+    this.userB,
+    this.unreadCount = 0,
+  });
+
+  final String id;
+  final String userAId;
+  final String userBId;
+  final String? lastMessage;
+  final DateTime? lastMessageAt;
+  final UserSummary? lastSender;
+  final UserSummary? userA;
+  final UserSummary? userB;
+  final int unreadCount;
+
+  ChatRoom copyWith({int? unreadCount}) {
+    return ChatRoom(
+      id: id,
+      userAId: userAId,
+      userBId: userBId,
+      lastMessage: lastMessage,
+      lastMessageAt: lastMessageAt,
+      lastSender: lastSender,
+      userA: userA,
+      userB: userB,
+      unreadCount: unreadCount ?? this.unreadCount,
+    );
+  }
+
+  factory ChatRoom.fromRecord(
+    RecordModel record,
+    PocketBase pocketBase,
+  ) {
+    final userARecord = record.expand['user_a'] as RecordModel?;
+    final userBRecord = record.expand['user_b'] as RecordModel?;
+    final lastSenderRecord = record.expand['last_sender'] as RecordModel?;
+
+    return ChatRoom(
+      id: record.id,
+      userAId: record.getStringValue('user_a'),
+      userBId: record.getStringValue('user_b'),
+      lastMessage: record.getStringValue('last_message').isEmpty
+          ? null
+          : record.getStringValue('last_message'),
+      lastMessageAt: _parseDate(record.getStringValue('last_message_at')),
+      lastSender: lastSenderRecord == null
+          ? null
+          : UserSummary.fromRecord(lastSenderRecord, pocketBase),
+      userA: userARecord == null
+          ? null
+          : UserSummary.fromRecord(userARecord, pocketBase),
+      userB: userBRecord == null
+          ? null
+          : UserSummary.fromRecord(userBRecord, pocketBase),
+    );
+  }
+
+  ChatContact? toChatContact(String? currentUserId) {
+    if (currentUserId == null) return null;
+    final friend = currentUserId == userAId ? userB : userA;
+    if (friend == null) return null;
+    final timeLabel = lastMessageAt == null
+        ? null
+        : DateFormat.Hm().format(lastMessageAt!.toLocal());
+    return ChatContact(
+      id: friend.id,
+      roomId: id,
+      name: friend.displayName,
+      avatarText: friend.initials,
+      avatarUrl: friend.avatarUrl,
+      lastMessage: lastMessage,
+      lastMessageTimeLabel: timeLabel,
+      unreadCount: unreadCount,
+    );
+  }
+
+  static DateTime? _parseDate(String value) {
+    if (value.isEmpty) return null;
+    return DateTime.tryParse(value);
+  }
+}

--- a/lib/models/chat_room.dart
+++ b/lib/models/chat_room.dart
@@ -47,9 +47,17 @@ class ChatRoom {
     RecordModel record,
     PocketBase pocketBase,
   ) {
-    final userARecord = record.expand['user_a'] as RecordModel?;
-    final userBRecord = record.expand['user_b'] as RecordModel?;
-    final lastSenderRecord = record.expand['last_sender'] as RecordModel?;
+    final userAList = record.expand['user_a'] as List<RecordModel>?;
+    final userBList = record.expand['user_b'] as List<RecordModel>?;
+    final lastSenderList = record.expand['last_sender'] as List<RecordModel>?;
+
+    final userARecord =
+        (userAList != null && userAList.isNotEmpty) ? userAList.first : null;
+    final userBRecord =
+        (userBList != null && userBList.isNotEmpty) ? userBList.first : null;
+    final lastSenderRecord = (lastSenderList != null && lastSenderList.isNotEmpty)
+        ? lastSenderList.first
+        : null;
 
     return ChatRoom(
       id: record.id,

--- a/lib/models/friend_request.dart
+++ b/lib/models/friend_request.dart
@@ -43,8 +43,15 @@ class FriendRequest {
     final updatedAt = DateTime.tryParse(record.getStringValue('updated')) ??
         createdAt;
 
-    final fromUserRecord = record.expand['from_user'] as RecordModel?;
-    final toUserRecord = record.expand['to_user'] as RecordModel?;
+    final fromUserList = record.expand['from_user'] as List<RecordModel>?;
+    final toUserList = record.expand['to_user'] as List<RecordModel>?;
+
+    final fromUserRecord = (fromUserList != null && fromUserList.isNotEmpty)
+        ? fromUserList.first
+        : null;
+    final toUserRecord = (toUserList != null && toUserList.isNotEmpty)
+        ? toUserList.first
+        : null;
 
     return FriendRequest(
       id: record.id,

--- a/lib/models/friend_request.dart
+++ b/lib/models/friend_request.dart
@@ -1,0 +1,67 @@
+import 'package:meta/meta.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import 'user_summary.dart';
+
+enum FriendRequestStatus { pending, accepted, rejected, cancelled }
+
+@immutable
+class FriendRequest {
+  const FriendRequest({
+    required this.id,
+    required this.fromUserId,
+    required this.toUserId,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+    this.fromUser,
+    this.toUser,
+  });
+
+  final String id;
+  final String fromUserId;
+  final String toUserId;
+  final FriendRequestStatus status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final UserSummary? fromUser;
+  final UserSummary? toUser;
+
+  bool get isPending => status == FriendRequestStatus.pending;
+
+  bool isIncoming(String currentUserId) => currentUserId == toUserId;
+
+  factory FriendRequest.fromRecord(
+    RecordModel record,
+    PocketBase pocketBase,
+  ) {
+    final fromUserId = record.getStringValue('from_user');
+    final toUserId = record.getStringValue('to_user');
+    final statusValue = record.getStringValue('status');
+    final createdAt = DateTime.tryParse(record.getStringValue('created')) ??
+        DateTime.fromMillisecondsSinceEpoch(0);
+    final updatedAt = DateTime.tryParse(record.getStringValue('updated')) ??
+        createdAt;
+
+    final fromUserRecord = record.expand['from_user'] as RecordModel?;
+    final toUserRecord = record.expand['to_user'] as RecordModel?;
+
+    return FriendRequest(
+      id: record.id,
+      fromUserId: fromUserId,
+      toUserId: toUserId,
+      status: FriendRequestStatus.values.firstWhere(
+        (element) => element.name == statusValue,
+        orElse: () => FriendRequestStatus.pending,
+      ),
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      fromUser: fromUserRecord == null
+          ? null
+          : UserSummary.fromRecord(fromUserRecord, pocketBase),
+      toUser: toUserRecord == null
+          ? null
+          : UserSummary.fromRecord(toUserRecord, pocketBase),
+    );
+  }
+}

--- a/lib/models/friendship.dart
+++ b/lib/models/friendship.dart
@@ -1,0 +1,76 @@
+import 'package:meta/meta.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/chat_contact.dart';
+import 'user_summary.dart';
+
+@immutable
+class Friendship {
+  const Friendship({
+    required this.id,
+    required this.userAId,
+    required this.userBId,
+    required this.createdAt,
+    required this.updatedAt,
+    this.userA,
+    this.userB,
+  });
+
+  final String id;
+  final String userAId;
+  final String userBId;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final UserSummary? userA;
+  final UserSummary? userB;
+
+  factory Friendship.fromRecord(
+    RecordModel record,
+    PocketBase pocketBase,
+  ) {
+    final createdAt = DateTime.tryParse(record.getStringValue('created')) ??
+        DateTime.fromMillisecondsSinceEpoch(0);
+    final updatedAt = DateTime.tryParse(record.getStringValue('updated')) ??
+        createdAt;
+
+    final userARecord = record.expand['user_a'] as RecordModel?;
+    final userBRecord = record.expand['user_b'] as RecordModel?;
+
+    return Friendship(
+      id: record.id,
+      userAId: record.getStringValue('user_a'),
+      userBId: record.getStringValue('user_b'),
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      userA: userARecord == null
+          ? null
+          : UserSummary.fromRecord(userARecord, pocketBase),
+      userB: userBRecord == null
+          ? null
+          : UserSummary.fromRecord(userBRecord, pocketBase),
+    );
+  }
+
+  UserSummary? friendOf(String currentUserId) {
+    if (userAId == currentUserId) {
+      return userB;
+    }
+    if (userBId == currentUserId) {
+      return userA;
+    }
+    return null;
+  }
+
+  ChatContact? toChatContact(String? currentUserId) {
+    if (currentUserId == null) return null;
+    final friend = friendOf(currentUserId);
+    if (friend == null) return null;
+    return ChatContact(
+      id: friend.id,
+      name: friend.displayName,
+      avatarText: friend.initials,
+      avatarUrl: friend.avatarUrl,
+      statusMessage: 'Kết bạn từ ${createdAt.year}',
+    );
+  }
+}

--- a/lib/models/friendship.dart
+++ b/lib/models/friendship.dart
@@ -33,8 +33,13 @@ class Friendship {
     final updatedAt = DateTime.tryParse(record.getStringValue('updated')) ??
         createdAt;
 
-    final userARecord = record.expand['user_a'] as RecordModel?;
-    final userBRecord = record.expand['user_b'] as RecordModel?;
+    final userAList = record.expand['user_a'] as List<RecordModel>?;
+    final userBList = record.expand['user_b'] as List<RecordModel>?;
+
+    final userARecord =
+        (userAList != null && userAList.isNotEmpty) ? userAList.first : null;
+    final userBRecord =
+        (userBList != null && userBList.isNotEmpty) ? userBList.first : null;
 
     return Friendship(
       id: record.id,

--- a/lib/models/user_summary.dart
+++ b/lib/models/user_summary.dart
@@ -1,0 +1,59 @@
+import 'package:characters/characters.dart';
+import 'package:meta/meta.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+@immutable
+class UserSummary {
+  const UserSummary({
+    required this.id,
+    required this.displayName,
+    this.avatarUrl,
+    this.username,
+    this.email,
+  });
+
+  final String id;
+  final String displayName;
+  final String? avatarUrl;
+  final String? username;
+  final String? email;
+
+  factory UserSummary.fromRecord(RecordModel record, PocketBase pocketBase) {
+    final avatarName = record.getStringValue('avatar');
+    final avatarUrl = avatarName.isEmpty
+        ? null
+        : pocketBase.files.getUrl(record, avatarName).toString();
+
+    final username = record.getStringValue('username');
+    final email = record.getStringValue('email');
+    final displayName = username.isNotEmpty
+        ? username
+        : (email.isNotEmpty ? email : record.id);
+
+    return UserSummary(
+      id: record.id,
+      displayName: displayName,
+      avatarUrl: avatarUrl,
+      username: username.isNotEmpty ? username : null,
+      email: email.isNotEmpty ? email : null,
+    );
+  }
+
+  String get initials {
+    if (displayName.trim().isEmpty) {
+      return '#';
+    }
+    final parts = displayName.trim().split(RegExp(r'\s+'));
+    if (parts.length == 1) {
+      return parts.first.characters.first.toUpperCase();
+    }
+    final buffer = StringBuffer();
+    for (final part in parts.take(2)) {
+      if (part.isNotEmpty) {
+        buffer.write(part.characters.first.toUpperCase());
+      }
+    }
+    final result = buffer.toString();
+    return result.isEmpty ? displayName.characters.first.toUpperCase() : result;
+  }
+}

--- a/lib/pages/social/chat/add_friend_page.dart
+++ b/lib/pages/social/chat/add_friend_page.dart
@@ -1,10 +1,18 @@
 import 'package:badminton_booking_app/models/chat_contact.dart';
+import 'package:badminton_booking_app/models/friend_request.dart';
+import 'package:badminton_booking_app/pages/social/chat/friend_manager.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/contact_list_tile.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-class AddFriendPage extends StatelessWidget {
+class AddFriendPage extends StatefulWidget {
   const AddFriendPage({super.key});
 
+  @override
+  State<AddFriendPage> createState() => _AddFriendPageState();
+}
+
+class _AddFriendPageState extends State<AddFriendPage> {
   static const List<ChatContact> _suggestedFriends = [
     ChatContact(
       id: 'suggest-1',
@@ -28,9 +36,19 @@ class AddFriendPage extends StatelessWidget {
   ];
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<FriendManager>().refreshRequests();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
+    final manager = context.watch<FriendManager>();
 
     return Scaffold(
       backgroundColor: const Color(0xFFF4F6FB),
@@ -49,6 +67,10 @@ class AddFriendPage extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             _buildSearchField(cs),
+            const SizedBox(height: 24),
+            _buildIncomingRequests(context, manager),
+            const SizedBox(height: 24),
+            _buildOutgoingRequests(context, manager),
             const SizedBox(height: 24),
             Text(
               'Gợi ý kết bạn',
@@ -144,6 +166,120 @@ class AddFriendPage extends StatelessWidget {
             child: const Text('Khám phá nhóm mới'),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildIncomingRequests(BuildContext context, FriendManager manager) {
+    final theme = Theme.of(context);
+    final requests = manager.incomingRequests;
+    if (manager.isLoadingRequests && requests.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (requests.isEmpty) {
+      return Text(
+        'Không có lời mời kết bạn nào.',
+        style: theme.textTheme.bodyMedium,
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Lời mời kết bạn',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 12),
+        ...requests.map((request) => _buildRequestTile(
+              context,
+              manager,
+              request,
+              isIncoming: true,
+            )),
+      ],
+    );
+  }
+
+  Widget _buildOutgoingRequests(BuildContext context, FriendManager manager) {
+    final theme = Theme.of(context);
+    final requests = manager.outgoingRequests;
+    if (requests.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Đã gửi',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 12),
+        ...requests.map((request) => _buildRequestTile(
+              context,
+              manager,
+              request,
+              isIncoming: false,
+            )),
+      ],
+    );
+  }
+
+  Widget _buildRequestTile(
+    BuildContext context,
+    FriendManager manager,
+    FriendRequest request,
+    {required bool isIncoming},
+  ) {
+    final userSummary =
+        isIncoming ? request.fromUser : request.toUser;
+    final contact = manager.contactFromSummary(userSummary);
+    if (contact == null) {
+      return const SizedBox.shrink();
+    }
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ContactListTile.friend(
+              contact: contact,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                if (isIncoming) ...[
+                  Expanded(
+                    child: FilledButton(
+                      onPressed: () => manager.acceptRequest(request.id),
+                      child: const Text('Đồng ý'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => manager.rejectRequest(request.id),
+                      child: const Text('Từ chối'),
+                    ),
+                  ),
+                ] else ...[
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => manager.cancelRequest(request.id),
+                      child: const Text('Huỷ yêu cầu'),
+                    ),
+                  ),
+                ]
+              ],
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/social/chat/chat_home_page.dart
+++ b/lib/pages/social/chat/chat_home_page.dart
@@ -1,104 +1,31 @@
 import 'package:badminton_booking_app/models/chat_contact.dart';
+import 'package:badminton_booking_app/pages/social/chat/add_friend_page.dart';
+import 'package:badminton_booking_app/pages/social/chat/chat_manager.dart';
+import 'package:badminton_booking_app/pages/social/chat/friend_manager.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_page.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/chat_header.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/chat_section_header.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/contact_list_tile.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-import 'add_friend_page.dart';
-
-class ChatHomePage extends StatelessWidget {
+class ChatHomePage extends StatefulWidget {
   const ChatHomePage({super.key});
 
-  static const List<ChatContact> _activeChats = [
-    ChatContact(
-      id: 'chat-1',
-      name: 'Nhỏ quậy lắm chiều',
-      avatarText: 'NC',
-      lastMessage: 'Bạn: hehe hehe <3 tối qua đánh cầu nhe bạn',
-      lastMessageTimeLabel: '1 phút',
-      unreadCount: 2,
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'chat-2',
-      name: 'Bến Đò Không Người Lái Đó',
-      avatarText: 'BD',
-      lastMessage: 'Bạn: tìm được con trai thất lạc nên khóc...',
-      lastMessageTimeLabel: '15 phút',
-    ),
-    ChatContact(
-      id: 'chat-3',
-      name: 'Cf chủ nhật',
-      avatarText: 'CF',
-      lastMessage: '😊 😌',
-      lastMessageTimeLabel: '30 phút',
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'chat-4',
-      name: 'Trần Gia Thạnh',
-      avatarText: 'TT',
-      lastMessage: 'Đã gửi cho bạn một ảnh',
-      lastMessageTimeLabel: '1 giờ',
-    ),
-    ChatContact(
-      id: 'chat-5',
-      name: 'Khu Tự Trị Dữ Đồ',
-      avatarText: 'KD',
-      lastMessage: 'Bé thỏ mới uống: Mà deokdame đáng cháy vcl',
-      lastMessageTimeLabel: '2 giờ',
-      unreadCount: 1,
-    ),
-    ChatContact(
-      id: 'chat-6',
-      name: 'Hua Tan Datt',
-      avatarText: 'HD',
-      lastMessage: 'Game bào điên',
-      lastMessageTimeLabel: '5 giờ',
-    ),
-  ];
+  @override
+  State<ChatHomePage> createState() => _ChatHomePageState();
+}
 
-  static const List<ChatContact> _friends = [
-    ChatContact(
-      id: 'friend-1',
-      name: 'Nhỏ quậy lắm chiều',
-      avatarText: 'NC',
-      statusMessage: 'Bạn: chờ nứng l đi mà nứng !',
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'friend-2',
-      name: 'Bến Đò Không Người Lái Đó',
-      avatarText: 'BD',
-      statusMessage: 'Bạn: tìm được con trai thất lạc nên khóc...',
-    ),
-    ChatContact(
-      id: 'friend-3',
-      name: 'Cf chủ nhật',
-      avatarText: 'CF',
-      statusMessage: 'Bạn bè để cà phê thôi nha 😌',
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'friend-4',
-      name: 'Trần Gia Thạnh',
-      avatarText: 'TT',
-      statusMessage: 'Luôn sẵn sàng cho một set đôi',
-    ),
-    ChatContact(
-      id: 'friend-5',
-      name: 'Khu Tự Trị Dữ Đồ',
-      avatarText: 'KD',
-      statusMessage: 'Tối nay đánh tăng 2 nhen',
-    ),
-    ChatContact(
-      id: 'friend-6',
-      name: 'Hua Tan Datt',
-      avatarText: 'HD',
-      statusMessage: 'Game báo done',
-    ),
-  ];
+class _ChatHomePageState extends State<ChatHomePage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<FriendManager>().loadInitial();
+      context.read<ChatManager>().refreshRooms();
+    });
+  }
 
   TabBar _buildTabs(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -131,6 +58,10 @@ class ChatHomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final friendManager = context.watch<FriendManager>();
+    final chatManager = context.watch<ChatManager>();
+    final activeChats = chatManager.activeChats;
+    final friends = friendManager.friendContacts;
     return DefaultTabController(
       length: 2,
       child: Scaffold(
@@ -155,106 +86,156 @@ class ChatHomePage extends StatelessWidget {
         ),
         body: TabBarView(
           children: [
-            _buildActiveChatList(context),
-            _buildFriendList(context, cs),
+            _buildActiveChatList(context, chatManager, activeChats),
+            _buildFriendList(context, cs, friendManager, friends),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildActiveChatList(BuildContext context) {
-    return ListView.builder(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
-      itemCount: _activeChats.length + 1,
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return const Padding(
-            padding: EdgeInsets.only(bottom: 12),
-            child: ChatSectionHeader(
-              title: 'Đang trò chuyện',
-              subtitle: 'Danh sách những người bạn đang nhắn tin gần đây',
-            ),
-          );
-        }
+  Widget _buildActiveChatList(
+    BuildContext context,
+    ChatManager manager,
+    List<ChatContact> contacts,
+  ) {
+    return RefreshIndicator(
+      onRefresh: manager.refreshRooms,
+      child: ListView.builder(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+        itemCount: contacts.length + 1,
+        itemBuilder: (context, index) {
+          if (index == 0) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const ChatSectionHeader(
+                    title: 'Đang trò chuyện',
+                    subtitle: 'Danh sách những người bạn đang nhắn tin gần đây',
+                  ),
+                  if (manager.isLoadingRooms && contacts.isEmpty)
+                    const Padding(
+                      padding: EdgeInsets.only(top: 24),
+                      child: Center(child: CircularProgressIndicator()),
+                    )
+                  else if (contacts.isEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 16),
+                      child: Text(
+                        'Chưa có cuộc trò chuyện nào. Hãy nhắn tin với bạn bè để bắt đầu!',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    ),
+                ],
+              ),
+            );
+          }
 
-        final contact = _activeChats[index - 1];
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: ContactListTile.chat(
-            contact: contact,
-            onTap: () => _openChat(context, contact),
-          ),
-        );
-      },
-    );
-  }
-
-  Widget _buildFriendList(BuildContext context, ColorScheme cs) {
-    return ListView.builder(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
-      itemCount: _friends.length + 1,
-      itemBuilder: (context, index) {
-        if (index == 0) {
+          final contact = contacts[index - 1];
           return Padding(
             padding: const EdgeInsets.only(bottom: 12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const ChatSectionHeader(
-                  title: 'Tất cả bạn bè',
-                  subtitle: 'Bấm vào biểu tượng chat để mở cuộc trò chuyện',
-                ),
-                const SizedBox(height: 12),
-                Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(18),
-                    color: cs.primaryContainer.withOpacity(0.3),
-                  ),
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    children: [
-                      Icon(Icons.search_rounded, color: cs.primary),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Text(
-                          'Tìm kiếm bạn bè nhanh chóng',
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodyMedium
-                              ?.copyWith(color: cs.primary),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+            child: ContactListTile.chat(
+              contact: contact,
+              onTap: () => _openChat(context, contact),
             ),
           );
-        }
-
-        final contact = _friends[index - 1];
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: ContactListTile.friend(
-            contact: contact,
-            onTap: () => _openChat(context, contact),
-            onChatPressed: () => _openChat(context, contact),
-          ),
-        );
-      },
+        },
+      ),
     );
   }
 
-  void _openChat(BuildContext context, ChatContact contact) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => ChatPage(
-          contactName: contact.name,
-          isContactOnline: contact.isOnline,
-          avatarText: contact.avatarText,
-        ),
+  Widget _buildFriendList(
+    BuildContext context,
+    ColorScheme cs,
+    FriendManager manager,
+    List<ChatContact> contacts,
+  ) {
+    return RefreshIndicator(
+      onRefresh: () async {
+        await manager.refreshFriends();
+      },
+      child: ListView.builder(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+        itemCount: contacts.length + 1,
+        itemBuilder: (context, index) {
+          if (index == 0) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const ChatSectionHeader(
+                    title: 'Tất cả bạn bè',
+                    subtitle: 'Bấm vào biểu tượng chat để mở cuộc trò chuyện',
+                  ),
+                  const SizedBox(height: 12),
+                  Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(18),
+                      color: cs.primaryContainer.withOpacity(0.3),
+                    ),
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        Icon(Icons.search_rounded, color: cs.primary),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            manager.isLoadingFriends && contacts.isEmpty
+                                ? 'Đang tải danh sách bạn bè...'
+                                : 'Tìm kiếm bạn bè nhanh chóng',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(color: cs.primary),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final contact = contacts[index - 1];
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: ContactListTile.friend(
+              contact: contact,
+              onTap: () => _openChat(context, contact),
+              onChatPressed: () => _openChat(context, contact),
+            ),
+          );
+        },
       ),
     );
+  }
+
+  Future<void> _openChat(BuildContext context, ChatContact contact) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    try {
+      final chatManager = context.read<ChatManager>();
+      final roomId = contact.roomId ?? (await chatManager.ensureRoom(contact.id)).id;
+      final updatedContact = contact.roomId == null
+          ? contact.copyWith(roomId: roomId)
+          : contact;
+      if (!mounted) return;
+      navigator.push(
+        MaterialPageRoute(
+          builder: (_) => ChatPage(
+            roomId: roomId,
+            contact: updatedContact,
+          ),
+        ),
+      );
+    } catch (error) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    }
   }
 }

--- a/lib/pages/social/chat/chat_manager.dart
+++ b/lib/pages/social/chat/chat_manager.dart
@@ -1,0 +1,95 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../models/chat_contact.dart';
+import '../../../models/chat_message.dart';
+import '../../../models/chat_room.dart';
+import '../../../services/chat_service.dart';
+import '../../../services/user_service.dart';
+
+class ChatManager with ChangeNotifier {
+  ChatManager()
+      : _chatService = ChatService(),
+        _userService = UserDetailsService();
+
+  final ChatService _chatService;
+  final UserDetailsService _userService;
+
+  bool _isLoadingRooms = false;
+  final Map<String, bool> _loadingMessages = {};
+  final Map<String, List<ChatMessage>> _messagesByRoom = {};
+  List<ChatRoom> _rooms = [];
+  String? _currentUserId;
+  String? _error;
+
+  bool get isLoadingRooms => _isLoadingRooms;
+  String? get errorMessage => _error;
+
+  UnmodifiableListView<ChatRoom> get rooms =>
+      UnmodifiableListView<ChatRoom>(_rooms);
+
+  List<ChatMessage> messagesForRoom(String roomId) =>
+      _messagesByRoom[roomId] ?? const <ChatMessage>[];
+
+  bool isLoadingMessages(String roomId) => _loadingMessages[roomId] ?? false;
+
+  Future<void> refreshRooms() async {
+    _isLoadingRooms = true;
+    notifyListeners();
+    try {
+      _currentUserId ??= await _userService.getCurrentUserId();
+      _rooms = await _chatService.fetchRooms();
+      _error = null;
+    } catch (error) {
+      _error = error.toString();
+    } finally {
+      _isLoadingRooms = false;
+      notifyListeners();
+    }
+  }
+
+  List<ChatContact> get activeChats {
+    return _rooms
+        .map((room) => room.toChatContact(_currentUserId))
+        .whereType<ChatContact>()
+        .toList(growable: false);
+  }
+
+  Future<ChatRoom> ensureRoom(String userId) async {
+    final room = await _chatService.ensureRoom(userId);
+    await refreshRooms();
+    return room;
+  }
+
+  Future<void> loadMessages(String roomId) async {
+    _loadingMessages[roomId] = true;
+    notifyListeners();
+    try {
+      _messagesByRoom[roomId] = await _chatService.fetchMessages(roomId);
+      await _chatService.markMessagesAsRead(roomId);
+      _error = null;
+    } catch (error) {
+      _error = error.toString();
+    } finally {
+      _loadingMessages[roomId] = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> sendMessage(String roomId, String content) async {
+    try {
+      final message = await _chatService.sendMessage(
+        roomId: roomId,
+        content: content,
+      );
+      final messages = List<ChatMessage>.from(_messagesByRoom[roomId] ?? const []);
+      messages.add(message);
+      _messagesByRoom[roomId] = messages;
+      await refreshRooms();
+    } catch (error) {
+      _error = error.toString();
+      rethrow;
+    }
+  }
+}

--- a/lib/pages/social/chat/chat_page.dart
+++ b/lib/pages/social/chat/chat_page.dart
@@ -1,105 +1,85 @@
+import 'dart:async';
+
 import 'package:badminton_booking_app/components/chat_input.dart';
-import 'package:badminton_booking_app/models/chat_message.dart';
+import 'package:badminton_booking_app/models/chat_contact.dart';
+import 'package:badminton_booking_app/pages/social/chat/chat_manager.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/chat_app_bar.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/chat_message_list.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class ChatPage extends StatefulWidget {
   const ChatPage({
     super.key,
-    this.contactName = 'Nguyễn Minh',
-    this.avatarText = 'NM',
-    this.isContactOnline = true,
+    required this.roomId,
+    required this.contact,
   });
 
-  final String contactName;
-  final String avatarText;
-  final bool isContactOnline;
+  final String roomId;
+  final ChatContact contact;
 
   @override
   State<ChatPage> createState() => _ChatPageState();
 }
 
 class _ChatPageState extends State<ChatPage> {
-  // sau này bạn sẽ thay bằng data từ backend
-  final List<ChatMessage> _messages = [
-    const ChatMessage(
-      id: '1',
-      author: 'Nguyễn Minh',
-      content: 'Chào bạn, mình thấy bài tuyển thành viên của bạn.',
-      time: '17:45',
-      isMe: false,
-    ),
-    const ChatMessage(
-      id: '2',
-      author: 'Bạn',
-      content: 'Hi Minh, bạn đang đánh trình nào vậy?',
-      time: '17:46',
-      isMe: true,
-    ),
-    const ChatMessage(
-      id: '3',
-      author: 'Nguyễn Minh',
-      content: 'Mình đang ở mức trung bình khá, hay đánh đôi.',
-      time: '17:46',
-      isMe: false,
-    ),
-    const ChatMessage(
-      id: '4',
-      author: 'Bạn',
-      content:
-          'Okie, sân mình đặt ở Quận 7 lúc 20:00. Bạn đến trước 10 phút nhé!',
-      time: '17:47',
-      isMe: true,
-    ),
-    const ChatMessage(
-      id: '5',
-      author: 'Nguyễn Minh',
-      content: 'Quá ổn luôn, tối gặp nhé!',
-      time: '17:47',
-      isMe: false,
-    ),
-  ];
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<ChatManager>().loadMessages(widget.roomId);
+    });
+  }
 
   void _handleSend(String text) {
     if (text.trim().isEmpty) return;
-    setState(() {
-      _messages.add(
-        ChatMessage(
-          id: DateTime.now().millisecondsSinceEpoch.toString(),
-          author: 'Bạn',
-          content: text.trim(),
-          time: TimeOfDay.now().format(context),
-          isMe: true,
-        ),
-      );
-    });
+    final manager = context.read<ChatManager>();
+    unawaited(
+      manager.sendMessage(widget.roomId, text).catchError((error) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error.toString())),
+        );
+      }),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final contact = widget.contact;
     return Scaffold(
       backgroundColor: const Color(0xFFF4F6FB),
       appBar: ChatAppBar(
-        name: widget.contactName,
-        isOnline: widget.isContactOnline,
-        avatarText: widget.avatarText,
+        name: contact.name,
+        isOnline: contact.isOnline,
+        avatarText: contact.avatarText,
         onCall: () {},
         onVideoCall: () {},
       ),
-      body: Column(
-        children: [
-          Expanded(
-            child: ChatMessageList(
-              messages: _messages,
-            ),
-          ),
-          ChatInput(
-            onSend: _handleSend,
-            backgroundColor: cs.background,
-          ),
-        ],
+      body: Consumer<ChatManager>(
+        builder: (context, manager, _) {
+          final messages = manager.messagesForRoom(widget.roomId);
+          final isLoading = manager.isLoadingMessages(widget.roomId);
+          return Column(
+            children: [
+              Expanded(
+                child: isLoading && messages.isEmpty
+                    ? const Center(child: CircularProgressIndicator())
+                    : ChatMessageList(
+                        messages: messages,
+                        peerInitial: contact.avatarText,
+                        peerAvatarUrl: contact.avatarUrl,
+                      ),
+              ),
+              ChatInput(
+                onSend: _handleSend,
+                backgroundColor: cs.background,
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/pages/social/chat/friend_manager.dart
+++ b/lib/pages/social/chat/friend_manager.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../models/chat_contact.dart';
+import '../../../models/friend_request.dart';
+import '../../../models/friendship.dart';
+import '../../../models/user_summary.dart';
+import '../../../services/friend_service.dart';
+import '../../../services/user_service.dart';
+
+class FriendManager with ChangeNotifier {
+  FriendManager()
+      : _friendService = FriendService(),
+        _userService = UserDetailsService();
+
+  final FriendService _friendService;
+  final UserDetailsService _userService;
+
+  List<Friendship> _friends = [];
+  List<FriendRequest> _incomingRequests = [];
+  List<FriendRequest> _outgoingRequests = [];
+  bool _isLoadingFriends = false;
+  bool _isLoadingRequests = false;
+  String? _currentUserId;
+  String? _error;
+
+  List<Friendship> get friends => _friends;
+  List<FriendRequest> get incomingRequests => _incomingRequests;
+  List<FriendRequest> get outgoingRequests => _outgoingRequests;
+  bool get isLoadingFriends => _isLoadingFriends;
+  bool get isLoadingRequests => _isLoadingRequests;
+  String? get errorMessage => _error;
+
+  Future<void> loadInitial() async {
+    await Future.wait([
+      refreshFriends(),
+      refreshRequests(),
+    ]);
+  }
+
+  Future<void> refreshFriends() async {
+    _isLoadingFriends = true;
+    notifyListeners();
+    try {
+      _currentUserId ??= await _userService.getCurrentUserId();
+      _friends = await _friendService.fetchFriends();
+      _error = null;
+    } catch (error) {
+      _error = error.toString();
+    } finally {
+      _isLoadingFriends = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshRequests() async {
+    _isLoadingRequests = true;
+    notifyListeners();
+    try {
+      _currentUserId ??= await _userService.getCurrentUserId();
+      final results = await Future.wait([
+        _friendService.fetchIncomingRequests(),
+        _friendService.fetchOutgoingRequests(),
+      ]);
+      _incomingRequests = results[0];
+      _outgoingRequests = results[1];
+      _error = null;
+    } catch (error) {
+      _error = error.toString();
+    } finally {
+      _isLoadingRequests = false;
+      notifyListeners();
+    }
+  }
+
+  List<ChatContact> get friendContacts {
+    return _friends
+        .map((friendship) => friendship.toChatContact(_currentUserId))
+        .whereType<ChatContact>()
+        .toList(growable: false);
+  }
+
+  Future<void> sendFriendRequest(String targetUserId) async {
+    try {
+      final request = await _friendService.sendFriendRequest(targetUserId);
+      _outgoingRequests = [request, ..._outgoingRequests];
+      _error = null;
+      notifyListeners();
+    } catch (error) {
+      _error = error.toString();
+      rethrow;
+    }
+  }
+
+  Future<void> cancelRequest(String requestId) async {
+    await _friendService.cancelFriendRequest(requestId);
+    _outgoingRequests =
+        _outgoingRequests.where((req) => req.id != requestId).toList();
+    notifyListeners();
+  }
+
+  Future<void> rejectRequest(String requestId) async {
+    await _friendService.rejectFriendRequest(requestId);
+    _incomingRequests =
+        _incomingRequests.where((req) => req.id != requestId).toList();
+    notifyListeners();
+  }
+
+  Future<void> acceptRequest(String requestId) async {
+    final friendship = await _friendService.acceptFriendRequest(requestId);
+    _incomingRequests =
+        _incomingRequests.where((req) => req.id != requestId).toList();
+    _friends = [friendship, ..._friends];
+    notifyListeners();
+  }
+
+  Future<void> unfriend(String friendUserId) async {
+    await _friendService.unfriend(friendUserId);
+    _friends = _friends
+        .where((friendship) =>
+            friendship.userAId != friendUserId &&
+            friendship.userBId != friendUserId)
+        .toList();
+    notifyListeners();
+  }
+
+  ChatContact? contactFromSummary(UserSummary? summary) {
+    if (summary == null) return null;
+    return ChatContact(
+      id: summary.id,
+      name: summary.displayName,
+      avatarText: summary.initials,
+      avatarUrl: summary.avatarUrl,
+    );
+  }
+}

--- a/lib/pages/social/chat/widgets/chat_message_list.dart
+++ b/lib/pages/social/chat/widgets/chat_message_list.dart
@@ -4,10 +4,14 @@ import 'package:flutter/material.dart';
 
 class ChatMessageList extends StatelessWidget {
   final List<ChatMessage> messages;
+  final String peerInitial;
+  final String? peerAvatarUrl;
 
   const ChatMessageList({
     super.key,
     required this.messages,
+    required this.peerInitial,
+    this.peerAvatarUrl,
   });
 
   @override
@@ -28,6 +32,8 @@ class ChatMessageList extends StatelessWidget {
           message: message,
           showAvatar: !message.isMe && isFirstFromAuthor,
           showSeen: isLastFromMe,
+          peerInitial: peerInitial,
+          peerAvatarUrl: peerAvatarUrl,
         );
       },
       separatorBuilder: (_, __) => const SizedBox(height: 8),

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,0 +1,149 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/chat_message.dart';
+import '../models/chat_room.dart';
+import 'pocketbase_client.dart';
+
+class ChatServiceException implements Exception {
+  ChatServiceException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class ChatService {
+  static const _rooms = 'room_chats';
+  static const _messages = 'chat_messages';
+
+  Future<String> _currentUserId(PocketBase pb) async {
+    final userId = pb.authStore.record?.id;
+    if (userId == null) {
+      throw ChatServiceException('Bạn cần đăng nhập để sử dụng chat.');
+    }
+    return userId;
+  }
+
+  Future<List<ChatRoom>> fetchRooms({int page = 1, int perPage = 30}) async {
+    final pb = await getPocketbaseInstance();
+    final me = await _currentUserId(pb);
+    final result = await pb.collection(_rooms).getList(
+          page: page,
+          perPage: perPage,
+          filter: 'user_a = "$me" || user_b = "$me"',
+          expand: 'user_a,user_b,last_sender',
+          sort: '-last_message_at,-updated',
+        );
+    final rooms = result.items
+        .map((record) => ChatRoom.fromRecord(record, pb))
+        .toList(growable: false);
+
+    final roomsWithUnread = await Future.wait(
+      rooms.map((room) async {
+        final unread = await fetchUnreadCount(room.id);
+        return room.copyWith(unreadCount: unread);
+      }),
+    );
+    return roomsWithUnread;
+  }
+
+  Future<ChatRoom> ensureRoom(String otherUserId) async {
+    final pb = await getPocketbaseInstance();
+    final me = await _currentUserId(pb);
+    final pair = _sortedPair(me, otherUserId);
+    try {
+      final existing = await pb.collection(_rooms).getFirstListItem(
+            'user_a = "${pair.$1}" && user_b = "${pair.$2}"',
+            expand: 'user_a,user_b,last_sender',
+          );
+      final room = ChatRoom.fromRecord(existing, pb);
+      final unread = await fetchUnreadCount(room.id);
+      return room.copyWith(unreadCount: unread);
+    } on ClientException catch (error) {
+      if (error.statusCode != 404) rethrow;
+    }
+
+    final record = await pb.collection(_rooms).create(body: {
+      'user_a': pair.$1,
+      'user_b': pair.$2,
+    });
+    final expanded = await pb.collection(_rooms).getOne(
+          record.id,
+          expand: 'user_a,user_b,last_sender',
+        );
+    return ChatRoom.fromRecord(expanded, pb);
+  }
+
+  Future<List<ChatMessage>> fetchMessages(
+    String roomId, {
+    int page = 1,
+    int perPage = 50,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final me = await _currentUserId(pb);
+    final result = await pb.collection(_messages).getList(
+          page: page,
+          perPage: perPage,
+          filter: 'chat = "$roomId"',
+          expand: 'sender',
+          sort: 'created',
+        );
+    return result.items
+        .map((record) => ChatMessage.fromRecord(record, me))
+        .toList(growable: false);
+  }
+
+  Future<ChatMessage> sendMessage({
+    required String roomId,
+    required String content,
+  }) async {
+    if (content.trim().isEmpty) {
+      throw ChatServiceException('Tin nhắn không được để trống.');
+    }
+    final pb = await getPocketbaseInstance();
+    final me = await _currentUserId(pb);
+    final record = await pb.collection(_messages).create(body: {
+      'chat': roomId,
+      'sender': me,
+      'content': content.trim(),
+      'is_read': false,
+    });
+
+    await pb.collection(_rooms).update(roomId, body: {
+      'last_message': content.trim(),
+      'last_message_at': DateTime.now().toUtc().toIso8601String(),
+      'last_sender': me,
+    });
+
+    return ChatMessage.fromRecord(record, me);
+  }
+
+  Future<void> markMessagesAsRead(String roomId) async {
+    final pb = await getPocketbaseInstance();
+    final me = await _currentUserId(pb);
+    final unread = await pb.collection(_messages).getFullList(
+          filter: 'chat = "$roomId" && sender != "$me" && is_read = false',
+        );
+    for (final msg in unread) {
+      await pb.collection(_messages).update(msg.id, body: {
+        'is_read': true,
+        'read_at': DateTime.now().toUtc().toIso8601String(),
+      });
+    }
+  }
+
+  Future<int> fetchUnreadCount(String roomId) async {
+    final pb = await getPocketbaseInstance();
+    final me = await _currentUserId(pb);
+    final result = await pb.collection(_messages).getList(
+          page: 1,
+          perPage: 1,
+          filter: 'chat = "$roomId" && sender != "$me" && is_read = false',
+        );
+    return result.totalItems;
+  }
+
+  (String, String) _sortedPair(String a, String b) {
+    final list = [a, b]..sort();
+    return (list[0], list[1]);
+  }
+}

--- a/lib/services/friend_service.dart
+++ b/lib/services/friend_service.dart
@@ -1,0 +1,213 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/friend_request.dart';
+import '../models/friendship.dart';
+import 'pocketbase_client.dart';
+
+class FriendServiceException implements Exception {
+  FriendServiceException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class FriendService {
+  static const _friendRequests = 'friend_requests';
+  static const _friendships = 'friendships';
+
+  Future<String> _currentUserId(PocketBase pocketBase) async {
+    final userId = pocketBase.authStore.record?.id;
+    if (userId == null) {
+      throw FriendServiceException('Bạn cần đăng nhập để sử dụng tính năng này.');
+    }
+    return userId;
+  }
+
+  Future<List<Friendship>> fetchFriends({int page = 1, int perPage = 30}) async {
+    final pb = await getPocketbaseInstance();
+    final userId = await _currentUserId(pb);
+    final result = await pb.collection(_friendships).getList(
+          page: page,
+          perPage: perPage,
+          filter: 'user_a = "$userId" || user_b = "$userId"',
+          expand: 'user_a,user_b',
+          sort: '-created',
+        );
+    return result.items
+        .map((record) => Friendship.fromRecord(record, pb))
+        .toList(growable: false);
+  }
+
+  Future<List<FriendRequest>> fetchIncomingRequests({
+    int page = 1,
+    int perPage = 30,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final userId = await _currentUserId(pb);
+    final result = await pb.collection(_friendRequests).getList(
+          page: page,
+          perPage: perPage,
+          filter: 'to_user = "$userId" && status = "pending"',
+          expand: 'from_user,to_user',
+          sort: '-created',
+        );
+    return result.items
+        .map((record) => FriendRequest.fromRecord(record, pb))
+        .toList(growable: false);
+  }
+
+  Future<List<FriendRequest>> fetchOutgoingRequests({
+    int page = 1,
+    int perPage = 30,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final userId = await _currentUserId(pb);
+    final result = await pb.collection(_friendRequests).getList(
+          page: page,
+          perPage: perPage,
+          filter: 'from_user = "$userId" && status = "pending"',
+          expand: 'from_user,to_user',
+          sort: '-created',
+        );
+    return result.items
+        .map((record) => FriendRequest.fromRecord(record, pb))
+        .toList(growable: false);
+  }
+
+  Future<FriendRequest> sendFriendRequest(String targetUserId) async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = await _currentUserId(pb);
+    if (currentUserId == targetUserId) {
+      throw FriendServiceException('Bạn không thể tự gửi lời mời cho chính mình.');
+    }
+
+    await _ensureNotFriends(pb, currentUserId, targetUserId);
+    await _ensureNoPendingRequest(pb, currentUserId, targetUserId);
+
+    final record = await pb.collection(_friendRequests).create(body: {
+      'from_user': currentUserId,
+      'to_user': targetUserId,
+      'status': 'pending',
+    });
+
+    return FriendRequest.fromRecord(await _expandRequest(pb, record), pb);
+  }
+
+  Future<void> cancelFriendRequest(String requestId) async {
+    final pb = await getPocketbaseInstance();
+    await pb.collection(_friendRequests).update(requestId, body: {
+      'status': 'cancelled',
+    });
+  }
+
+  Future<void> rejectFriendRequest(String requestId) async {
+    final pb = await getPocketbaseInstance();
+    await pb.collection(_friendRequests).update(requestId, body: {
+      'status': 'rejected',
+    });
+  }
+
+  Future<Friendship> acceptFriendRequest(String requestId) async {
+    final pb = await getPocketbaseInstance();
+    final request = await pb.collection(_friendRequests).update(
+      requestId,
+      body: {
+        'status': 'accepted',
+      },
+    );
+
+    final fromUserId = request.getStringValue('from_user');
+    final toUserId = request.getStringValue('to_user');
+    final pair = _sortedPair(fromUserId, toUserId);
+
+    try {
+      final existing = await pb.collection(_friendships).getFirstListItem(
+            'user_a = "${pair.$1}" && user_b = "${pair.$2}"',
+          );
+      return Friendship.fromRecord(existing, pb);
+    } catch (_) {
+      final friendship = await pb.collection(_friendships).create(body: {
+        'user_a': pair.$1,
+        'user_b': pair.$2,
+      });
+      final expanded = await _expandFriendship(pb, friendship);
+      return Friendship.fromRecord(expanded, pb);
+    }
+  }
+
+  Future<void> unfriend(String friendUserId) async {
+    final pb = await getPocketbaseInstance();
+    final me = await _currentUserId(pb);
+    final pair = _sortedPair(me, friendUserId);
+    try {
+      final friendship = await pb.collection(_friendships).getFirstListItem(
+            'user_a = "${pair.$1}" && user_b = "${pair.$2}"',
+          );
+      await pb.collection(_friendships).delete(friendship.id);
+    } on ClientException catch (error) {
+      if (error.statusCode != 404) {
+        rethrow;
+      }
+    }
+  }
+
+  Future<void> _ensureNotFriends(
+    PocketBase pocketBase,
+    String me,
+    String target,
+  ) async {
+    final pair = _sortedPair(me, target);
+    try {
+      await pocketBase.collection(_friendships).getFirstListItem(
+            'user_a = "${pair.$1}" && user_b = "${pair.$2}"',
+          );
+      throw FriendServiceException('Hai bạn đã là bạn bè.');
+    } on ClientException catch (error) {
+      if (error.statusCode != 404) {
+        rethrow;
+      }
+    }
+  }
+
+  Future<void> _ensureNoPendingRequest(
+    PocketBase pocketBase,
+    String me,
+    String target,
+  ) async {
+    final filter =
+        '((from_user = "$me" && to_user = "$target") || (from_user = "$target" && to_user = "$me")) && status = "pending"';
+    try {
+      await pocketBase.collection(_friendRequests).getFirstListItem(filter);
+      throw FriendServiceException('Đang có lời mời kết bạn chờ xử lý.');
+    } on ClientException catch (error) {
+      if (error.statusCode != 404) {
+        rethrow;
+      }
+    }
+  }
+
+  Future<RecordModel> _expandRequest(
+    PocketBase pocketBase,
+    RecordModel record,
+  ) async {
+    return pocketBase.collection(_friendRequests).getOne(
+          record.id,
+          expand: 'from_user,to_user',
+        );
+  }
+
+  Future<RecordModel> _expandFriendship(
+    PocketBase pocketBase,
+    RecordModel record,
+  ) async {
+    return pocketBase.collection(_friendships).getOne(
+          record.id,
+          expand: 'user_a,user_b',
+        );
+  }
+
+  (String, String) _sortedPair(String a, String b) {
+    final list = [a, b]..sort();
+    return (list[0], list[1]);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   image_picker: ^1.2.0
   http: ^1.5.0
   intl: ^0.20.2
+  characters: ^1.3.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add PocketBase-driven friend/friendship services plus chat room/message services and helper models to represent user summaries, requests, friendships, and chat rooms
- introduce FriendManager and ChatManager state objects, wire them into the provider tree, and update chat list, chat page, and add-friend UI to load real data and respond to user actions
- enhance chat rendering components to work with live avatars/timestamps and add the characters package dependency for initials support

## Testing
- Not run (Flutter SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919cd7756c8832ba1895b06e2bcc53e)