### PR TITLE
Add realtime PocketBase chat support

### DIFF
--- a/lib/components/chat_bubble.dart
+++ b/lib/components/chat_bubble.dart
@@ -17,6 +17,7 @@ class ChatBubble extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isMe = message.isMe;
+    final initials = _initials(message.author);
 
     final bubbleColor = isMe ? cs.primary : Colors.grey.shade300;
     final textColor = isMe ? cs.onPrimary : cs.onSurface;
@@ -39,7 +40,10 @@ class ChatBubble extends StatelessWidget {
                 child: CircleAvatar(
                   radius: 16,
                   backgroundColor: cs.primary,
-                  child: const Text('NM', style: TextStyle(fontSize: 12)),
+                  child: Text(
+                    initials,
+                    style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+                  ),
                 ),
               ),
               const SizedBox(width: 8),
@@ -78,7 +82,7 @@ class ChatBubble extends StatelessWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Text(
-                            message.time,
+                            message.timeLabel,
                             style: Theme.of(context)
                                 .textTheme
                                 .labelSmall
@@ -108,4 +112,18 @@ class ChatBubble extends StatelessWidget {
       ),
     );
   }
+}
+
+String _initials(String name) {
+  final parts = name.trim().split(RegExp(r'\s+'));
+  if (parts.length == 1) {
+    final word = parts.first;
+    if (word.isEmpty) return '??';
+    return word.substring(0, word.length >= 2 ? 2 : 1).toUpperCase();
+  }
+
+  final first = parts.first.isNotEmpty ? parts.first[0] : '';
+  final last = parts.last.isNotEmpty ? parts.last[0] : '';
+  final result = (first + last).trim();
+  return result.isEmpty ? '??' : result.toUpperCase();
 }

--- a/lib/components/chat_bubble.dart
+++ b/lib/components/chat_bubble.dart
@@ -42,7 +42,8 @@ class ChatBubble extends StatelessWidget {
                   backgroundColor: cs.primary,
                   child: Text(
                     initials,
-                    style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+                    style: const TextStyle(
+                        fontSize: 12, fontWeight: FontWeight.w700),
                   ),
                 ),
               ),
