### PR TITLE
Enable sending image attachments in chat

### DIFF
--- a/lib/components/chat_bubble.dart
+++ b/lib/components/chat_bubble.dart
@@ -18,9 +18,15 @@ class ChatBubble extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final isMe = message.isMe;
     final initials = _initials(message.author);
+    final hasAttachment = message.hasAttachment;
+    final hasText = message.hasText;
 
     final bubbleColor = isMe ? cs.primary : Colors.grey.shade300;
     final textColor = isMe ? cs.onPrimary : cs.onSurface;
+
+    final EdgeInsets bubblePadding = hasAttachment && !hasText
+        ? const EdgeInsets.all(6)
+        : const EdgeInsets.symmetric(horizontal: 14, vertical: 10);
 
     return Align(
       alignment: isMe ? Alignment.centerRight : Alignment.centerLeft,
@@ -63,8 +69,7 @@ class ChatBubble extends StatelessWidget {
                   ),
                 ),
                 child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                  padding: bubblePadding,
                   child: Column(
                     // crossAxisAlignment: isMe
                     //     ? CrossAxisAlignment.start
@@ -72,15 +77,61 @@ class ChatBubble extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Text(
-                        message.content,
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              fontSize: 16,
-                              color: textColor,
-                              height: 1.35,
+                      if (message.attachmentUrl != null) ...[
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(14),
+                          child: ConstrainedBox(
+                            constraints: const BoxConstraints(
+                              maxWidth: 240,
+                              maxHeight: 280,
+                              minWidth: 120,
                             ),
-                      ),
-                      const SizedBox(height: 4),
+                            child: Image.network(
+                              message.attachmentUrl!,
+                              fit: BoxFit.cover,
+                              loadingBuilder: (context, child, progress) {
+                                if (progress == null) return child;
+                                return SizedBox(
+                                  height: 180,
+                                  width: 180,
+                                  child: Center(
+                                    child: CircularProgressIndicator(
+                                      value: progress.expectedTotalBytes != null
+                                          ? progress.cumulativeBytesLoaded /
+                                              (progress.expectedTotalBytes ?? 1)
+                                          : null,
+                                      color: textColor,
+                                    ),
+                                  ),
+                                );
+                              },
+                              errorBuilder: (_, __, ___) => Container(
+                                height: 160,
+                                width: 180,
+                                color: Colors.black12,
+                                alignment: Alignment.center,
+                                child: Icon(
+                                  Icons.broken_image_outlined,
+                                  color: textColor,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        if (hasText) const SizedBox(height: 8),
+                      ],
+                      if (hasText) ...[
+                        Text(
+                          message.content,
+                          style:
+                              Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    fontSize: 16,
+                                    color: textColor,
+                                    height: 1.35,
+                                  ),
+                        ),
+                        const SizedBox(height: 4),
+                      ],
                       Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [

--- a/lib/components/chat_input.dart
+++ b/lib/components/chat_input.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 
 class ChatInput extends StatefulWidget {
   final Future<void> Function(String text) onSend;
+  final Future<void> Function(XFile image)? onPickImage;
   final Color? backgroundColor;
 
   const ChatInput({
     super.key,
     required this.onSend,
+    this.onPickImage,
     this.backgroundColor,
   });
 
@@ -17,6 +20,8 @@ class ChatInput extends StatefulWidget {
 class _ChatInputState extends State<ChatInput> {
   final _controller = TextEditingController();
   bool _isSending = false;
+
+  final _picker = ImagePicker();
 
   Future<void> _handleSubmit() async {
     final text = _controller.text.trim();
@@ -33,6 +38,25 @@ class _ChatInputState extends State<ChatInput> {
       });
     }
     // để rebuild nút gửi (enable/disable)
+  }
+
+  Future<void> _handlePickImage() async {
+    if (_isSending || widget.onPickImage == null) return;
+
+    try {
+      final image = await _picker.pickImage(source: ImageSource.gallery);
+      if (image == null) return;
+
+      setState(() {
+        _isSending = true;
+      });
+
+      await widget.onPickImage!(image);
+    } finally {
+      setState(() {
+        _isSending = false;
+      });
+    }
   }
 
   @override
@@ -69,7 +93,7 @@ class _ChatInputState extends State<ChatInput> {
             _CircleIconButton(
               icon: Icons.image_outlined,
               color: primary,
-              onTap: () {},
+              onTap: _handlePickImage,
             ),
             const SizedBox(width: 10),
             // ô nhập dài

--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -6,6 +6,7 @@ class ChatMessage {
   final String authorId;
   final String author;
   final String content;
+  final String? attachmentUrl;
   final DateTime createdAt;
   final bool isMe;
 
@@ -14,18 +15,21 @@ class ChatMessage {
     required this.authorId,
     required this.author,
     required this.content,
+    this.attachmentUrl,
     required this.createdAt,
     required this.isMe,
   });
 
   factory ChatMessage.fromRecord(
     RecordModel record, {
+    required PocketBase pb,
     required String currentUserId,
     String? authorName,
   }) {
     final senderId = record.getStringValue('sender');
     final created = _parseDateTime(record.data['created']) ?? DateTime.now();
     String? resolvedName = authorName;
+    String? attachmentUrl;
 
     final expandedSender = record.expand['sender'] as List<dynamic>?;
     if (expandedSender != null && expandedSender.isNotEmpty) {
@@ -35,15 +39,24 @@ class ChatMessage {
       }
     }
 
+    final attachmentName = record.getStringValue('attachments');
+    if (attachmentName.isNotEmpty) {
+      attachmentUrl = pb.files.getUrl(record, attachmentName).toString();
+    }
+
     return ChatMessage(
       id: record.id,
       authorId: senderId,
       author: resolvedName ?? 'Người dùng',
       content: record.getStringValue('content'),
+      attachmentUrl: attachmentUrl,
       createdAt: created.toLocal(),
       isMe: senderId == currentUserId,
     );
   }
+
+  bool get hasAttachment => attachmentUrl != null;
+  bool get hasText => content.isNotEmpty;
 
   String get timeLabel => DateFormat('HH:mm').format(createdAt);
 }

--- a/lib/pages/social/chat/chat_conversation_manager.dart
+++ b/lib/pages/social/chat/chat_conversation_manager.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:image_picker/image_picker.dart';
 import 'package:pocketbase/pocketbase.dart';
+import 'package:path/path.dart' as p;
 
 import '../../../models/chat_message.dart';
 import '../../../services/chat_service.dart';
@@ -72,11 +75,34 @@ class ChatConversationManager extends ChangeNotifier {
     if (trimmed.isEmpty) return;
 
     try {
-      final message = await _service.sendMessage(chatId: chatId, content: trimmed);
+      final message =
+          await _service.sendMessage(chatId: chatId, content: trimmed);
       _upsertMessage(message);
     } catch (error) {
       if (kDebugMode) {
         debugPrint('Send message failed: $error');
+      }
+    }
+  }
+
+  Future<void> sendImage(XFile image) async {
+    try {
+      final bytes = await image.readAsBytes();
+      final fileName = p.basename(image.path);
+      final multipart = http.MultipartFile.fromBytes(
+        'attachments',
+        bytes,
+        filename: fileName,
+      );
+
+      final message = await _service.sendMessage(
+        chatId: chatId,
+        attachment: multipart,
+      );
+      _upsertMessage(message);
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Send image failed: $error');
       }
     }
   }
@@ -87,11 +113,12 @@ class ChatConversationManager extends ChangeNotifier {
     if (event.action == 'delete') return;
 
     try {
-      final userId =
-          _currentUserId ?? (await getPocketbaseInstance()).authStore.record?.id;
+      final pb = await getPocketbaseInstance();
+      final userId = _currentUserId ?? pb.authStore.record?.id;
       _currentUserId ??= userId;
       final current = ChatMessage.fromRecord(
         record,
+        pb: pb,
         currentUserId: userId ?? '',
       );
       _upsertMessage(current);

--- a/lib/pages/social/chat/chat_page.dart
+++ b/lib/pages/social/chat/chat_page.dart
@@ -59,6 +59,7 @@ class _ChatPageState extends State<ChatPage> {
           ),
           ChatInput(
             onSend: manager.sendMessage,
+            onPickImage: manager.sendImage,
             backgroundColor: cs.background,
           ),
         ],

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,3 +1,4 @@
+import 'package:http/http.dart' as http;
 import 'package:pocketbase/pocketbase.dart';
 
 import '../models/chat_message.dart';
@@ -73,6 +74,7 @@ class ChatService {
         .map(
           (record) => ChatMessage.fromRecord(
             record,
+            pb: pb,
             currentUserId: currentUserId,
           ),
         )
@@ -81,7 +83,8 @@ class ChatService {
 
   Future<ChatMessage> sendMessage({
     required String chatId,
-    required String content,
+    String content = '',
+    http.MultipartFile? attachment,
   }) async {
     final pb = await getPocketbaseInstance();
     final currentUserId = pb.authStore.record?.id;
@@ -90,21 +93,35 @@ class ChatService {
       throw Exception('Bạn chưa đăng nhập.');
     }
 
-    final record = await pb.collection(messagesCollection).create(body: {
-      'chat': chatId,
-      'sender': currentUserId,
-      'content': content.trim(),
-      'is_read': false,
-    });
+    if (content.trim().isEmpty && attachment == null) {
+      throw Exception('Vui lòng nhập tin nhắn hoặc chọn tệp đính kèm.');
+    }
+
+    final record = await pb.collection(messagesCollection).create(
+      body: {
+        'chat': chatId,
+        'sender': currentUserId,
+        'content': content.trim(),
+        'is_read': false,
+      },
+      files: attachment != null ? [attachment] : null,
+    );
+
+    final lastMessageLabel = content.trim().isNotEmpty
+        ? content.trim()
+        : attachment != null
+            ? '[Ảnh]'
+            : '';
 
     await pb.collection(chatsCollection).update(chatId, body: {
-      'last_message': content.trim(),
+      'last_message': lastMessageLabel,
       'last_message_at': DateTime.now().toIso8601String(),
       'last_sender': currentUserId,
     });
 
     return ChatMessage.fromRecord(
       record,
+      pb: pb,
       currentUserId: currentUserId,
       authorName: 'Bạn',
     );

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -51,7 +51,8 @@ class ChatService {
         );
 
     return result.items
-        .map((record) => ChatRoom.fromRecord(record, currentUserId: currentUserId))
+        .map((record) =>
+            ChatRoom.fromRecord(record, currentUserId: currentUserId))
         .toList();
   }
 
@@ -104,7 +105,9 @@ class ChatService {
         'content': content.trim(),
         'is_read': false,
       },
-      files: attachment != null ? [attachment] : null,
+      files: attachment != null
+          ? <http.MultipartFile>[attachment]
+          : <http.MultipartFile>[],
     );
 
     final lastMessageLabel = content.trim().isNotEmpty


### PR DESCRIPTION
## Summary
- add support for storing attachment URLs on chat messages and rendering image bubbles
- allow picking images in the chat input and sending them via PocketBase as attachments
- update chat service logic to upload image files, set last message labels, and pass PocketBase clients into message parsing

## Testing
- Not run (Flutter SDK not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69251f5dae14832bb42f43c3b0198a2c)