### PR TITLE
Add friend search flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
+import 'package:badminton_booking_app/pages/social/chat/friend_manager.dart';
 import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:flutter/material.dart';
@@ -24,6 +25,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => UserManager()),
         ChangeNotifierProvider(create: (_) => CourtManager()),
         ChangeNotifierProvider(create: (_) => SocialManager()),
+        ChangeNotifierProvider(create: (_) => FriendManager()),
       ],
       child: const MyApp(),
     ),

--- a/lib/models/friend_candidate.dart
+++ b/lib/models/friend_candidate.dart
@@ -1,0 +1,92 @@
+import 'package:badminton_booking_app/models/chat_contact.dart';
+import 'package:badminton_booking_app/models/user.dart';
+import 'package:badminton_booking_app/models/user_details.dart';
+
+class FriendCandidate {
+  const FriendCandidate({
+    required this.user,
+    this.details,
+  });
+
+  final User user;
+  final UserDetails? details;
+
+  String get displayName {
+    final fullName = details?.fullname?.trim();
+    if (fullName != null && fullName.isNotEmpty) {
+      return fullName;
+    }
+    if (user.username.trim().isNotEmpty) {
+      return user.username.trim();
+    }
+    if (user.email.trim().isNotEmpty) {
+      return user.email.trim();
+    }
+    if (user.phone.trim().isNotEmpty) {
+      return user.phone.trim();
+    }
+    return 'Người dùng';
+  }
+
+  String? get statusMessage {
+    final parts = <String>[];
+    if (user.username.trim().isNotEmpty) {
+      parts.add('@${user.username.trim()}');
+    }
+    if (user.email.trim().isNotEmpty) {
+      parts.add(user.email.trim());
+    }
+    if (user.phone.trim().isNotEmpty) {
+      parts.add(user.phone.trim());
+    }
+    if (details?.level != null && details!.level!.trim().isNotEmpty) {
+      parts.add(details!.level!.trim());
+    }
+    if (parts.isEmpty) {
+      return null;
+    }
+    return parts.join(' • ');
+  }
+
+  String get avatarText {
+    final normalized = displayName.trim();
+    if (normalized.isEmpty) {
+      return '??';
+    }
+    final segments = normalized
+        .split(RegExp(r'\s+'))
+        .where((segment) => segment.isNotEmpty)
+        .toList(growable: false);
+    if (segments.isEmpty) {
+      return '??';
+    }
+    if (segments.length == 1) {
+      final value = segments.first;
+      final length = value.length >= 2 ? 2 : 1;
+      return value.substring(0, length).toUpperCase();
+    }
+    return (_firstCharacter(segments.first) + _firstCharacter(segments.last))
+        .toUpperCase();
+  }
+
+  String? get avatarUrl => details?.avatarUrl;
+
+  ChatContact toChatContact() {
+    return ChatContact(
+      id: user.id,
+      name: displayName,
+      avatarText: avatarText,
+      avatarUrl: avatarUrl,
+      statusMessage: statusMessage,
+    );
+  }
+
+  String _firstCharacter(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return '?';
+    }
+    final firstCodePoint = trimmed.runes.first;
+    return String.fromCharCode(firstCodePoint);
+  }
+}

--- a/lib/pages/social/chat/add_friend_page.dart
+++ b/lib/pages/social/chat/add_friend_page.dart
@@ -1,6 +1,9 @@
 import 'package:badminton_booking_app/models/chat_contact.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/contact_list_tile.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:badminton_booking_app/pages/social/chat/friend_manager.dart';
 
 class AddFriendPage extends StatelessWidget {
   const AddFriendPage({super.key});
@@ -48,26 +51,30 @@ class AddFriendPage extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            _buildSearchField(cs),
+            _buildSearchField(context, cs),
             const SizedBox(height: 24),
-            Text(
-              'Gợi ý kết bạn',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
+            Consumer<FriendManager>(
+              builder: (context, manager, _) {
+                if (manager.hasQuery) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Kết quả tìm kiếm',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      _buildSearchResultList(context, manager),
+                    ],
+                  );
+                }
+
+                return _buildSuggestedFriendsSection(theme);
+              },
             ),
