### PR TITLE
Add realtime friend request and friendship syncing

### DIFF
--- a/lib/pages/social/chat/chat_home_page.dart
+++ b/lib/pages/social/chat/chat_home_page.dart
@@ -65,7 +65,7 @@ class _ChatHomePageState extends State<ChatHomePage> {
             Navigator.of(context).push(
               MaterialPageRoute(
                 builder: (_) => ChangeNotifierProvider(
-                  create: (_) => FriendManager(),
+                  create: (_) => FriendManager()..initialize(),
                   child: const AddFriendPage(),
                 ),
               ),
@@ -78,7 +78,7 @@ class _ChatHomePageState extends State<ChatHomePage> {
             Navigator.of(context).push(
               MaterialPageRoute(
                 builder: (_) => ChangeNotifierProvider(
-                  create: (_) => FriendManager(),
+                  create: (_) => FriendManager()..initialize(),
                   child: const AddFriendPage(),
                 ),
               ),

--- a/lib/pages/social/chat/friend_list_manager.dart
+++ b/lib/pages/social/chat/friend_list_manager.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
 
 import '../../../models/friend_search_result.dart';
 import '../../../services/friendship_service.dart';
+import '../../../services/pocketbase_client.dart';
 
 class FriendListManager extends ChangeNotifier {
   FriendListManager() : _service = FriendshipService();
@@ -11,10 +15,17 @@ class FriendListManager extends ChangeNotifier {
   List<FriendSearchResult> _friends = const <FriendSearchResult>[];
   bool _isLoading = false;
   String? _error;
+  UnsubscribeFunc? _unsubscribe;
+  String? _currentUserId;
 
   List<FriendSearchResult> get friends => _friends;
   bool get isLoading => _isLoading;
   String? get error => _error;
+
+  Future<void> initialize() async {
+    await loadFriends();
+    await _setupRealtime();
+  }
 
   Future<void> loadFriends() async {
     _isLoading = true;
@@ -23,11 +34,84 @@ class FriendListManager extends ChangeNotifier {
 
     try {
       _friends = await _service.fetchFriends();
+      final pb = await getPocketbaseInstance();
+      _currentUserId = pb.authStore.record?.id;
     } catch (_) {
       _error = 'Không thể tải danh sách bạn bè. Vui lòng thử lại.';
     } finally {
       _isLoading = false;
       notifyListeners();
     }
+  }
+
+  Future<void> _setupRealtime() async {
+    final pb = await getPocketbaseInstance();
+    _currentUserId = pb.authStore.record?.id;
+    final userId = _currentUserId;
+
+    if (userId == null) return;
+
+    final oldUnsub = _unsubscribe;
+    _unsubscribe = null;
+    if (oldUnsub != null) {
+      await oldUnsub();
+    }
+
+    try {
+      _unsubscribe = await pb
+          .collection('friendships')
+          .subscribe('*', _handleRealtimeEvent);
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to subscribe friendships: $error');
+      }
+    }
+  }
+
+  Future<void> _handleRealtimeEvent(RecordSubscriptionEvent event) async {
+    final record = event.record;
+    final userId = _currentUserId;
+    if (record == null || userId == null) return;
+
+    final userA = record.getStringValue('user_a');
+    final userB = record.getStringValue('user_b');
+
+    if (userA != userId && userB != userId) return;
+
+    final otherUserId = userA == userId ? userB : userA;
+
+    switch (event.action) {
+      case 'delete':
+        _friends =
+            _friends.where((friend) => friend.user.id != otherUserId).toList();
+        break;
+      case 'create':
+      case 'update':
+        final pb = await getPocketbaseInstance();
+        final friend =
+            await _service.buildFriendFromRecord(pb, record, userId);
+        if (friend == null) break;
+
+        final index =
+            _friends.indexWhere((element) => element.user.id == otherUserId);
+        if (index == -1) {
+          _friends = <FriendSearchResult>[friend, ..._friends];
+        } else {
+          final mutable = [..._friends];
+          mutable[index] = friend;
+          _friends = mutable;
+        }
+        break;
+      default:
+        break;
+    }
+
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_unsubscribe?.call());
+    super.dispose();
   }
 }

--- a/lib/pages/social/chat/friend_manager.dart
+++ b/lib/pages/social/chat/friend_manager.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:badminton_booking_app/models/friend_relation.dart';
 import 'package:badminton_booking_app/models/friend_search_result.dart';
 import 'package:badminton_booking_app/services/friend_request_service.dart';
+import 'package:badminton_booking_app/services/pocketbase_client.dart';
 import 'package:badminton_booking_app/services/user_service.dart';
 import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
 
 class FriendManager extends ChangeNotifier {
   FriendManager()
@@ -23,6 +25,9 @@ class FriendManager extends ChangeNotifier {
 
   final Map<String, FriendRelationStatus> _relations = {};
   final Map<String, bool> _actionLoading = {};
+  UnsubscribeFunc? _requestUnsubscribe;
+  UnsubscribeFunc? _friendshipUnsubscribe;
+  String? _currentUserId;
 
   List<FriendSearchResult> get searchResults => _searchResults;
   bool get isSearching => _isSearching;
@@ -43,7 +48,121 @@ class FriendManager extends ChangeNotifier {
   @override
   void dispose() {
     _searchDebounce?.cancel();
+    unawaited(_requestUnsubscribe?.call());
+    unawaited(_friendshipUnsubscribe?.call());
     super.dispose();
+  }
+
+  Future<void> initialize() async {
+    final pb = await getPocketbaseInstance();
+    _currentUserId = pb.authStore.record?.id;
+    await _setupRealtime(pb);
+  }
+
+  Future<void> _setupRealtime(PocketBase pocketBase) async {
+    final userId = _currentUserId;
+    if (userId == null) return;
+
+    final oldReqUnsub = _requestUnsubscribe;
+    _requestUnsubscribe = null;
+    if (oldReqUnsub != null) {
+      await oldReqUnsub();
+    }
+
+    final oldFriendshipUnsub = _friendshipUnsubscribe;
+    _friendshipUnsubscribe = null;
+    if (oldFriendshipUnsub != null) {
+      await oldFriendshipUnsub();
+    }
+
+    try {
+      _requestUnsubscribe = await pocketBase
+          .collection('friend_requests')
+          .subscribe('*', _handleRequestEvent);
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to subscribe friend requests: $error');
+      }
+    }
+
+    try {
+      _friendshipUnsubscribe = await pocketBase
+          .collection('friendships')
+          .subscribe('*', _handleFriendshipEvent);
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to subscribe friendships: $error');
+      }
+    }
+  }
+
+  Future<void> _handleRequestEvent(RecordSubscriptionEvent event) async {
+    final record = event.record;
+    final userId = _currentUserId;
+    if (record == null || userId == null) return;
+
+    final fromUser = record.getStringValue('from_user');
+    final toUser = record.getStringValue('to_user');
+
+    if (fromUser != userId && toUser != userId) return;
+
+    final otherUserId = fromUser == userId ? toUser : fromUser;
+    final status = record.getStringValue('status');
+
+    switch (event.action) {
+      case 'delete':
+        _relations[otherUserId] = const FriendRelationStatus.none();
+        break;
+      case 'create':
+      case 'update':
+        if (status == 'pending') {
+          final type = toUser == userId
+              ? FriendRelationType.incomingRequest
+              : FriendRelationType.outgoingRequest;
+          _relations[otherUserId] = FriendRelationStatus(
+            type: type,
+            requestId: record.id,
+          );
+        } else if (status == 'accepted') {
+          _relations[otherUserId] =
+              const FriendRelationStatus(type: FriendRelationType.friends);
+        } else {
+          _relations[otherUserId] = const FriendRelationStatus.none();
+        }
+        break;
+      default:
+        break;
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> _handleFriendshipEvent(RecordSubscriptionEvent event) async {
+    final record = event.record;
+    final userId = _currentUserId;
+    if (record == null || userId == null) return;
+
+    final userA = record.getStringValue('user_a');
+    final userB = record.getStringValue('user_b');
+
+    if (userA != userId && userB != userId) return;
+
+    final otherUserId = userA == userId ? userB : userA;
+
+    switch (event.action) {
+      case 'delete':
+        _relations[otherUserId] = const FriendRelationStatus.none();
+        break;
+      case 'create':
+      case 'update':
+        _relations[otherUserId] =
+            const FriendRelationStatus(type: FriendRelationType.friends);
+        break;
+      default:
+        break;
+    }
+
+    notifyListeners();
   }
 
   void searchDebounced(String keyword) {

--- a/lib/pages/social/chat/friend_request_manager.dart
+++ b/lib/pages/social/chat/friend_request_manager.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
+import 'package:pocketbase/pocketbase.dart';
 
 import '../../../models/friend_request.dart';
 import '../../../services/friend_request_service.dart';
+import '../../../services/pocketbase_client.dart';
 
 class FriendRequestManager extends ChangeNotifier {
   FriendRequestManager() : _service = FriendRequestService();
@@ -12,12 +16,19 @@ class FriendRequestManager extends ChangeNotifier {
   bool _isLoading = false;
   String? _error;
   final Map<String, bool> _actionLoading = {};
+  UnsubscribeFunc? _unsubscribe;
+  String? _currentUserId;
 
   List<FriendRequestItem> get incoming => _incoming;
   bool get isLoading => _isLoading;
   String? get error => _error;
 
   bool isProcessing(String requestId) => _actionLoading[requestId] == true;
+
+  Future<void> initialize() async {
+    await loadIncomingRequests();
+    await _setupRealtime();
+  }
 
   Future<void> loadIncomingRequests() async {
     _isLoading = true;
@@ -26,12 +37,79 @@ class FriendRequestManager extends ChangeNotifier {
 
     try {
       _incoming = await _service.fetchIncomingRequests();
+      final pb = await getPocketbaseInstance();
+      _currentUserId = pb.authStore.record?.id;
     } catch (err) {
       _error = 'Không thể tải lời mời kết bạn. Vui lòng thử lại.';
     } finally {
       _isLoading = false;
       notifyListeners();
     }
+  }
+
+  Future<void> _setupRealtime() async {
+    final pb = await getPocketbaseInstance();
+    _currentUserId = pb.authStore.record?.id;
+    final userId = _currentUserId;
+
+    if (userId == null) return;
+
+    final oldUnsub = _unsubscribe;
+    _unsubscribe = null;
+    if (oldUnsub != null) {
+      await oldUnsub();
+    }
+
+    try {
+      _unsubscribe = await pb
+          .collection('friend_requests')
+          .subscribe('*', _handleRealtimeEvent);
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to subscribe friend requests: $error');
+      }
+    }
+  }
+
+  Future<void> _handleRealtimeEvent(RecordSubscriptionEvent event) async {
+    final record = event.record;
+    final userId = _currentUserId;
+    if (record == null || userId == null) return;
+
+    final toUser = record.getStringValue('to_user');
+    if (toUser != userId) return;
+
+    switch (event.action) {
+      case 'delete':
+        _incoming = _incoming.where((req) => req.id != record.id).toList();
+        break;
+      case 'create':
+      case 'update':
+        final status = record.getStringValue('status');
+        if (status != 'pending') {
+          _incoming = _incoming.where((req) => req.id != record.id).toList();
+          break;
+        }
+
+        final pb = await getPocketbaseInstance();
+        final item = await _service.buildIncomingRequestItem(pb, record);
+        if (item == null) break;
+
+        final existingIndex =
+            _incoming.indexWhere((element) => element.id == record.id);
+        if (existingIndex == -1) {
+          _incoming = <FriendRequestItem>[item, ..._incoming];
+        } else {
+          final mutable = [..._incoming];
+          mutable[existingIndex] = item;
+          _incoming = mutable;
+        }
+        break;
+      default:
+        break;
+    }
+
+    notifyListeners();
   }
 
   Future<void> accept(String requestId) async {
@@ -66,5 +144,11 @@ class FriendRequestManager extends ChangeNotifier {
   void _setProcessing(String requestId, bool value) {
     _actionLoading[requestId] = value;
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_unsubscribe?.call());
+    super.dispose();
   }
 }

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -115,11 +115,10 @@ class _SocialPageState extends State<SocialPage> {
                         builder: (_) => MultiProvider(
                           providers: [
                             ChangeNotifierProvider(
-                              create: (_) =>
-                                  FriendRequestManager()..loadIncomingRequests(),
+                              create: (_) => FriendRequestManager()..initialize(),
                             ),
                             ChangeNotifierProvider(
-                              create: (_) => FriendListManager()..loadFriends(),
+                              create: (_) => FriendListManager()..initialize(),
                             ),
                             ChangeNotifierProvider(
                               create: (_) => ChatListManager()..initialize(),

--- a/lib/services/friend_request_service.dart
+++ b/lib/services/friend_request_service.dart
@@ -63,6 +63,41 @@ class FriendRequestService {
     return result;
   }
 
+  Future<FriendRequestItem?> buildIncomingRequestItem(
+    PocketBase pb,
+    RecordModel record,
+  ) async {
+    final fromUserId = record.getStringValue('from_user');
+    if (fromUserId.isEmpty) return null;
+
+    User? fromUser;
+
+    final expanded = record.expand['from_user'] as List<dynamic>?;
+    if (expanded != null && expanded.isNotEmpty) {
+      final expandedUser = expanded.first;
+      if (expandedUser is RecordModel) {
+        fromUser = User.fromJson(expandedUser.toJson());
+      }
+    }
+
+    fromUser ??= User(id: fromUserId, username: '', email: '', phone: '');
+
+    final details = await _userDetailsService.getByUserIdWithClient(
+      pb,
+      fromUserId,
+    );
+
+    final createdAt = DateTime.tryParse(record.getStringValue('created')) ??
+        DateTime.now();
+
+    return FriendRequestItem(
+      id: record.id,
+      from: FriendSearchResult(user: fromUser, details: details),
+      createdAt: createdAt,
+      timeLabel: formatRelativeTime(createdAt),
+    );
+  }
+
   Future<String?> getPendingRequestIdTo(String toUserId) async {
     try {
       final pb = await getPocketbaseInstance();

--- a/lib/services/friendship_service.dart
+++ b/lib/services/friendship_service.dart
@@ -62,4 +62,54 @@ class FriendshipService {
 
     return results;
   }
+
+  Future<FriendSearchResult?> buildFriendFromRecord(
+    PocketBase pb,
+    RecordModel record,
+    String currentUserId,
+  ) async {
+    final userAId = record.getStringValue('user_a');
+    final userBId = record.getStringValue('user_b');
+    final otherUserId = userAId == currentUserId ? userBId : userAId;
+
+    if (otherUserId.isEmpty) return null;
+
+    User? otherUser;
+
+    final userAExpanded = record.expand['user_a'] as List<dynamic>?;
+    final userBExpanded = record.expand['user_b'] as List<dynamic>?;
+
+    if (userAExpanded != null && userAExpanded.isNotEmpty) {
+      final expandedUser = userAExpanded.first;
+      if (expandedUser is RecordModel && expandedUser.id == otherUserId) {
+        otherUser = User.fromJson(expandedUser.toJson());
+      }
+    }
+
+    if (otherUser == null && userBExpanded != null && userBExpanded.isNotEmpty) {
+      final expandedUser = userBExpanded.first;
+      if (expandedUser is RecordModel && expandedUser.id == otherUserId) {
+        otherUser = User.fromJson(expandedUser.toJson());
+      }
+    }
+
+    try {
+      final userRecord = await pb.collection('users').getOne(otherUserId);
+      otherUser = User.fromJson(userRecord.toJson());
+    } catch (_) {
+      otherUser ??= User(
+        id: otherUserId,
+        username: '',
+        email: '',
+        phone: '',
+      );
+    }
+
+    final details = await _userDetailsService.getByUserIdWithClient(
+      pb,
+      otherUserId,
+    );
+
+    return FriendSearchResult(user: otherUser, details: details);
+  }
 }


### PR DESCRIPTION
## Summary
- add realtime subscriptions for incoming friend requests and map realtime records into UI models
- keep friend relations and friend list in sync via friendship collection updates and new helpers
- initialize friend-related managers with realtime listeners when opening chat screens
