### PR TITLE
Add friend requests and friendship listing

### DIFF
--- a/lib/pages/social/chat/add_friend_page.dart
+++ b/lib/pages/social/chat/add_friend_page.dart
@@ -3,6 +3,7 @@ import 'package:badminton_booking_app/pages/social/chat/friend_manager.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/contact_list_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:badminton_booking_app/services/friend_service.dart';
 
 class AddFriendPage extends StatelessWidget {
   const AddFriendPage({super.key});
@@ -169,12 +170,42 @@ class AddFriendPage extends StatelessWidget {
                 statusMessage: result.subtitle.isEmpty ? null : result.subtitle,
               ),
               onTap: () {},
-              onChatPressed: () {},
+              actionLabel: _actionLabel(friendManager, result.user.id),
+              isActionEnabled:
+                  _actionHandler(friendManager, result.user.id) != null,
+              isBusy: friendManager.isPendingAction(result.user.id),
+              onChatPressed:
+                  _actionHandler(friendManager, result.user.id),
             ),
           ),
         ),
       ],
     );
+  }
+
+  String _actionLabel(FriendManager manager, String userId) {
+    final relation = manager.relationFor(userId).status;
+    return switch (relation) {
+      FriendRelationStatus.none => 'Kết bạn',
+      FriendRelationStatus.requestSent => 'Đã gửi',
+      FriendRelationStatus.incomingRequest => 'Chấp nhận',
+      FriendRelationStatus.friends => 'Bạn bè',
+    };
+  }
+
+  VoidCallback? _actionHandler(FriendManager manager, String userId) {
+    final relation = manager.relationFor(userId).status;
+    if (manager.isPendingAction(userId)) return null;
+
+    switch (relation) {
+      case FriendRelationStatus.none:
+        return () => manager.sendFriendRequest(userId);
+      case FriendRelationStatus.incomingRequest:
+        return () => manager.acceptRequest(userId);
+      case FriendRelationStatus.requestSent:
+      case FriendRelationStatus.friends:
+        return null;
+    }
   }
 
   Widget _buildCommunityCard(BuildContext context) {

--- a/lib/pages/social/chat/chat_home_page.dart
+++ b/lib/pages/social/chat/chat_home_page.dart
@@ -61,47 +61,6 @@ class ChatHomePage extends StatelessWidget {
     ),
   ];
 