-            const SizedBox(height: 12),
-            ..._suggestedFriends.map(
-              (contact) => Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: ContactListTile.suggestion(
-                  contact: contact,
-                  onTap: () {},
-                  onChatPressed: () {},
-                ),
-              ),
-            ),
-            const SizedBox(height: 12),
+            const SizedBox(height: 24),
             _buildCommunityCard(context),
           ],
         ),
@@ -75,7 +82,8 @@ class AddFriendPage extends StatelessWidget {
     );
   }
 
-  Widget _buildSearchField(ColorScheme cs) {
+  Widget _buildSearchField(BuildContext context, ColorScheme cs) {
+    final isSearching = context.watch<FriendManager>().isSearching;
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(20),
@@ -89,12 +97,124 @@ class AddFriendPage extends StatelessWidget {
         ],
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      child: const TextField(
+      child: TextField(
+        onChanged: (value) => context.read<FriendManager>().searchFriends(value),
         decoration: InputDecoration(
-          icon: Icon(Icons.search_rounded),
+          icon: const Icon(Icons.search_rounded),
           border: InputBorder.none,
           hintText: 'Nhập tên, số điện thoại hoặc mã thành viên',
+          suffixIcon: isSearching
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: Padding(
+                    padding: EdgeInsets.all(8),
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              : null,
         ),
+      ),
+    );
+  }
+
+  Widget _buildSearchResultList(BuildContext context, FriendManager manager) {
+    if (manager.isSearching) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 32),
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (manager.searchError != null) {
+      return _buildInfoMessage(
+        context,
+        icon: Icons.error_outline,
+        message: manager.searchError!,
+      );
+    }
+
+    if (manager.searchResults.isEmpty) {
+      return _buildInfoMessage(
+        context,
+        icon: Icons.search_off_outlined,
+        message: 'Không tìm thấy người dùng nào phù hợp từ từ khóa hiện tại.',
+      );
+    }
+
+    return Column(
+      children: manager.searchResults
+          .map(
+            (candidate) => Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: ContactListTile.suggestion(
+                contact: candidate.toChatContact(),
+                onTap: () {},
+                onChatPressed: () {},
+              ),
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+
+  Widget _buildSuggestedFriendsSection(ThemeData theme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Gợi ý kết bạn',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 12),
+        ..._suggestedFriends.map(
+          (contact) => Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: ContactListTile.suggestion(
+              contact: contact,
+              onTap: () {},
+              onChatPressed: () {},
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInfoMessage(
+    BuildContext context, {
+    required IconData icon,
+    required String message,
+  }) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        color: cs.surface,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 18,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          Icon(icon, color: cs.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              message,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/social/chat/friend_manager.dart
+++ b/lib/pages/social/chat/friend_manager.dart
@@ -1,0 +1,84 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:badminton_booking_app/models/friend_candidate.dart';
+import 'package:badminton_booking_app/services/user_service.dart';
+
+class FriendManager with ChangeNotifier {
+  FriendManager({UserDetailsService? userService})
+      : _userService = userService ?? UserDetailsService();
+
+  final UserDetailsService _userService;
+
+  final List<FriendCandidate> _searchResults = <FriendCandidate>[];
+  bool _isSearching = false;
+  String _searchQuery = '';
+  String? _searchError;
+  int _searchToken = 0;
+
+  UnmodifiableListView<FriendCandidate> get searchResults =>
+      UnmodifiableListView(_searchResults);
+  bool get isSearching => _isSearching;
+  String get searchQuery => _searchQuery;
+  String? get searchError => _searchError;
+  bool get hasQuery => _searchQuery.trim().isNotEmpty;
+
+  Future<void> searchFriends(String query) async {
+    _searchQuery = query;
+    final trimmedQuery = query.trim();
+    _searchToken++;
+    final currentToken = _searchToken;
+
+    if (trimmedQuery.isEmpty) {
+      _resetState(notify: true);
+      return;
+    }
+
+    _isSearching = true;
+    _searchError = null;
+    notifyListeners();
+
+    try {
+      final results =
+          await _userService.searchFriendCandidates(trimmedQuery, perPage: 30);
+      if (currentToken != _searchToken) {
+        return;
+      }
+      _searchResults
+        ..clear()
+        ..addAll(results);
+      _searchError = null;
+    } catch (error) {
+      if (currentToken != _searchToken) {
+        return;
+      }
+      _searchResults.clear();
+      _searchError = 'Không thể tìm kiếm bạn bè. Vui lòng thử lại sau.';
+      debugPrint('FriendManager search error: $error');
+    } finally {
+      if (currentToken != _searchToken) {
+        return;
+      }
+      _isSearching = false;
+      notifyListeners();
+    }
+  }
+
+  void clearSearch() {
+    if (!hasQuery && _searchResults.isEmpty) {
+      return;
+    }
+    _resetState(notify: true);
+  }
+
+  void _resetState({bool notify = false}) {
+    _searchQuery = '';
+    _searchResults.clear();
+    _isSearching = false;
+    _searchError = null;
+    if (notify) {
+      notifyListeners();
+    }
+  }
+}

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -4,8 +4,10 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:pocketbase/pocketbase.dart';
 
+import '../models/friend_candidate.dart';
 import '../models/user.dart';
 import '../models/user_details.dart';
+import '../utils/pocketbase_utils.dart';
 import 'pocketbase_client.dart';
 
 class UserDetailsService {
@@ -156,5 +158,65 @@ class UserDetailsService {
         : pb.files.getUrl(updated, avatarName).toString();
 
     return UserDetails.fromJson(data, avatarUrl: avatarUrl);
+  }
+
+  Future<List<FriendCandidate>> searchFriendCandidates(
+    String keyword, {
+    int page = 1,
+    int perPage = 20,
+  }) async {
+    final trimmedKeyword = keyword.trim();
+    if (trimmedKeyword.isEmpty) {
+      return const <FriendCandidate>[];
+    }
+
+    final pocketBase = await getPocketbaseInstance();
+    final sanitizedKeyword = trimmedKeyword.replaceAll("'", r"\'");
+    final likeQuery = '%$sanitizedKeyword%';
+    final filterConditions = [
+      "user_id.username ~ \"$likeQuery\"",
+      "user_id.email ~ \"$likeQuery\"",
+      "user_id.phone ~ \"$likeQuery\"",
+    ];
+    final filter = '(${filterConditions.join(' || ')})';
+
+    try {
+      final result = await pocketBase.collection(collection).getList(
+            page: page,
+            perPage: perPage,
+            filter: filter,
+            expand: 'user_id',
+          );
+
+      return result.items.map((record) {
+        final userRecord = resolveExpandedRecord(record.expand?['user_id']);
+        Map<String, dynamic>? userData;
+        if (userRecord != null) {
+          userData = userRecord.toJson();
+        } else if (record.data['user_id'] is Map<String, dynamic>) {
+          userData = (record.data['user_id'] as Map<String, dynamic>);
+        }
+
+        final user = userData != null
+            ? User.fromJson(userData)
+            : User(
+                id: (record.data['user_id'] as String?) ?? '',
+                username: '',
+                email: '',
+                phone: '',
+              );
+
+        final data = record.toJson();
+        final avatarName = (data['avatar'] as String?) ?? '';
+        final avatarUrl = avatarName.isEmpty
+            ? null
+            : pocketBase.files.getUrl(record, avatarName).toString();
+        final details = UserDetails.fromJson(data, avatarUrl: avatarUrl);
+
+        return FriendCandidate(user: user, details: details);
+      }).toList(growable: false);
+    } catch (error) {
+      throw Exception('searchFriendCandidates error: $error');
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a FriendManager and friend candidate model to coordinate search state and expose search results to the UI
- expose a search API on UserDetailsService to find candidates by username, email, or phone using PocketBase filters
- wire AddFriendPage to FriendManager so the search field updates results in real time with helpful empty/error states and register the manager provider at app startup

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a9503e144832b9044bfc3fd10145a)