@@ -65,14 +66,16 @@ class ChatBubble extends StatelessWidget {
                   padding:
                       const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
                   child: Column(
-                    crossAxisAlignment: isMe
-                        ? CrossAxisAlignment.start
-                        : CrossAxisAlignment.end,
+                    // crossAxisAlignment: isMe
+                    //     ? CrossAxisAlignment.start
+                    //     : CrossAxisAlignment.end,
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
                         message.content,
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              fontSize: 16,
                               color: textColor,
                               height: 1.35,
                             ),

--- a/lib/components/chat_input.dart
+++ b/lib/components/chat_input.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class ChatInput extends StatefulWidget {
-  final void Function(String text) onSend;
+  final Future<void> Function(String text) onSend;
   final Color? backgroundColor;
 
   const ChatInput({
@@ -16,13 +16,23 @@ class ChatInput extends StatefulWidget {
 
 class _ChatInputState extends State<ChatInput> {
   final _controller = TextEditingController();
+  bool _isSending = false;
 
-  void _handleSubmit() {
+  Future<void> _handleSubmit() async {
     final text = _controller.text.trim();
-    if (text.isEmpty) return;
-    widget.onSend(text);
-    _controller.clear();
-    setState(() {}); // để rebuild nút gửi (enable/disable)
+    if (text.isEmpty || _isSending) return;
+    setState(() {
+      _isSending = true;
+    });
+    try {
+      await widget.onSend(text);
+      _controller.clear();
+    } finally {
+      setState(() {
+        _isSending = false;
+      });
+    }
+    // để rebuild nút gửi (enable/disable)
   }
 
   @override
@@ -71,6 +81,7 @@ class _ChatInputState extends State<ChatInput> {
                 child: TextField(
                   controller: _controller,
                   keyboardType: TextInputType.multiline,
+                  enabled: !_isSending,
                   onChanged: (_) => setState(() {}),
                   maxLines: null,
                   minLines: 1,
@@ -85,7 +96,7 @@ class _ChatInputState extends State<ChatInput> {
                     ),
                     contentPadding:
                         EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                  ),
+                    ),
                   onSubmitted: (_) => _handleSubmit(),
                 ),
               ),
@@ -94,10 +105,12 @@ class _ChatInputState extends State<ChatInput> {
             Padding(
               padding: const EdgeInsets.only(right: 4),
               child: GestureDetector(
-                onTap: _controller.text.trim().isEmpty ? null : _handleSubmit,
+                onTap:
+                    _controller.text.trim().isEmpty || _isSending ? null : _handleSubmit,
                 child: AnimatedOpacity(
                   duration: const Duration(milliseconds: 180),
-                  opacity: _controller.text.trim().isEmpty ? 0.4 : 1.0,
+                  opacity:
+                      _controller.text.trim().isEmpty || _isSending ? 0.4 : 1.0,
                   child: Container(
                     width: 44,
                     height: 44,

--- a/lib/models/chat_contact.dart
+++ b/lib/models/chat_contact.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 @immutable
 class ChatContact {
   const ChatContact({
-    required this.id,
     required this.name,
     required this.avatarText,
+    this.id,
+    this.chatId,
+    this.userId,
     this.avatarUrl,
     this.statusMessage,
     this.lastMessage,
@@ -14,7 +16,9 @@ class ChatContact {
     this.isOnline = false,
   });
 
-  final String id;
+  final String? id;
+  final String? chatId;
+  final String? userId;
   final String name;
   final String avatarText;
   final String? avatarUrl;
@@ -25,4 +29,32 @@ class ChatContact {
   final bool isOnline;
 
   bool get hasUnreadMessages => unreadCount > 0;
+
+  ChatContact copyWith({
+    String? id,
+    String? chatId,
+    String? userId,
+    String? name,
+    String? avatarText,
+    String? avatarUrl,
+    String? statusMessage,
+    String? lastMessage,
+    String? lastMessageTimeLabel,
+    int? unreadCount,
+    bool? isOnline,
+  }) {
+    return ChatContact(
+      id: id ?? this.id,
+      chatId: chatId ?? this.chatId,
+      userId: userId ?? this.userId,
+      name: name ?? this.name,
+      avatarText: avatarText ?? this.avatarText,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      statusMessage: statusMessage ?? this.statusMessage,
+      lastMessage: lastMessage ?? this.lastMessage,
+      lastMessageTimeLabel: lastMessageTimeLabel ?? this.lastMessageTimeLabel,
+      unreadCount: unreadCount ?? this.unreadCount,
+      isOnline: isOnline ?? this.isOnline,
+    );
+  }
 }

--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -24,7 +24,7 @@ class ChatMessage {
     String? authorName,
   }) {
     final senderId = record.getStringValue('sender');
-    final created = record.getDateTimeValue('created') ?? DateTime.now();
+    final created = _parseDateTime(record.data['created']) ?? DateTime.now();
     String? resolvedName = authorName;
 
     final expandedSender = record.expand['sender'] as List<dynamic>?;
@@ -46,6 +46,13 @@ class ChatMessage {
   }
 
   String get timeLabel => DateFormat('HH:mm').format(createdAt);
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  if (value is String && value.isNotEmpty) {
+    return DateTime.tryParse(value);
+  }
+  return null;
 }
 
 String _resolveDisplayName(RecordModel userRecord) {

--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -1,15 +1,62 @@
+import 'package:intl/intl.dart';
+import 'package:pocketbase/pocketbase.dart';
+
 class ChatMessage {
   final String id;
+  final String authorId;
   final String author;
   final String content;
-  final String time;
+  final DateTime createdAt;
   final bool isMe;
 
   const ChatMessage({
     required this.id,
+    required this.authorId,
     required this.author,
     required this.content,
-    required this.time,
+    required this.createdAt,
     required this.isMe,
   });
+
+  factory ChatMessage.fromRecord(
+    RecordModel record, {
+    required String currentUserId,
+    String? authorName,
+  }) {
+    final senderId = record.getStringValue('sender');
+    final created = record.getDateTimeValue('created') ?? DateTime.now();
+    String? resolvedName = authorName;
+
+    final expandedSender = record.expand['sender'] as List<dynamic>?;
+    if (expandedSender != null && expandedSender.isNotEmpty) {
+      final senderRecord = expandedSender.first;
+      if (senderRecord is RecordModel) {
+        resolvedName = _resolveDisplayName(senderRecord);
+      }
+    }
+
+    return ChatMessage(
+      id: record.id,
+      authorId: senderId,
+      author: resolvedName ?? 'Người dùng',
+      content: record.getStringValue('content'),
+      createdAt: created.toLocal(),
+      isMe: senderId == currentUserId,
+    );
+  }
+
+  String get timeLabel => DateFormat('HH:mm').format(createdAt);
+}
+
+String _resolveDisplayName(RecordModel userRecord) {
+  final username = userRecord.getStringValue('username');
+  if (username.isNotEmpty) return username;
+
+  final email = userRecord.getStringValue('email');
+  if (email.isNotEmpty) return email;
+
+  final phone = userRecord.getStringValue('phone');
+  if (phone.isNotEmpty) return phone;
+
+  return 'Người dùng';
 }

--- a/lib/models/chat_room.dart
+++ b/lib/models/chat_room.dart
@@ -46,7 +46,7 @@ class ChatRoom {
       avatarText = _initials(otherUserName);
     }
 
-    final lastMessageAt = record.getDateTimeValue('last_message_at');
+    final lastMessageAt = _parseDateTime(record.data['last_message_at']);
 
     return ChatRoom(
       id: record.id,
@@ -61,7 +61,8 @@ class ChatRoom {
 
   ChatContact toContact(String currentUserId) {
     final isMyMessage = lastSenderId == currentUserId;
-    final prefix = isMyMessage && (lastMessage?.isNotEmpty ?? false) ? 'Bạn: ' : '';
+    final prefix =
+        isMyMessage && (lastMessage?.isNotEmpty ?? false) ? 'Bạn: ' : '';
 
     return ChatContact(
       id: id,
@@ -74,6 +75,13 @@ class ChatRoom {
           lastMessageAt != null ? formatRelativeTime(lastMessageAt!) : null,
     );
   }
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  if (value is String && value.isNotEmpty) {
+    return DateTime.tryParse(value);
+  }
+  return null;
 }
 
 String _resolveDisplayName(RecordModel userRecord) {
@@ -93,7 +101,9 @@ String _initials(String name) {
   final parts = name.trim().split(RegExp(r'\s+'));
   if (parts.isEmpty || parts.first.isEmpty) return '??';
   if (parts.length == 1) {
-    return parts.first.substring(0, parts.first.length >= 2 ? 2 : 1).toUpperCase();
+    return parts.first
+        .substring(0, parts.first.length >= 2 ? 2 : 1)
+        .toUpperCase();
   }
   final first = parts.first.isNotEmpty ? parts.first[0] : '';
   final last = parts.last.isNotEmpty ? parts.last[0] : '';

--- a/lib/models/chat_room.dart
+++ b/lib/models/chat_room.dart
@@ -1,0 +1,101 @@
+import 'package:badminton_booking_app/models/chat_contact.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../utils/time_ago.dart';
+
+class ChatRoom {
+  ChatRoom({
+    required this.id,
+    required this.otherUserId,
+    required this.otherUserName,
+    required this.avatarText,
+    this.lastMessage,
+    this.lastMessageAt,
+    this.lastSenderId,
+  });
+
+  final String id;
+  final String otherUserId;
+  final String otherUserName;
+  final String avatarText;
+  final String? lastMessage;
+  final DateTime? lastMessageAt;
+  final String? lastSenderId;
+
+  factory ChatRoom.fromRecord(
+    RecordModel record, {
+    required String currentUserId,
+  }) {
+    final userAId = record.getStringValue('user_a');
+    final userBId = record.getStringValue('user_b');
+    final otherUserId = userAId == currentUserId ? userBId : userAId;
+
+    final expandedA = record.expand['user_a'] as List<dynamic>?;
+    final expandedB = record.expand['user_b'] as List<dynamic>?;
+
+    final otherUser =
+        (expandedA != null && expandedA.isNotEmpty && userBId == currentUserId)
+            ? expandedA.first
+            : expandedB?.first;
+
+    String otherUserName = 'Người dùng';
+    String avatarText = '??';
+
+    if (otherUser is RecordModel) {
+      otherUserName = _resolveDisplayName(otherUser);
+      avatarText = _initials(otherUserName);
+    }
+
+    final lastMessageAt = record.getDateTimeValue('last_message_at');
+
+    return ChatRoom(
+      id: record.id,
+      otherUserId: otherUserId,
+      otherUserName: otherUserName,
+      avatarText: avatarText,
+      lastMessage: record.getStringValue('last_message'),
+      lastMessageAt: lastMessageAt?.toLocal(),
+      lastSenderId: record.getStringValue('last_sender'),
+    );
+  }
+
+  ChatContact toContact(String currentUserId) {
+    final isMyMessage = lastSenderId == currentUserId;
+    final prefix = isMyMessage && (lastMessage?.isNotEmpty ?? false) ? 'Bạn: ' : '';
+
+    return ChatContact(
+      id: id,
+      chatId: id,
+      userId: otherUserId,
+      name: otherUserName,
+      avatarText: avatarText,
+      lastMessage: lastMessage != null ? '$prefix$lastMessage' : null,
+      lastMessageTimeLabel:
+          lastMessageAt != null ? formatRelativeTime(lastMessageAt!) : null,
+    );
+  }
+}
+
+String _resolveDisplayName(RecordModel userRecord) {
+  final username = userRecord.getStringValue('username');
+  if (username.isNotEmpty) return username;
+
+  final email = userRecord.getStringValue('email');
+  if (email.isNotEmpty) return email;
+
+  final phone = userRecord.getStringValue('phone');
+  if (phone.isNotEmpty) return phone;
+
+  return 'Người dùng';
+}
+
+String _initials(String name) {
+  final parts = name.trim().split(RegExp(r'\s+'));
+  if (parts.isEmpty || parts.first.isEmpty) return '??';
+  if (parts.length == 1) {
+    return parts.first.substring(0, parts.first.length >= 2 ? 2 : 1).toUpperCase();
+  }
+  final first = parts.first.isNotEmpty ? parts.first[0] : '';
+  final last = parts.last.isNotEmpty ? parts.last[0] : '';
+  return (first + last).toUpperCase();
+}

--- a/lib/pages/social/chat/chat_conversation_manager.dart
+++ b/lib/pages/social/chat/chat_conversation_manager.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../../../models/chat_message.dart';
+import '../../../services/chat_service.dart';
+import '../../../services/pocketbase_client.dart';
+
+class ChatConversationManager extends ChangeNotifier {
+  ChatConversationManager({required this.chatId}) : _service = ChatService();
+
+  final String chatId;
+  final ChatService _service;
+
+  List<ChatMessage> _messages = const <ChatMessage>[];
+  bool _isLoading = false;
+  String? _error;
+  UnsubscribeFunc? _messagesUnsubscribe;
+  String? _currentUserId;
+
+  List<ChatMessage> get messages => _messages;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  Future<void> initialize() async {
+    await _loadMessages();
+    await _setupRealtime();
+  }
+
+  Future<void> _loadMessages() async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final pb = await getPocketbaseInstance();
+      _currentUserId = pb.authStore.record?.id;
+      _messages = await _service.fetchMessages(chatId);
+    } catch (error) {
+      _error = 'Không thể tải tin nhắn. Vui lòng thử lại.';
+      if (kDebugMode) {
+        debugPrint('Load messages failed: $error');
+      }
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _setupRealtime() async {
+    try {
+      final oldUnsub = _messagesUnsubscribe;
+      _messagesUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _messagesUnsubscribe = await _service.subscribeMessages(
+        chatId,
+        _handleMessageEvent,
+      );
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Subscribe messages failed: $error');
+      }
+    }
+  }
+
+  Future<void> sendMessage(String text) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+
+    try {
+      final message = await _service.sendMessage(chatId: chatId, content: trimmed);
+      _upsertMessage(message);
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Send message failed: $error');
+      }
+    }
+  }
+
+  Future<void> _handleMessageEvent(RecordSubscriptionEvent event) async {
+    final record = event.record;
+    if (record == null) return;
+    if (event.action == 'delete') return;
+
+    try {
+      final userId =
+          _currentUserId ?? (await getPocketbaseInstance()).authStore.record?.id;
+      _currentUserId ??= userId;
+      final current = ChatMessage.fromRecord(
+        record,
+        currentUserId: userId ?? '',
+      );
+      _upsertMessage(current);
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Realtime refresh failed: $error');
+      }
+    }
+  }
+
+  void _upsertMessage(ChatMessage message) {
+    final existingIndex = _messages.indexWhere((m) => m.id == message.id);
+    if (existingIndex >= 0) {
+      final mutable = [..._messages];
+      mutable[existingIndex] = message;
+      _messages = mutable;
+    } else {
+      _messages = [..._messages, message];
+    }
+    _messages.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_messagesUnsubscribe?.call());
+    super.dispose();
+  }
+}

--- a/lib/pages/social/chat/chat_home_page.dart
+++ b/lib/pages/social/chat/chat_home_page.dart
@@ -8,6 +8,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'add_friend_page.dart';
+import '../../../services/chat_service.dart';
+import 'chat_conversation_manager.dart';
+import 'chat_list_manager.dart';
 import 'friend_list_manager.dart';
 import 'friend_manager.dart';
 import 'friend_request_manager.dart';
@@ -20,55 +23,6 @@ class ChatHomePage extends StatefulWidget {
 }
 
 class _ChatHomePageState extends State<ChatHomePage> {
-  static const List<ChatContact> _activeChats = [
-    ChatContact(
-      id: 'chat-1',
-      name: 'Nhỏ quậy lắm chiều',
-      avatarText: 'NC',
-      lastMessage: 'Bạn: hehe hehe <3 tối qua đánh cầu nhe bạn',
-      lastMessageTimeLabel: '1 phút',
-      unreadCount: 2,
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'chat-2',
-      name: 'Bến Đò Không Người Lái Đó',
-      avatarText: 'BD',
-      lastMessage: 'Bạn: tìm được con trai thất lạc nên khóc...',
-      lastMessageTimeLabel: '15 phút',
-    ),
-    ChatContact(
-      id: 'chat-3',
-      name: 'Cf chủ nhật',
-      avatarText: 'CF',
-      lastMessage: '😊 😌',
-      lastMessageTimeLabel: '30 phút',
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'chat-4',
-      name: 'Trần Gia Thạnh',
-      avatarText: 'TT',
-      lastMessage: 'Đã gửi cho bạn một ảnh',
-      lastMessageTimeLabel: '1 giờ',
-    ),
-    ChatContact(
-      id: 'chat-5',
-      name: 'Khu Tự Trị Dữ Đồ',
-      avatarText: 'KD',
-      lastMessage: 'Bé thỏ mới uống: Mà deokdame đáng cháy vcl',
-      lastMessageTimeLabel: '2 giờ',
-      unreadCount: 1,
-    ),
-    ChatContact(
-      id: 'chat-6',
-      name: 'Hua Tan Datt',
-      avatarText: 'HD',
-      lastMessage: 'Game bào điên',
-      lastMessageTimeLabel: '5 giờ',
-    ),
-  ];
-
   TabBar _buildTabs(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
@@ -145,29 +99,83 @@ class _ChatHomePageState extends State<ChatHomePage> {
   }
 
   Widget _buildActiveChatList(BuildContext context) {
-    return ListView.builder(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
-      itemCount: _activeChats.length + 1,
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return const Padding(
-            padding: EdgeInsets.only(bottom: 12),
-            child: ChatSectionHeader(
-              title: 'Đang trò chuyện',
-              subtitle: 'Danh sách những người bạn đang nhắn tin gần đây',
+    final manager = context.watch<ChatListManager>();
+    final theme = Theme.of(context);
+
+    if (manager.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (manager.error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(manager.error!, style: theme.textTheme.bodyMedium),
+            const SizedBox(height: 12),
+            FilledButton(
+              onPressed: manager.loadChats,
+              child: const Text('Thử lại'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (manager.chats.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: manager.loadChats,
+        child: ListView(
+          padding: const EdgeInsets.all(24),
+          children: [
+            const SizedBox(height: 32),
+            Icon(Icons.chat_bubble_outline,
+                size: 56, color: theme.colorScheme.primary),
+            const SizedBox(height: 12),
+            Text(
+              'Chưa có cuộc trò chuyện',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Hãy bắt đầu trò chuyện với bạn bè để xuất hiện tại đây.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: manager.loadChats,
+      child: ListView.builder(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+        itemCount: manager.chats.length + 1,
+        itemBuilder: (context, index) {
+          if (index == 0) {
+            return const Padding(
+              padding: EdgeInsets.only(bottom: 12),
+              child: ChatSectionHeader(
+                title: 'Đang trò chuyện',
+                subtitle: 'Danh sách những người bạn đang nhắn tin gần đây',
+              ),
+            );
+          }
+
+          final contact = manager.chats[index - 1];
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: ContactListTile.chat(
+              contact: contact,
+              onTap: () => _openChat(context, contact),
             ),
           );
-        }
-
-        final contact = _activeChats[index - 1];
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: ContactListTile.chat(
-            contact: contact,
-            onTap: () => _openChat(context, contact),
-          ),
-        );
-      },
+        },
+      ),
     );
   }
 
@@ -222,13 +230,14 @@ class _ChatHomePageState extends State<ChatHomePage> {
       );
     }
 
-    final friendsContacts = manager.friends
-        .map(
-          (result) => ChatContact(
-            id: result.user.id,
-            name: result.displayName,
-            avatarText: result.initials,
-            avatarUrl: result.details?.avatarUrl,
+      final friendsContacts = manager.friends
+          .map(
+            (result) => ChatContact(
+              id: result.user.id,
+              userId: result.user.id,
+              name: result.displayName,
+              avatarText: result.initials,
+              avatarUrl: result.details?.avatarUrl,
             statusMessage:
                 result.details?.level ?? result.user.email ?? result.user.phone,
           ),
@@ -456,15 +465,44 @@ class _ChatHomePageState extends State<ChatHomePage> {
   }
 
   void _openChat(BuildContext context, ChatContact contact) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => ChatPage(
-          contactName: contact.name,
-          isContactOnline: contact.isOnline,
-          avatarText: contact.avatarText,
-        ),
-      ),
-    );
+    final service = ChatService();
+    final navigator = Navigator.of(context);
+    final scaffold = ScaffoldMessenger.of(context);
+
+    () async {
+      try {
+        final targetUserId = contact.userId ?? contact.id;
+        final roomId = contact.chatId ?? contact.id ?? contact.userId;
+
+        if (roomId == null && targetUserId == null) {
+          throw Exception('Không xác định được người nhận tin nhắn.');
+        }
+
+        final ensuredRoom = roomId ??
+            await service.ensureRoomWith(targetUserId ?? '');
+
+        if (!context.mounted) return;
+
+        final targetContact = contact.copyWith(
+          id: ensuredRoom,
+          chatId: ensuredRoom,
+        );
+
+        navigator.push(
+          MaterialPageRoute(
+            builder: (_) => ChangeNotifierProvider(
+              create: (_) => ChatConversationManager(chatId: ensuredRoom)
+                ..initialize(),
+              child: ChatPage(contact: targetContact),
+            ),
+          ),
+        );
+      } catch (error) {
+        scaffold.showSnackBar(
+          SnackBar(content: Text('$error')),
+        );
+      }
+    }();
   }
 }
 

--- a/lib/pages/social/chat/chat_home_page.dart
+++ b/lib/pages/social/chat/chat_home_page.dart
@@ -4,11 +4,11 @@ import 'package:badminton_booking_app/pages/social/chat/chat_page.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/chat_header.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/chat_section_header.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/contact_list_tile.dart';
+import 'package:badminton_booking_app/services/chat_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'add_friend_page.dart';
-import '../../../services/chat_service.dart';
 import 'chat_conversation_manager.dart';
 import 'chat_list_manager.dart';
 import 'friend_list_manager.dart';
@@ -230,14 +230,14 @@ class _ChatHomePageState extends State<ChatHomePage> {
       );
     }
 
-      final friendsContacts = manager.friends
-          .map(
-            (result) => ChatContact(
-              id: result.user.id,
-              userId: result.user.id,
-              name: result.displayName,
-              avatarText: result.initials,
-              avatarUrl: result.details?.avatarUrl,
+    final friendsContacts = manager.friends
+        .map(
+          (result) => ChatContact(
+            id: result.user.id,
+            userId: result.user.id,
+            name: result.displayName,
+            avatarText: result.initials,
+            avatarUrl: result.details?.avatarUrl,
             statusMessage:
                 result.details?.level ?? result.user.email ?? result.user.phone,
           ),
@@ -471,28 +471,42 @@ class _ChatHomePageState extends State<ChatHomePage> {
 
     () async {
       try {
+        // 1. Xác định id người bạn
         final targetUserId = contact.userId ?? contact.id;
-        final roomId = contact.chatId ?? contact.id ?? contact.userId;
 
-        if (roomId == null && targetUserId == null) {
+        if (targetUserId == null) {
           throw Exception('Không xác định được người nhận tin nhắn.');
         }
 
-        final ensuredRoom = roomId ??
-            await service.ensureRoomWith(targetUserId ?? '');
+        // 2. Chỉ coi contact.id là roomId nếu nó khác userId
+        //    (tức là contact được tạo từ ChatRoom.toContact)
+        String? roomId = contact.chatId;
+        if (roomId == null &&
+            contact.userId != null &&
+            contact.id != null &&
+            contact.id != contact.userId) {
+          // Trường hợp contact.id là roomId (tab Đang trò chuyện)
+          roomId = contact.id;
+        }
+
+        // 3. Nếu vẫn chưa có roomId → đảm bảo tạo/tìm phòng chat với bạn đó
+        final ensuredRoom =
+            roomId ?? await service.ensureRoomWith(targetUserId);
 
         if (!context.mounted) return;
 
+        // 4. Cập nhật lại contact để mang theo chatId chính xác
         final targetContact = contact.copyWith(
           id: ensuredRoom,
           chatId: ensuredRoom,
         );
 
+        // 5. Mở trang chat với chatId đúng
         navigator.push(
           MaterialPageRoute(
             builder: (_) => ChangeNotifierProvider(
-              create: (_) => ChatConversationManager(chatId: ensuredRoom)
-                ..initialize(),
+              create: (_) =>
+                  ChatConversationManager(chatId: ensuredRoom)..initialize(),
               child: ChatPage(contact: targetContact),
             ),
           ),

--- a/lib/pages/social/chat/chat_list_manager.dart
+++ b/lib/pages/social/chat/chat_list_manager.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../../../models/chat_contact.dart';
+import '../../../models/chat_room.dart';
+import '../../../services/chat_service.dart';
+import '../../../services/pocketbase_client.dart';
+
+class ChatListManager extends ChangeNotifier {
+  ChatListManager() : _service = ChatService();
+
+  final ChatService _service;
+
+  List<ChatContact> _chats = const <ChatContact>[];
+  bool _isLoading = false;
+  String? _error;
+  UnsubscribeFunc? _roomUnsubscribe;
+  String? _currentUserId;
+
+  List<ChatContact> get chats => _chats;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  Future<void> initialize() async {
+    await loadChats();
+    await _setupRealtime();
+  }
+
+  Future<void> loadChats() async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final rooms = await _service.fetchRooms();
+      final pb = await getPocketbaseInstance();
+      _currentUserId = pb.authStore.record?.id;
+      _chats = _mapRoomsToContacts(rooms);
+    } catch (error) {
+      _error = 'Không thể tải danh sách trò chuyện. Vui lòng thử lại.';
+      if (kDebugMode) {
+        debugPrint('Load chats failed: $error');
+      }
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _setupRealtime() async {
+    if (_currentUserId == null) {
+      final pb = await getPocketbaseInstance();
+      _currentUserId = pb.authStore.record?.id;
+    }
+    final userId = _currentUserId;
+    if (userId == null) return;
+
+    try {
+      final oldUnsub = _roomUnsubscribe;
+      _roomUnsubscribe = null;
+      if (oldUnsub != null) {
+        await oldUnsub();
+      }
+
+      _roomUnsubscribe = await _service.subscribeRooms(userId, _handleRoomEvent);
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to subscribe rooms: $error');
+      }
+    }
+  }
+
+  Future<void> _handleRoomEvent(RecordSubscriptionEvent event) async {
+    final record = event.record;
+    final userId = _currentUserId;
+    if (record == null || userId == null) return;
+
+    final room = ChatRoom.fromRecord(record, currentUserId: userId);
+    final updatedContact = room.toContact(userId);
+
+    switch (event.action) {
+      case 'delete':
+        _chats = _chats.where((c) => c.chatId != room.id && c.id != room.id).toList();
+        break;
+      case 'create':
+      case 'update':
+        _upsertContact(updatedContact);
+        break;
+      default:
+        break;
+    }
+
+    notifyListeners();
+  }
+
+  void _upsertContact(ChatContact contact) {
+    final index = _chats.indexWhere((element) =>
+        (element.chatId ?? element.id) == (contact.chatId ?? contact.id));
+    if (index == -1) {
+      _chats = <ChatContact>[contact, ..._chats];
+    } else {
+      final mutable = [..._chats];
+      mutable[index] = contact;
+      _chats = mutable;
+    }
+  }
+
+  List<ChatContact> _mapRoomsToContacts(List<ChatRoom> rooms) {
+    final userId = _currentUserId;
+    if (userId == null) return const <ChatContact>[];
+
+    return rooms.map((room) => room.toContact(userId)).toList();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_roomUnsubscribe?.call());
+    super.dispose();
+  }
+}

--- a/lib/pages/social/chat/chat_page.dart
+++ b/lib/pages/social/chat/chat_page.dart
@@ -1,102 +1,64 @@
 import 'package:badminton_booking_app/components/chat_input.dart';
-import 'package:badminton_booking_app/models/chat_message.dart';
+import 'package:badminton_booking_app/models/chat_contact.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/chat_app_bar.dart';
 import 'package:badminton_booking_app/pages/social/chat/widgets/chat_message_list.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'chat_conversation_manager.dart';
 
 class ChatPage extends StatefulWidget {
   const ChatPage({
     super.key,
-    this.contactName = 'Nguyễn Minh',
-    this.avatarText = 'NM',
-    this.isContactOnline = true,
+    required this.contact,
   });
 
-  final String contactName;
-  final String avatarText;
-  final bool isContactOnline;
+  final ChatContact contact;
 
   @override
   State<ChatPage> createState() => _ChatPageState();
 }
 
 class _ChatPageState extends State<ChatPage> {
-  // sau này bạn sẽ thay bằng data từ backend
-  final List<ChatMessage> _messages = [
-    const ChatMessage(
-      id: '1',
-      author: 'Nguyễn Minh',
-      content: 'Chào bạn, mình thấy bài tuyển thành viên của bạn.',
-      time: '17:45',
-      isMe: false,
-    ),
-    const ChatMessage(
-      id: '2',
-      author: 'Bạn',
-      content: 'Hi Minh, bạn đang đánh trình nào vậy?',
-      time: '17:46',
-      isMe: true,
-    ),
-    const ChatMessage(
-      id: '3',
-      author: 'Nguyễn Minh',
-      content: 'Mình đang ở mức trung bình khá, hay đánh đôi.',
-      time: '17:46',
-      isMe: false,
-    ),
-    const ChatMessage(
-      id: '4',
-      author: 'Bạn',
-      content:
-          'Okie, sân mình đặt ở Quận 7 lúc 20:00. Bạn đến trước 10 phút nhé!',
-      time: '17:47',
-      isMe: true,
-    ),
-    const ChatMessage(
-      id: '5',
-      author: 'Nguyễn Minh',
-      content: 'Quá ổn luôn, tối gặp nhé!',
-      time: '17:47',
-      isMe: false,
-    ),
-  ];
-
-  void _handleSend(String text) {
-    if (text.trim().isEmpty) return;
-    setState(() {
-      _messages.add(
-        ChatMessage(
-          id: DateTime.now().millisecondsSinceEpoch.toString(),
-          author: 'Bạn',
-          content: text.trim(),
-          time: TimeOfDay.now().format(context),
-          isMe: true,
-        ),
-      );
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<ChatConversationManager>().initialize();
+      }
     });
   }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final manager = context.watch<ChatConversationManager>();
+
     return Scaffold(
       backgroundColor: const Color(0xFFF4F6FB),
       appBar: ChatAppBar(
-        name: widget.contactName,
-        isOnline: widget.isContactOnline,
-        avatarText: widget.avatarText,
+        name: widget.contact.name,
+        isOnline: widget.contact.isOnline,
+        avatarText: widget.contact.avatarText,
         onCall: () {},
         onVideoCall: () {},
       ),
       body: Column(
         children: [
           Expanded(
-            child: ChatMessageList(
-              messages: _messages,
-            ),
+            child: manager.isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : manager.error != null && manager.messages.isEmpty
+                    ? Center(
+                        child: Text(manager.error!),
+                      )
+                    : ChatMessageList(
+                        messages: manager.messages,
+                      ),
           ),
           ChatInput(
-            onSend: _handleSend,
+            onSend: manager.sendMessage,
             backgroundColor: cs.background,
           ),
         ],

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -7,6 +7,7 @@ import 'package:badminton_booking_app/components/recruitment_post_card.dart';
 import 'package:badminton_booking_app/models/community_post.dart';
 import 'package:badminton_booking_app/models/recruitment_post.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_home_page.dart';
+import 'package:badminton_booking_app/pages/social/chat/chat_list_manager.dart';
 import 'package:badminton_booking_app/pages/social/create_post_page.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/recruitment_page.dart';
 import 'package:badminton_booking_app/pages/social/social_manager.dart';
@@ -109,22 +110,25 @@ class _SocialPageState extends State<SocialPage> {
               icon: const Icon(Icons.group, size: 30),
               tooltip: 'Tin nhắn',
               onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => MultiProvider(
-                      providers: [
-                        ChangeNotifierProvider(
-                          create: (_) =>
-                              FriendRequestManager()..loadIncomingRequests(),
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => MultiProvider(
+                          providers: [
+                            ChangeNotifierProvider(
+                              create: (_) =>
+                                  FriendRequestManager()..loadIncomingRequests(),
+                            ),
+                            ChangeNotifierProvider(
+                              create: (_) => FriendListManager()..loadFriends(),
+                            ),
+                            ChangeNotifierProvider(
+                              create: (_) => ChatListManager()..initialize(),
+                            ),
+                          ],
+                          child: const ChatHomePage(),
                         ),
-                        ChangeNotifierProvider(
-                          create: (_) => FriendListManager()..loadFriends(),
-                        ),
-                      ],
-                      child: const ChatHomePage(),
-                    ),
-                  ),
-                );
+                      ),
+                    );
               },
             ),
             const SizedBox(width: 6),

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,0 +1,138 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/chat_message.dart';
+import '../models/chat_room.dart';
+import '../services/pocketbase_client.dart';
+
+class ChatService {
+  static const chatsCollection = 'room_chats';
+  static const messagesCollection = 'chat_messages';
+
+  Future<String> ensureRoomWith(String otherUserId) async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = pb.authStore.record?.id;
+
+    if (currentUserId == null) {
+      throw Exception('Bạn chưa đăng nhập.');
+    }
+
+    final filter =
+        "(user_a = '$currentUserId' && user_b = '$otherUserId') || (user_a = '$otherUserId' && user_b = '$currentUserId')";
+
+    try {
+      final existing =
+          await pb.collection(chatsCollection).getFirstListItem(filter);
+      return existing.id;
+    } on ClientException catch (error) {
+      if (error.statusCode != 404) rethrow;
+    }
+
+    final created = await pb.collection(chatsCollection).create(body: {
+      'user_a': currentUserId,
+      'user_b': otherUserId,
+    });
+
+    return created.id;
+  }
+
+  Future<List<ChatRoom>> fetchRooms() async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = pb.authStore.record?.id;
+
+    if (currentUserId == null) {
+      throw Exception('Bạn chưa đăng nhập.');
+    }
+
+    final result = await pb.collection(chatsCollection).getList(
+          filter: "user_a = '$currentUserId' || user_b = '$currentUserId'",
+          sort: '-last_message_at,-updated',
+          expand: 'user_a,user_b,last_sender',
+        );
+
+    return result.items
+        .map((record) => ChatRoom.fromRecord(record, currentUserId: currentUserId))
+        .toList();
+  }
+
+  Future<List<ChatMessage>> fetchMessages(String chatId) async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = pb.authStore.record?.id;
+
+    if (currentUserId == null) {
+      throw Exception('Bạn chưa đăng nhập.');
+    }
+
+    final result = await pb.collection(messagesCollection).getList(
+          filter: "chat = '$chatId'",
+          sort: 'created',
+          expand: 'sender',
+          perPage: 200,
+        );
+
+    return result.items
+        .map(
+          (record) => ChatMessage.fromRecord(
+            record,
+            currentUserId: currentUserId,
+          ),
+        )
+        .toList();
+  }
+
+  Future<ChatMessage> sendMessage({
+    required String chatId,
+    required String content,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = pb.authStore.record?.id;
+
+    if (currentUserId == null) {
+      throw Exception('Bạn chưa đăng nhập.');
+    }
+
+    final record = await pb.collection(messagesCollection).create(body: {
+      'chat': chatId,
+      'sender': currentUserId,
+      'content': content.trim(),
+      'is_read': false,
+    });
+
+    await pb.collection(chatsCollection).update(chatId, body: {
+      'last_message': content.trim(),
+      'last_message_at': DateTime.now().toIso8601String(),
+      'last_sender': currentUserId,
+    });
+
+    return ChatMessage.fromRecord(
+      record,
+      currentUserId: currentUserId,
+      authorName: 'Bạn',
+    );
+  }
+
+  Future<UnsubscribeFunc> subscribeRooms(
+    String currentUserId,
+    RecordSubscriptionFunc handler,
+  ) async {
+    final pb = await getPocketbaseInstance();
+    return pb.collection(chatsCollection).subscribe(
+          '*',
+          handler,
+          filter: "user_a = '$currentUserId' || user_b = '$currentUserId'",
+          expand: 'user_a,user_b,last_sender',
+        );
+  }
+
+  Future<UnsubscribeFunc> subscribeMessages(
+    String chatId,
+    RecordSubscriptionFunc handler,
+  ) async {
+    final pb = await getPocketbaseInstance();
+    return pb.collection(messagesCollection).subscribe(
+          '*',
+          handler,
+          filter: "chat = '$chatId'",
+          expand: 'sender',
+        );
+  }
+}


### PR DESCRIPTION
## Summary
- add PocketBase chat service, room model, and realtime subscriptions for chats and messages
- refresh chat home to load recent conversations, create rooms from friend entries, and navigate into live chats
- update chat page input and rendering to consume realtime messages via new conversation manager

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242aa91b6c832b9e914e04af4d27a1)