-  static const List<ChatContact> _friends = [
-    ChatContact(
-      id: 'friend-1',
-      name: 'Nhỏ quậy lắm chiều',
-      avatarText: 'NC',
-      statusMessage: 'Bạn: chờ nứng l đi mà nứng !',
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'friend-2',
-      name: 'Bến Đò Không Người Lái Đó',
-      avatarText: 'BD',
-      statusMessage: 'Bạn: tìm được con trai thất lạc nên khóc...',
-    ),
-    ChatContact(
-      id: 'friend-3',
-      name: 'Cf chủ nhật',
-      avatarText: 'CF',
-      statusMessage: 'Bạn bè để cà phê thôi nha 😌',
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'friend-4',
-      name: 'Trần Gia Thạnh',
-      avatarText: 'TT',
-      statusMessage: 'Luôn sẵn sàng cho một set đôi',
-    ),
-    ChatContact(
-      id: 'friend-5',
-      name: 'Khu Tự Trị Dữ Đồ',
-      avatarText: 'KD',
-      statusMessage: 'Tối nay đánh tăng 2 nhen',
-    ),
-    ChatContact(
-      id: 'friend-6',
-      name: 'Hua Tan Datt',
-      avatarText: 'HD',
-      statusMessage: 'Game báo done',
-    ),
-  ];
-
   TabBar _buildTabs(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
@@ -132,6 +91,7 @@ class ChatHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final friendManager = context.watch<FriendManager>();
     final cs = Theme.of(context).colorScheme;
     return DefaultTabController(
       length: 2,
@@ -142,8 +102,8 @@ class ChatHomePage extends StatelessWidget {
           onAddFriend: () {
             Navigator.of(context).push(
               MaterialPageRoute(
-                builder: (_) => ChangeNotifierProvider(
-                  create: (_) => FriendManager(),
+                builder: (_) => ChangeNotifierProvider.value(
+                  value: friendManager,
                   child: const AddFriendPage(),
                 ),
               ),
@@ -155,8 +115,8 @@ class ChatHomePage extends StatelessWidget {
           onPressed: () {
             Navigator.of(context).push(
               MaterialPageRoute(
-                builder: (_) => ChangeNotifierProvider(
-                  create: (_) => FriendManager(),
+                builder: (_) => ChangeNotifierProvider.value(
+                  value: friendManager,
                   child: const AddFriendPage(),
                 ),
               ),
@@ -168,7 +128,7 @@ class ChatHomePage extends StatelessWidget {
         body: TabBarView(
           children: [
             _buildActiveChatList(context),
-            _buildFriendList(context, cs),
+            _buildFriendList(context, cs, friendManager),
           ],
         ),
       ),
@@ -202,20 +162,35 @@ class ChatHomePage extends StatelessWidget {
     );
   }
 
-  Widget _buildFriendList(BuildContext context, ColorScheme cs) {
-    return ListView.builder(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
-      itemCount: _friends.length + 1,
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return Padding(
-            padding: const EdgeInsets.only(bottom: 12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+  Widget _buildFriendList(
+    BuildContext context,
+    ColorScheme cs,
+    FriendManager friendManager,
+  ) {
+    return RefreshIndicator(
+      onRefresh: friendManager.loadFriends,
+      child: Builder(
+        builder: (context) {
+          if (friendManager.isLoadingFriends) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (friendManager.friendError != null) {
+            return ListView(
+              padding: const EdgeInsets.all(24),
+              children: [
+                Text(friendManager.friendError!),
+              ],
+            );
+          }
+
+          if (friendManager.friends.isEmpty) {
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
               children: [
                 const ChatSectionHeader(
                   title: 'Tất cả bạn bè',
-                  subtitle: 'Bấm vào biểu tượng chat để mở cuộc trò chuyện',
+                  subtitle: 'Bấm vào Thêm bạn bè để bắt đầu kết nối',
                 ),
                 const SizedBox(height: 12),
                 Container(
@@ -230,7 +205,7 @@ class ChatHomePage extends StatelessWidget {
                       const SizedBox(width: 12),
                       Expanded(
                         child: Text(
-                          'Tìm kiếm bạn bè nhanh chóng',
+                          'Chưa có bạn bè nào. Hãy gửi lời mời kết bạn ngay! ',
                           style: Theme.of(context)
                               .textTheme
                               .bodyMedium
@@ -241,20 +216,64 @@ class ChatHomePage extends StatelessWidget {
                   ),
                 ),
               ],
-            ),
-          );
-        }
+            );
+          }
 
-        final contact = _friends[index - 1];
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: ContactListTile.friend(
-            contact: contact,
-            onTap: () => _openChat(context, contact),
-            onChatPressed: () => _openChat(context, contact),
-          ),
-        );
-      },
+          return ListView.builder(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+            itemCount: friendManager.friends.length + 1,
+            itemBuilder: (context, index) {
+              if (index == 0) {
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const ChatSectionHeader(
+                        title: 'Tất cả bạn bè',
+                        subtitle: 'Bấm vào biểu tượng chat để mở cuộc trò chuyện',
+                      ),
+                      const SizedBox(height: 12),
+                      Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(18),
+                          color: cs.primaryContainer.withOpacity(0.3),
+                        ),
+                        padding: const EdgeInsets.all(16),
+                        child: Row(
+                          children: [
+                            Icon(Icons.search_rounded, color: cs.primary),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                'Tìm kiếm bạn bè nhanh chóng',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyMedium
+                                    ?.copyWith(color: cs.primary),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }
+
+              final contact = friendManager.friends[index - 1];
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: ContactListTile.friend(
+                  contact: contact,
+                  onTap: () => _openChat(context, contact),
+                  onChatPressed: () => _openChat(context, contact),
+                ),
+              );
+            },
+          );
+        },
+      ),
     );
   }
 

--- a/lib/pages/social/chat/friend_manager.dart
+++ b/lib/pages/social/chat/friend_manager.dart
@@ -1,25 +1,41 @@
+import 'dart:async';
+
+import 'package:badminton_booking_app/models/chat_contact.dart';
 import 'package:badminton_booking_app/models/friend_search_result.dart';
+import 'package:badminton_booking_app/services/friend_service.dart';
 import 'package:badminton_booking_app/services/user_service.dart';
 import 'package:flutter/foundation.dart';
 
-import 'dart:async';
-
 class FriendManager extends ChangeNotifier {
-  FriendManager() : _userDetailsService = UserDetailsService();
+  FriendManager()
+      : _userDetailsService = UserDetailsService(),
+        _friendService = FriendService();
 
   Timer? _searchDebounce;
 
   final UserDetailsService _userDetailsService;
+  final FriendService _friendService;
 
   List<FriendSearchResult> _searchResults = const <FriendSearchResult>[];
+  List<ChatContact> _friends = const <ChatContact>[];
+  final Map<String, FriendRelation> _relations = {};
+  final Set<String> _pendingActions = {};
   bool _isSearching = false;
+  bool _isLoadingFriends = false;
   String _currentQuery = '';
   String? _error;
+  String? _friendError;
 
   List<FriendSearchResult> get searchResults => _searchResults;
+  List<ChatContact> get friends => _friends;
+  FriendRelation relationFor(String userId) =>
+      _relations[userId] ?? const FriendRelation(FriendRelationStatus.none);
+  bool isPendingAction(String userId) => _pendingActions.contains(userId);
   bool get isSearching => _isSearching;
+  bool get isLoadingFriends => _isLoadingFriends;
   String get currentQuery => _currentQuery;
   String? get error => _error;
+  String? get friendError => _friendError;
 
   @override
   void dispose() {
@@ -41,6 +57,7 @@ class FriendManager extends ChangeNotifier {
 
     if (term.isEmpty) {
       _searchResults = const <FriendSearchResult>[];
+      _relations.clear();
       _error = null;
       _isSearching = false;
       notifyListeners();
@@ -58,6 +75,7 @@ class FriendManager extends ChangeNotifier {
         return;
       }
       _searchResults = results;
+      await _loadRelations(results);
     } catch (_) {
       if (_currentQuery.trim() != term) return;
       _error = 'Không thể tìm kiếm. Vui lòng thử lại.';
@@ -67,5 +85,62 @@ class FriendManager extends ChangeNotifier {
         notifyListeners();
       }
     }
+  }
+
+  Future<void> sendFriendRequest(String userId) async {
+    _pendingActions.add(userId);
+    notifyListeners();
+
+    try {
+      await _friendService.sendFriendRequest(userId);
+      _relations[userId] = const FriendRelation(FriendRelationStatus.requestSent);
+    } catch (e) {
+      _error = e.toString();
+    } finally {
+      _pendingActions.remove(userId);
+      notifyListeners();
+    }
+  }
+
+  Future<void> acceptRequest(String userId) async {
+    final relation = _relations[userId];
+    if (relation == null || relation.requestId == null) return;
+
+    _pendingActions.add(userId);
+    notifyListeners();
+
+    try {
+      await _friendService.acceptFriendRequest(relation.requestId!, userId);
+      _relations[userId] = const FriendRelation(FriendRelationStatus.friends);
+      await loadFriends();
+    } catch (e) {
+      _error = e.toString();
+    } finally {
+      _pendingActions.remove(userId);
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadFriends() async {
+    _isLoadingFriends = true;
+    _friendError = null;
+    notifyListeners();
+
+    try {
+      _friends = await _friendService.loadFriends();
+    } catch (e) {
+      _friendError = 'Không thể tải danh sách bạn bè: $e';
+    } finally {
+      _isLoadingFriends = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _loadRelations(List<FriendSearchResult> results) async {
+    for (final result in results) {
+      final relation = await _friendService.getRelationWith(result.user.id);
+      _relations[result.user.id] = relation;
+    }
+    notifyListeners();
   }
 }

--- a/lib/pages/social/chat/widgets/contact_list_tile.dart
+++ b/lib/pages/social/chat/widgets/contact_list_tile.dart
@@ -10,6 +10,9 @@ class ContactListTile extends StatelessWidget {
     required this.type,
     this.onTap,
     this.onChatPressed,
+    this.actionLabel,
+    this.isActionEnabled = true,
+    this.isBusy = false,
   });
 
   factory ContactListTile.chat({
@@ -45,6 +48,9 @@ class ContactListTile extends StatelessWidget {
     required ChatContact contact,
     VoidCallback? onTap,
     VoidCallback? onChatPressed,
+    String? actionLabel,
+    bool isActionEnabled = true,
+    bool isBusy = false,
   }) {
     return ContactListTile._(
       key: key,
@@ -52,6 +58,9 @@ class ContactListTile extends StatelessWidget {
       type: _ContactTileType.suggestion,
       onTap: onTap,
       onChatPressed: onChatPressed,
+      actionLabel: actionLabel,
+      isActionEnabled: isActionEnabled,
+      isBusy: isBusy,
     );
   }
 
@@ -59,6 +68,9 @@ class ContactListTile extends StatelessWidget {
   final _ContactTileType type;
   final VoidCallback? onTap;
   final VoidCallback? onChatPressed;
+  final String? actionLabel;
+  final bool isActionEnabled;
+  final bool isBusy;
 
   @override
   Widget build(BuildContext context) {
@@ -188,8 +200,14 @@ class ContactListTile extends StatelessWidget {
         );
       case _ContactTileType.suggestion:
         return FilledButton(
-          onPressed: onChatPressed,
-          child: const Text('Kết bạn'),
+          onPressed: isActionEnabled ? onChatPressed : null,
+          child: isBusy
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(actionLabel ?? 'Kết bạn'),
         );
     }
   }

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -7,6 +7,7 @@ import 'package:badminton_booking_app/components/recruitment_post_card.dart';
 import 'package:badminton_booking_app/models/community_post.dart';
 import 'package:badminton_booking_app/models/recruitment_post.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_home_page.dart';
+import 'package:badminton_booking_app/pages/social/chat/friend_manager.dart';
 import 'package:badminton_booking_app/pages/social/create_post_page.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/recruitment_page.dart';
 import 'package:badminton_booking_app/pages/social/social_manager.dart';
@@ -108,7 +109,12 @@ class _SocialPageState extends State<SocialPage> {
               tooltip: 'Tin nhắn',
               onPressed: () {
                 Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => ChatHomePage()),
+                  MaterialPageRoute(
+                    builder: (_) => ChangeNotifierProvider(
+                      create: (_) => FriendManager()..loadFriends(),
+                      child: const ChatHomePage(),
+                    ),
+                  ),
                 );
               },
             ),

--- a/lib/services/friend_service.dart
+++ b/lib/services/friend_service.dart
@@ -1,0 +1,168 @@
+import 'package:badminton_booking_app/models/chat_contact.dart';
+import 'package:badminton_booking_app/models/friend_search_result.dart';
+import 'package:badminton_booking_app/models/user.dart';
+import 'package:badminton_booking_app/models/user_details.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import 'pocketbase_client.dart';
+import 'user_service.dart';
+
+enum FriendRelationStatus { none, requestSent, incomingRequest, friends }
+
+class FriendRelation {
+  const FriendRelation(this.status, {this.requestId});
+
+  final FriendRelationStatus status;
+  final String? requestId;
+}
+
+class FriendService {
+  FriendService() : _userDetailsService = UserDetailsService();
+
+  final UserDetailsService _userDetailsService;
+
+  Future<String> _currentUserId(PocketBase pb) async {
+    final id = pb.authStore.record?.id;
+    if (id == null || id.isEmpty) {
+      throw Exception('Bạn chưa đăng nhập.');
+    }
+    return id;
+  }
+
+  Future<FriendRelation> getRelationWith(String otherUserId) async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = await _currentUserId(pb);
+
+    // Check existing friendship
+    final friendshipFilter = """
+      (user_a = '$currentUserId' && user_b = '$otherUserId')
+      || (user_a = '$otherUserId' && user_b = '$currentUserId')
+    """;
+
+    try {
+      await pb.collection('friendships').getFirstListItem(friendshipFilter);
+      return const FriendRelation(FriendRelationStatus.friends);
+    } catch (_) {
+      // ignore not found
+    }
+
+    // Check outgoing pending request
+    try {
+      final req = await pb.collection('friend_requests').getFirstListItem(
+            "from_user = '$currentUserId' && to_user = '$otherUserId' && status = 'pending'",
+          );
+      return FriendRelation(
+        FriendRelationStatus.requestSent,
+        requestId: req.id,
+      );
+    } catch (_) {
+      // ignore
+    }
+
+    // Check incoming pending request
+    try {
+      final req = await pb.collection('friend_requests').getFirstListItem(
+            "from_user = '$otherUserId' && to_user = '$currentUserId' && status = 'pending'",
+          );
+      return FriendRelation(
+        FriendRelationStatus.incomingRequest,
+        requestId: req.id,
+      );
+    } catch (_) {
+      // ignore
+    }
+
+    return const FriendRelation(FriendRelationStatus.none);
+  }
+
+  Future<void> sendFriendRequest(String toUserId) async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = await _currentUserId(pb);
+
+    await pb.collection('friend_requests').create(body: {
+      'from_user': currentUserId,
+      'to_user': toUserId,
+      'status': 'pending',
+    });
+  }
+
+  Future<void> acceptFriendRequest(String requestId, String otherUserId) async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = await _currentUserId(pb);
+
+    await pb.collection('friend_requests').update(
+      requestId,
+      body: {'status': 'accepted'},
+    );
+
+    await _createFriendship(pb, currentUserId, otherUserId);
+  }
+
+  Future<List<ChatContact>> loadFriends() async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = await _currentUserId(pb);
+
+    final records = await pb.collection('friendships').getFullList(
+          filter: "user_a='$currentUserId' || user_b='$currentUserId'",
+          expand: 'user_a,user_b',
+        );
+
+    final contacts = <ChatContact>[];
+
+    for (final record in records) {
+      final userAList = record.expand['user_a'] ?? <RecordModel>[];
+      final userBList = record.expand['user_b'] ?? <RecordModel>[];
+      final userA = userAList.isNotEmpty ? userAList.first : null;
+      final userB = userBList.isNotEmpty ? userBList.first : null;
+      if (userA == null || userB == null) continue;
+
+      final other = userA.id == currentUserId ? userB : userA;
+      final user = User.fromJson(other.toJson());
+
+      UserDetails? details;
+      try {
+        details = await _userDetailsService.getByUserIdWithClient(pb, user.id);
+      } catch (_) {
+        // ignore
+      }
+
+      final result = FriendSearchResult(user: user, details: details);
+      contacts.add(
+        ChatContact(
+          id: user.id,
+          name: result.displayName,
+          avatarText: result.initials,
+          statusMessage: result.subtitle.isEmpty ? null : result.subtitle,
+        ),
+      );
+    }
+
+    return contacts;
+  }
+
+  Future<void> _createFriendship(
+    PocketBase pb,
+    String userA,
+    String userB,
+  ) async {
+    // Sort ids to avoid duplicate pair ordering
+    final ordered = [userA, userB]..sort();
+    final a = ordered.first;
+    final b = ordered.last;
+
+    // check existing
+    try {
+      await pb.collection('friendships').getFirstListItem(
+            "user_a='$a' && user_b='$b'",
+          );
+      return;
+    } catch (_) {
+      // not found
+    }
+
+    await pb.collection('friendships').create(body: {
+      'user_a': a,
+      'user_b': b,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add PocketBase-backed friend request handling and relationship checks
- show add friend actions in search results and allow accepting invitations
- load and display friends from the friendships collection in chat home

## Testing
- ⚠️ `dart format ...` (failed: command not found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923197620ac832ba4d824cc33c3fe33)