### PR TITLE
Add recruitment applicant management and closing controls

### DIFF
--- a/lib/components/create_post.dart
+++ b/lib/components/create_post.dart
@@ -49,14 +49,15 @@ class CreatePostBar extends StatelessWidget {
     return Material(
       elevation: elevation,
       color: Colors.transparent,
-      borderRadius: BorderRadius.circular(16),
+      borderRadius: BorderRadius.circular(28),
+      shadowColor: Colors.black.withOpacity(0.1),
       child: Container(
         decoration: BoxDecoration(
           color: backgroundColor ?? theme.cardColor,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: colorScheme.outline),
+          borderRadius: BorderRadius.circular(28),
+          border: Border.all(color: colorScheme.outline.withOpacity(0.8)),
         ),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 20),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -64,7 +65,7 @@ class CreatePostBar extends StatelessWidget {
             Row(
               children: [
                 _Avatar(imageProvider: avatarImageProvider),
-                const SizedBox(width: 10),
+                const SizedBox(width: 12),
                 Expanded(
                   child: _FakeInput(
                     hintText: hintText,
@@ -73,29 +74,34 @@ class CreatePostBar extends StatelessWidget {
                 ),
               ],
             ),
-            if (!compact) const SizedBox(height: 8),
+            if (!compact) const SizedBox(height: 12),
             if (!compact)
               Divider(
-                height: 16,
-                thickness: 0.8,
-                color: theme.dividerColor.withOpacity(0.6),
+                height: 1,
+                thickness: 1,
+                color: theme.dividerColor.withOpacity(0.4),
               ),
-            if (!compact) const SizedBox(height: 2),
+            if (!compact) const SizedBox(height: 12),
             if (!compact)
               Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
-                  _Action(
-                    icon: Icons.photo_library_outlined,
-                    label: 'Ảnh',
-                    onTap: onPickPhoto,
-                    activeColor: basePrimary,
+                  Expanded(
+                    child: _Action(
+                      icon: Icons.photo_library_outlined,
+                      label: 'Ảnh',
+                      onTap: onPickPhoto,
+                      activeColor: basePrimary,
+                    ),
                   ),
-                  _Action(
-                    icon: Icons.person_add_alt_1_outlined,
-                    label: 'Mời bạn bè',
-                    onTap: onInviteFriends,
-                    activeColor: basePrimary,
+                  const SizedBox(width: 16), // Thêm khoảng cách giữa hai nút
+                  Expanded(
+                    child: _Action(
+                      icon: Icons.person_add_alt_1_outlined,
+                      label: 'Mời bạn bè',
+                      onTap: onInviteFriends,
+                      activeColor: basePrimary,
+                    ),
                   ),
                 ],
               ),
@@ -114,13 +120,23 @@ class _Avatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return CircleAvatar(
-      radius: 30,
-      backgroundColor: theme.colorScheme.surfaceVariant,
-      backgroundImage: imageProvider,
-      child: imageProvider == null
-          ? Icon(Icons.person, color: theme.colorScheme.onSurfaceVariant)
-          : null,
+    return Container(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: theme.colorScheme.primary.withOpacity(0.2),
+          width: 2,
+        ),
+      ),
+      child: CircleAvatar(
+        radius: 24,
+        backgroundColor: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+        backgroundImage: imageProvider,
+        child: imageProvider == null
+            ? Icon(Icons.person_rounded,
+                color: theme.colorScheme.primary, size: 28)
+            : null,
+      ),
     );
   }
 }
@@ -141,24 +157,32 @@ class _FakeInput extends StatelessWidget {
 
     return InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(24),
+      borderRadius: BorderRadius.circular(28),
       child: Container(
-        height: 55,
-        padding: const EdgeInsets.symmetric(horizontal: 14),
+        height: 48,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
         alignment: Alignment.centerLeft,
         decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
-          borderRadius: BorderRadius.circular(24),
-          border: Border.all(color: cs.outline),
+          color: theme.colorScheme.surfaceVariant.withOpacity(0.3),
+          borderRadius: BorderRadius.circular(28),
+          border: Border.all(color: cs.outline.withOpacity(0.2)),
         ),
-        child: Text(
-          hintText,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.bodyMedium?.copyWith(
-            fontSize: 16, // ✅ thêm dòng này để tăng font size
-            color: theme.hintColor,
-          ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                hintText,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontSize: 16,
+                  color: theme.hintColor.withOpacity(0.8),
+                ),
+              ),
+            ),
+            Icon(Icons.edit_rounded,
+                size: 20, color: cs.primary.withOpacity(0.7)),
+          ],
         ),
       ),
     );
@@ -183,33 +207,36 @@ class _Action extends StatelessWidget {
     final theme = Theme.of(context);
     final isEnabled = onTap != null;
 
-    return Expanded(
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
-        child: Container(
-          height: 40,
-          alignment: Alignment.center,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                icon,
-                size: 20,
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        height: 44,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: isEnabled
+              ? activeColor.withOpacity(0.1)
+              : theme.disabledColor.withOpacity(0.1),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 22,
+              color: isEnabled ? activeColor : theme.disabledColor,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                fontSize: 15,
                 color: isEnabled ? activeColor : theme.disabledColor,
               ),
-              const SizedBox(width: 6),
-              Text(
-                label,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: isEnabled
-                      ? theme.textTheme.bodyMedium?.color
-                      : theme.disabledColor,
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/components/my_court_time.dart
+++ b/lib/components/my_court_time.dart
@@ -391,7 +391,8 @@ class _CourtTimelineState extends State<CourtTimeline> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final dividerColor = cs.outline;
+    final dividerColor = cs.outlineVariant
+        .withOpacity(0.5); // Softer divider for better aesthetics
     final colors = _SlotColors.fromColorScheme(cs);
 
     return Column(
@@ -400,7 +401,12 @@ class _CourtTimelineState extends State<CourtTimeline> {
           height: widget.headerHeight,
           decoration: BoxDecoration(
             color: const Color(0xFFBDEFFF),
-            border: Border(bottom: BorderSide(color: dividerColor)),
+            border: Border(
+                bottom: BorderSide(
+                    color: dividerColor,
+                    width: 1.5)), // Thicker border for emphasis
+            borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(8)), // Rounded top corners
           ),
           child: Row(
             children: [
@@ -414,7 +420,9 @@ class _CourtTimelineState extends State<CourtTimeline> {
                     child: Padding(
                       padding: EdgeInsets.only(left: widget.leftColumnWidth),
                       child: SizedBox(
-                        width: _totalWidth + widget.headerLeadingInset,
+                        width: _totalWidth +
+                            widget.headerLeadingInset +
+                            20, // Extra padding to prevent label cutoff
                         height: widget.headerHeight,
                         child: CustomPaint(
                           painter: _TimeHeaderPainterHalfHour(
@@ -423,11 +431,12 @@ class _CourtTimelineState extends State<CourtTimeline> {
                             slotWidth: widget.slotWidth,
                             leadingInset: widget.headerLeadingInset,
                             hourTickColor: const Color(0xFFFFB300),
-                            halfTickColor: const Color(0xFFFFB300),
+                            halfTickColor: const Color(0xFFFFB300)
+                                .withOpacity(0.7), // Softer half tick
                             hourTickStroke: 2.5,
                             halfTickStroke: 2.0,
-                            hourTickHeight: 16,
-                            halfTickHeight: 12,
+                            hourTickHeight: 18, // Slightly taller ticks
+                            halfTickHeight: 14,
                             textStyle: const TextStyle(
                               fontSize: 14,
                               fontWeight: FontWeight.w600,
@@ -448,8 +457,17 @@ class _CourtTimelineState extends State<CourtTimeline> {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              SizedBox(
+              Container(
                 width: widget.leftColumnWidth,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFE7FFF0),
+                  border: Border(
+                      right: BorderSide(
+                          color: dividerColor,
+                          width: 1.5)), // Right border for separation
+                  borderRadius: const BorderRadius.vertical(
+                      bottom: Radius.circular(8)), // Rounded bottom corners
+                ),
                 child: Scrollbar(
                   controller: _leftColumnCtrl,
                   child: ListView.separated(
@@ -458,12 +476,18 @@ class _CourtTimelineState extends State<CourtTimeline> {
                     itemCount: widget.rows.length,
                     itemBuilder: (_, index) => Container(
                       height: widget.rowHeight,
-                      color: const Color(0xFFE7FFF0),
                       alignment: Alignment.centerLeft,
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal:
+                              16), // Increased padding for better spacing
                       child: Text(
                         widget.rows[index].label,
-                        style: const TextStyle(fontWeight: FontWeight.w600),
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 15, // Slightly larger font for readability
+                          color:
+                              Color(0xFF123B28), // Matching header text color
+                        ),
                       ),
                     ),
                     separatorBuilder: (_, __) =>
@@ -473,13 +497,15 @@ class _CourtTimelineState extends State<CourtTimeline> {
               ),
               Expanded(
                 child: Container(
-                  decoration: const BoxDecoration(
+                  decoration: BoxDecoration(
                     border: Border(
                       bottom: BorderSide(
-                        color: Colors.black,
-                        width: 2,
+                        color: dividerColor,
+                        width: 1.5,
                       ),
                     ),
+                    borderRadius: const BorderRadius.vertical(
+                        bottom: Radius.circular(8)), // Rounded bottom corners
                   ),
                   child: Scrollbar(
                     controller: _gridCtrl,
@@ -488,7 +514,8 @@ class _CourtTimelineState extends State<CourtTimeline> {
                       controller: _gridCtrl,
                       scrollDirection: Axis.horizontal,
                       child: SizedBox(
-                        width: _totalWidth,
+                        width:
+                            _totalWidth + 20, // Extra width to prevent cutoff
                         child: Scrollbar(
                           controller: _gridVerticalCtrl,
                           child: ListView.separated(
@@ -603,8 +630,14 @@ class _TimeHeaderPainterHalfHour extends CustomPainter {
           DateFormat('H:00').format(DateTime(2000, 1, 1, hourVal));
       tp.text = TextSpan(text: labelHour, style: textStyle);
       tp.layout();
-      final hourTx = hourX - tp.width / 2;
+      double hourTx = hourX - tp.width / 2;
       final hourTy = hourTop - tp.height - 2;
+
+      // Adjust last label to prevent cutoff
+      if (i == slotCount && hourTx + tp.width > size.width) {
+        hourTx = size.width - tp.width - 4; // Align to right with small padding
+      }
+
       tp.paint(canvas, Offset(hourTx, hourTy));
 
       if (showHalf && i < slotCount) {

--- a/lib/components/my_text_field.dart
+++ b/lib/components/my_text_field.dart
@@ -31,7 +31,7 @@ class MyTextfield extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final radius = BorderRadius.circular(18);
+    final radius = BorderRadius.circular(28);
 
     return TextFormField(
       onTap: onTap,
@@ -46,20 +46,25 @@ class MyTextfield extends StatelessWidget {
         prefixIcon: prefixIcon,
         suffixIcon: suffixIcon,
         filled: true,
-        fillColor: cs.surfaceVariant.withOpacity(0.6),
+        fillColor: cs.surfaceVariant.withOpacity(0.3),
+        hintStyle: TextStyle(color: cs.onSurfaceVariant.withOpacity(0.7)),
         contentPadding:
-            const EdgeInsets.symmetric(vertical: 18, horizontal: 18),
+            const EdgeInsets.symmetric(vertical: 20, horizontal: 20),
         border: OutlineInputBorder(
           borderRadius: radius,
-          borderSide: BorderSide(color: cs.outline.withOpacity(0.15)),
+          borderSide: BorderSide(color: cs.outline.withOpacity(0.1)),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: radius,
-          borderSide: BorderSide(color: cs.outline.withOpacity(0.12)),
+          borderSide: BorderSide(color: cs.outline.withOpacity(0.1)),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: radius,
-          borderSide: BorderSide(color: cs.primary, width: 1.6),
+          borderSide: BorderSide(color: cs.primary, width: 2.0),
+        ),
+        disabledBorder: OutlineInputBorder(
+          borderRadius: radius,
+          borderSide: BorderSide(color: cs.outline.withOpacity(0.05)),
         ),
       ),
       validator: validator,

--- a/lib/components/post_comments_sheet.dart
+++ b/lib/components/post_comments_sheet.dart
@@ -85,76 +85,144 @@ class _PostCommentsSheetState extends State<PostCommentsSheet> {
               widget.manager.isSubmittingComment(widget.postId);
 
           return Container(
-            padding: EdgeInsets.fromLTRB(16, 12, 16, 12 + bottomInset),
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomInset),
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surface,
+              color: cs.surface,
               borderRadius:
-                  const BorderRadius.vertical(top: Radius.circular(20)),
+                  const BorderRadius.vertical(top: Radius.circular(28)),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.1),
+                  blurRadius: 30,
+                  offset: const Offset(0, -10),
+                ),
+              ],
             ),
             child: SizedBox(
               height: height,
               child: Column(
                 mainAxisSize: MainAxisSize.max,
                 children: [
+                  // Modern drag handle
                   Container(
-                    width: 40,
+                    width: 48,
                     height: 4,
-                    margin: const EdgeInsets.only(bottom: 12),
+                    margin: const EdgeInsets.only(bottom: 20),
                     decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.outlineVariant,
-                      borderRadius: BorderRadius.circular(12),
+                      color: cs.outlineVariant.withOpacity(0.5),
+                      borderRadius: BorderRadius.circular(2),
                     ),
                   ),
                   Expanded(
                     child: isLoading
-                        ? const Center(child: CircularProgressIndicator())
+                        ? Center(
+                            child: CircularProgressIndicator(
+                              color: cs.primary,
+                              strokeWidth: 2.5,
+                            ),
+                          )
                         : comments.isEmpty
-                            ? const Center(
-                                child: Text('Chưa có bình luận nào.'))
+                            ? Center(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(
+                                      Icons.comment_outlined,
+                                      size: 64,
+                                      color: cs.outlineVariant,
+                                    ),
+                                    const SizedBox(height: 16),
+                                    Text(
+                                      'Chưa có bình luận nào',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium
+                                          ?.copyWith(
+                                            color: cs.onSurfaceVariant,
+                                          ),
+                                    ),
+                                    const SizedBox(height: 8),
+                                    Text(
+                                      'Hãy là người đầu tiên bình luận!',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .bodyMedium
+                                          ?.copyWith(
+                                            color: cs.outlineVariant,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              )
                             : ListView.separated(
                                 padding: EdgeInsets.zero,
+                                physics: const ClampingScrollPhysics(),
                                 itemCount: comments.length,
                                 separatorBuilder: (_, __) =>
-                                    const Divider(height: 16),
+                                    const SizedBox(height: 16),
                                 itemBuilder: (_, index) {
                                   final comment = comments[index];
                                   return _CommentTile(comment: comment);
                                 },
                               ),
                   ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: TextField(
-                          controller: _controller,
-                          focusNode: _focusNode,
-                          textInputAction: TextInputAction.send,
-                          onSubmitted: (_) => _submit(),
-                          decoration: const InputDecoration(
-                            hintText: 'Viết bình luận...',
-                            border: OutlineInputBorder(),
-                            isDense: true,
+                  const SizedBox(height: 16),
+                  // Modern input bar
+                  Container(
+                    padding: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: cs.surfaceVariant.withOpacity(0.5),
+                      borderRadius: BorderRadius.circular(28),
+                    ),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: TextField(
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            textInputAction: TextInputAction.send,
+                            onSubmitted: (_) => _submit(),
+                            decoration: InputDecoration(
+                              hintText: 'Viết bình luận của bạn...',
+                              hintStyle: TextStyle(color: cs.outlineVariant),
+                              border: InputBorder.none,
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 20,
+                                vertical: 16,
+                              ),
+                              isDense: true,
+                            ),
+                            style: Theme.of(context).textTheme.bodyLarge,
                           ),
                         ),
-                      ),
-                      const SizedBox(width: 12),
-                      ElevatedButton(
-                        onPressed: isSubmitting ? null : _submit,
-                        child: isSubmitting
-                            ? const SizedBox(
-                                height: 18,
-                                width: 18,
-                                child:
-                                    CircularProgressIndicator(strokeWidth: 2.2),
-                              )
-                            : Icon(
-                                Icons.send_rounded,
-                                size: 20,
-                                color: cs.onPrimary,
-                              ),
-                      ),
-                    ],
+                        const SizedBox(width: 4),
+                        Material(
+                          color: cs.primary,
+                          borderRadius: BorderRadius.circular(24),
+                          child: InkWell(
+                            onTap: isSubmitting ? null : _submit,
+                            borderRadius: BorderRadius.circular(24),
+                            child: Container(
+                              padding: const EdgeInsets.all(12),
+                              child: isSubmitting
+                                  ? SizedBox(
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2.2,
+                                        color: cs.onPrimary,
+                                      ),
+                                    )
+                                  : Icon(
+                                      Icons.send_rounded,
+                                      size: 20,
+                                      color: cs.onPrimary,
+                                    ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ],
               ),
@@ -174,64 +242,107 @@ class _CommentTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        CircleAvatar(
-          radius: 18,
-          backgroundColor:
-              comment.authorAvatarUrl == null ? cs.primary : Colors.transparent,
-          backgroundImage: comment.authorAvatarUrl != null
-              ? NetworkImage(comment.authorAvatarUrl!)
-              : null,
-          child: comment.authorAvatarUrl == null
-              ? Text(
-                  comment.authorName.isNotEmpty
-                      ? comment.authorName[0].toUpperCase()
-                      : 'U',
-                  style: TextStyle(
-                    color: cs.onPrimary,
-                    fontWeight: FontWeight.w700,
-                  ),
-                )
-              : null,
-        ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                comment.authorName,
-                style: const TextStyle(fontWeight: FontWeight.w600),
-              ),
-              const SizedBox(height: 4),
-              Text(comment.content),
-              const SizedBox(height: 6),
-              Text(
-                _timeAgo(comment.createdAt),
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: cs.onSurfaceVariant,
-                    ),
-              ),
-            ],
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Avatar with subtle ring
+          Container(
+            padding: const EdgeInsets.all(2),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: cs.primary.withOpacity(0.1),
+            ),
+            child: CircleAvatar(
+              radius: 20,
+              backgroundColor: comment.authorAvatarUrl == null
+                  ? cs.primary
+                  : Colors.transparent,
+              backgroundImage: comment.authorAvatarUrl != null
+                  ? NetworkImage(comment.authorAvatarUrl!)
+                  : null,
+              child: comment.authorAvatarUrl == null
+                  ? Text(
+                      comment.authorName.isNotEmpty
+                          ? comment.authorName[0].toUpperCase()
+                          : 'U',
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                    )
+                  : null,
+            ),
           ),
-        ),
-      ],
+          const SizedBox(width: 12),
+          Expanded(
+            child: Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: cs.surfaceVariant.withOpacity(0.4),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Name + Time on same row
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          comment.authorName,
+                          style: const TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: Color(0xFF1D1D1F),
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        _timeAgo(comment.createdAt),
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: cs.outlineVariant,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  // Content
+                  Text(
+                    comment.content,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      height: 1.4,
+                      color: Color(0xFF1D1D1F),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
   String _timeAgo(DateTime t) {
     final diff = DateTime.now().difference(t);
     if (diff.inMinutes < 1) return 'Vừa xong';
-    if (diff.inMinutes < 60) return '${diff.inMinutes} phút trước';
-    if (diff.inHours < 24) return '${diff.inHours} giờ trước';
-    if (diff.inDays < 7) return '${diff.inDays} ngày trước';
+    if (diff.inMinutes < 60) return '${diff.inMinutes} phút';
+    if (diff.inHours < 24) return '${diff.inHours} giờ';
+    if (diff.inDays < 7) return '${diff.inDays} ngày';
     final weeks = (diff.inDays / 7).floor();
-    if (weeks < 5) return '$weeks tuần trước';
+    if (weeks < 5) return '$weeks tuần';
     final months = (diff.inDays / 30).floor();
-    if (months < 12) return '$months tháng trước';
+    if (months < 12) return '$months tháng';
     final years = (diff.inDays / 365).floor();
-    return '$years năm trước';
+    return '$years năm';
   }
 }

--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -46,15 +46,14 @@ class RecruitmentPostCard extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
     final totalSlots = requiredPlayers <= 0 ? joinedPlayers : requiredPlayers;
-    final progress = totalSlots == 0
-        ? 0.0
-        : (joinedPlayers / totalSlots).clamp(0, 1).toDouble();
+    final progress =
+        totalSlots == 0 ? 0.0 : (joinedPlayers / totalSlots).clamp(0.0, 1.0);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Material(
-        elevation: 6,
-        borderRadius: BorderRadius.circular(24),
+        elevation: 4,
+        borderRadius: BorderRadius.circular(28),
         color: cs.surface,
         child: Padding(
           padding: const EdgeInsets.all(20),
@@ -63,109 +62,105 @@ class RecruitmentPostCard extends StatelessWidget {
             children: [
               _buildHeader(context, textTheme),
               if (description != null && description!.isNotEmpty) ...[
-                const SizedBox(height: 12),
+                const SizedBox(height: 16),
                 Text(
                   description!,
-                  style: textTheme.bodyMedium?.copyWith(color: cs.onSurface),
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: cs.onSurface.withOpacity(0.85),
+                    height: 1.4,
+                  ),
                 ),
               ],
-              const SizedBox(height: 16),
+              const SizedBox(height: 20),
+              // Player count with modern styling
               Row(
                 children: [
-                  Icon(Icons.group_outlined, color: cs.primary),
-                  const SizedBox(width: 8),
+                  Icon(Icons.group_rounded, color: cs.primary, size: 22),
+                  const SizedBox(width: 10),
                   Expanded(
                     child: Text(
                       'Đã có $joinedPlayers / $requiredPlayers thành viên',
-                      style: textTheme.bodyMedium?.copyWith(
+                      style: textTheme.titleSmall?.copyWith(
                         fontWeight: FontWeight.w600,
+                        color: cs.onSurface,
                       ),
-                    ),
-                  ),
-                  FilledButton.icon(
-                    onPressed: (!isActive || isJoined || isOwner || isJoinLoading)
-                        ? null
-                        : onJoin,
-                    icon: isJoinLoading
-                        ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Icon(
-                            isActive
-                                ? (isJoined
-                                    ? Icons.check_circle
-                                    : Icons.add_circle_outline)
-                                : Icons.lock_outline,
-                          ),
-                    label: Text(
-                      isOwner
-                          ? 'Bài của bạn'
-                          : !isActive
-                              ? 'Đã đóng'
-                              : isJoined
-                                  ? 'Đã tham gia'
-                                  : 'Tham gia',
                     ),
                   ),
                 ],
               ),
-              if (isOwner && onManage != null) ...[
-                const SizedBox(height: 8),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: TextButton.icon(
-                    onPressed: onManage,
-                    icon: const Icon(Icons.assignment_ind_outlined),
-                    label: const Text('Quản lý yêu cầu'),
-                  ),
-                ),
-              ],
               const SizedBox(height: 12),
+              // Progress bar with capsule shape
               ClipRRect(
                 borderRadius: BorderRadius.circular(50),
                 child: LinearProgressIndicator(
                   value: progress,
                   minHeight: 8,
-                  backgroundColor: cs.surfaceVariant,
-                  color: cs.primary,
+                  backgroundColor: cs.surfaceVariant.withOpacity(0.5),
+                  valueColor: AlwaysStoppedAnimation<Color>(cs.primary),
                 ),
               ),
               const SizedBox(height: 20),
+              // Chips section
               Wrap(
-                spacing: 8,
-                runSpacing: 8,
+                spacing: 10,
+                runSpacing: 10,
                 children: [
                   if (skillLevel != null && skillLevel!.isNotEmpty)
                     _InfoChip(
                       icon: Icons.stars_rounded,
                       label: 'Trình độ: $skillLevel',
-                      color: cs.primaryContainer,
+                      color: cs.primaryContainer.withOpacity(0.8),
                       iconColor: cs.primary,
                     ),
                   if (playStyle != null && playStyle!.isNotEmpty)
                     _InfoChip(
-                      icon: Icons.sports_tennis,
+                      icon: Icons.sports_tennis_rounded,
                       label: 'Lối chơi: $playStyle',
-                      color: cs.secondaryContainer,
+                      color: cs.secondaryContainer.withOpacity(0.8),
                       iconColor: cs.secondary,
                     ),
                   if (courtName != null && courtName!.isNotEmpty)
                     _InfoChip(
-                      icon: Icons.location_on_outlined,
+                      icon: Icons.location_on_rounded,
                       label: 'Sân: $courtName',
-                      color: cs.tertiaryContainer,
+                      color: cs.tertiaryContainer.withOpacity(0.8),
                       iconColor: cs.tertiary,
                     ),
                   if (playTime != null)
                     _InfoChip(
-                      icon: Icons.access_time,
+                      icon: Icons.access_time_rounded,
                       label:
                           'Giờ đánh: ${DateFormat('HH:mm - dd/MM').format(playTime!)}',
-                      color: cs.surfaceVariant,
+                      color: cs.surfaceVariant.withOpacity(0.8),
                       iconColor: cs.primary,
                     ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              // Professional button layout: Full-width for main action, secondary aligned right
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _buildActionButton(context),
+                  if (isOwner && onManage != null) ...[
+                    const SizedBox(height: 12),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: OutlinedButton.icon(
+                        onPressed: onManage,
+                        icon: Icon(Icons.assignment_ind_rounded, size: 20),
+                        label: const Text('Quản lý yêu cầu'),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: cs.primary,
+                          side: BorderSide(color: cs.primary.withOpacity(0.5)),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 20, vertical: 12),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(24)),
+                        ),
+                      ),
+                    ),
+                  ],
                 ],
               ),
             ],
@@ -178,7 +173,7 @@ class RecruitmentPostCard extends StatelessWidget {
   Widget _buildHeader(BuildContext context, TextTheme textTheme) {
     final cs = Theme.of(context).colorScheme;
     return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         CircleAvatar(
           radius: 26,
@@ -205,6 +200,7 @@ class RecruitmentPostCard extends StatelessWidget {
                 hostName,
                 style: textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.w700,
+                  fontSize: 18,
                 ),
               ),
               const SizedBox(height: 4),
@@ -216,20 +212,25 @@ class RecruitmentPostCard extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(width: 12),
         Container(
           decoration: BoxDecoration(
-            color: isActive ? cs.primaryContainer : cs.surfaceVariant,
-            borderRadius: BorderRadius.circular(16),
+            color: isActive
+                ? cs.primaryContainer.withOpacity(0.9)
+                : cs.surfaceVariant.withOpacity(0.9),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+                color: isActive
+                    ? cs.primary.withOpacity(0.3)
+                    : cs.outline.withOpacity(0.3)),
           ),
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
               Icon(
-                isActive ? Icons.bolt : Icons.lock,
+                isActive ? Icons.bolt_rounded : Icons.lock_rounded,
                 color: isActive ? cs.primary : cs.onSurfaceVariant,
-                size: 16,
+                size: 18,
               ),
               const SizedBox(width: 6),
               Text(
@@ -243,6 +244,50 @@ class RecruitmentPostCard extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildActionButton(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    final bool isDisabled = !isActive || isJoined || isOwner || isJoinLoading;
+
+    return FilledButton.icon(
+      onPressed: isDisabled ? null : onJoin,
+      style: FilledButton.styleFrom(
+        minimumSize: const Size(double.infinity, 50),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+        elevation: isDisabled ? 0 : 2,
+        backgroundColor: isDisabled ? cs.surfaceVariant : cs.primary,
+        foregroundColor: isDisabled ? cs.onSurfaceVariant : cs.onPrimary,
+      ),
+      icon: isJoinLoading
+          ? SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                strokeWidth: 2.5,
+                color: cs.onPrimary,
+              ),
+            )
+          : Icon(
+              isActive
+                  ? (isJoined
+                      ? Icons.check_circle_rounded
+                      : Icons.add_circle_rounded)
+                  : Icons.lock_rounded,
+              size: 22,
+            ),
+      label: Text(
+        isOwner
+            ? 'Bài của bạn'
+            : !isActive
+                ? 'Đã đóng'
+                : isJoined
+                    ? 'Đã tham gia'
+                    : 'Tham gia',
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+      ),
     );
   }
 }
@@ -264,24 +309,26 @@ class _InfoChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
       decoration: BoxDecoration(
         color: color,
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(color: cs.outline.withOpacity(0.2)),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: cs.outline.withOpacity(0.15)),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(icon, size: 16, color: iconColor),
-          const SizedBox(width: 6),
-          Text(
-            label,
-            style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: Theme.of(context).colorScheme.onSurface,
-                ),
-            overflow: TextOverflow.ellipsis,
+          Icon(icon, size: 18, color: iconColor),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: cs.onSurface,
+                  ),
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       ),

--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -17,6 +17,8 @@ class RecruitmentPostCard extends StatelessWidget {
   final bool isJoined;
   final bool isOwner;
   final bool isJoinLoading;
+  final bool isActive;
+  final VoidCallback? onManage;
 
   const RecruitmentPostCard({
     super.key,
@@ -35,6 +37,8 @@ class RecruitmentPostCard extends StatelessWidget {
     this.isJoined = false,
     this.isOwner = false,
     this.isJoinLoading = false,
+    this.isActive = true,
+    this.onManage,
   });
 
   @override
@@ -79,27 +83,45 @@ class RecruitmentPostCard extends StatelessWidget {
                     ),
                   ),
                   FilledButton.icon(
-                    onPressed:
-                        (isJoined || isOwner || isJoinLoading) ? null : onJoin,
+                    onPressed: (!isActive || isJoined || isOwner || isJoinLoading)
+                        ? null
+                        : onJoin,
                     icon: isJoinLoading
                         ? const SizedBox(
                             width: 18,
                             height: 18,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : Icon(isJoined
-                            ? Icons.check_circle
-                            : Icons.add_circle_outline),
+                        : Icon(
+                            isActive
+                                ? (isJoined
+                                    ? Icons.check_circle
+                                    : Icons.add_circle_outline)
+                                : Icons.lock_outline,
+                          ),
                     label: Text(
                       isOwner
                           ? 'Bài của bạn'
-                          : isJoined
-                              ? 'Đã tham gia'
-                              : 'Tham gia',
+                          : !isActive
+                              ? 'Đã đóng'
+                              : isJoined
+                                  ? 'Đã tham gia'
+                                  : 'Tham gia',
                     ),
                   ),
                 ],
               ),
+              if (isOwner && onManage != null) ...[
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: onManage,
+                    icon: const Icon(Icons.assignment_ind_outlined),
+                    label: const Text('Quản lý yêu cầu'),
+                  ),
+                ),
+              ],
               const SizedBox(height: 12),
               ClipRRect(
                 borderRadius: BorderRadius.circular(50),
@@ -197,19 +219,23 @@ class RecruitmentPostCard extends StatelessWidget {
         const SizedBox(width: 12),
         Container(
           decoration: BoxDecoration(
-            color: cs.primaryContainer,
+            color: isActive ? cs.primaryContainer : cs.surfaceVariant,
             borderRadius: BorderRadius.circular(16),
           ),
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.bolt, color: cs.primary, size: 16),
+              Icon(
+                isActive ? Icons.bolt : Icons.lock,
+                color: isActive ? cs.primary : cs.onSurfaceVariant,
+                size: 16,
+              ),
               const SizedBox(width: 6),
               Text(
-                'Tuyển gấp',
+                isActive ? 'Đang tuyển' : 'Đã đóng',
                 style: textTheme.labelMedium?.copyWith(
-                  color: cs.primary,
+                  color: isActive ? cs.primary : cs.onSurfaceVariant,
                   fontWeight: FontWeight.w700,
                 ),
               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,28 +71,65 @@ class SplashScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final size = MediaQuery.of(context).size;
-    final logoSize = size.width * 0.5;
+    final logoSize = size.width * 0.45;
 
     return Scaffold(
-      backgroundColor: colorScheme.background,
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Image.asset(
-              "assets/images/logo_splash.png",
-              width: logoSize,
-              height: logoSize,
-            ),
-            Text(
-              "C O U R T I F Y",
-              style: TextStyle(
-                fontSize: 30,
-                fontWeight: FontWeight.bold,
-                color: colorScheme.onBackground,
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              colorScheme.primary.withOpacity(0.95),
+              colorScheme.primary.withOpacity(0.75)
+            ],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  boxShadow: [
+                    BoxShadow(
+                      color: colorScheme.primary.withOpacity(0.3),
+                      blurRadius: 20,
+                      offset: const Offset(0, 8),
+                    ),
+                  ],
+                ),
+                child: ClipOval(
+                  child: Image.asset(
+                    "assets/images/logo_splash.png",
+                    width: logoSize,
+                    height: logoSize,
+                    fit: BoxFit.cover,
+                  ),
+                ),
               ),
-            ),
-          ],
+              const SizedBox(height: 24),
+              Text(
+                "C O U R T I F Y",
+                style: TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 2.0,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: 40,
+                height: 40,
+                child: CircularProgressIndicator(
+                  strokeWidth: 3,
+                  color: Colors.white.withOpacity(0.8),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/models/recruitment_applicant.dart
+++ b/lib/models/recruitment_applicant.dart
@@ -1,0 +1,56 @@
+import '../utils/pocketbase_utils.dart';
+import '../utils/recruitment_dictionary.dart';
+
+class RecruitmentApplicant {
+  const RecruitmentApplicant({
+    required this.id,
+    required this.userId,
+    required this.displayName,
+    required this.status,
+    required this.createdAt,
+    this.avatarUrl,
+    this.level,
+    this.playStyles = const [],
+  });
+
+  factory RecruitmentApplicant.fromJson(Map<String, dynamic> json) {
+    return RecruitmentApplicant(
+      id: json['id'] as String,
+      userId: json['user_id'] as String,
+      displayName: sanitizeDisplayName(json['display_name'] as String?),
+      status: json['status'] as String? ?? 'pending',
+      avatarUrl: json['avatar_url'] as String?,
+      level: RecruitmentDictionary.skillLabelFromValue(json['level']),
+      playStyles: (json['play_styles'] as List?)
+              ?.map((e) => RecruitmentDictionary.playStyleLabelFromValue(e))
+              .whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+  }
+
+  final String id;
+  final String userId;
+  final String displayName;
+  final String status;
+  final DateTime createdAt;
+  final String? avatarUrl;
+  final String? level;
+  final List<String> playStyles;
+
+  RecruitmentApplicant copyWith({
+    String? status,
+  }) {
+    return RecruitmentApplicant(
+      id: id,
+      userId: userId,
+      displayName: displayName,
+      status: status ?? this.status,
+      createdAt: createdAt,
+      avatarUrl: avatarUrl,
+      level: level,
+      playStyles: playStyles,
+    );
+  }
+}

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -20,6 +20,9 @@ class RecruitmentPost {
     required this.isJoined,
     required this.isOwner,
     required this.locationNote,
+    required this.isActive,
+    required this.expiresAt,
+    required this.hasCourt,
   });
 
   factory RecruitmentPost.fromRecord({
@@ -52,6 +55,7 @@ class RecruitmentPost {
     final courtRecord = _resolveExpandedRecord(record.expand?['court']);
     final courtData = courtRecord?.data;
     final courtName = _sanitizeName(courtData?['name'] as String?);
+    final courtId = (data['court'] as String?) ?? courtRecord?.id;
 
     final applicantUserIds = applicants
         .map((rec) =>
@@ -60,7 +64,12 @@ class RecruitmentPost {
         .cast<String>()
         .toList();
 
-    final joinedCount = applicantUserIds.length + 1; // tính cả chủ bài
+    final acceptedApplicants = applicants.where((rec) {
+      final status = (rec.data['status'] as String?) ?? 'pending';
+      return status == 'accepted';
+    }).length;
+
+    final joinedCount = acceptedApplicants + 1; // tính cả chủ bài
     final hasJoined = applicantUserIds.contains(loggedInUserId);
 
     return RecruitmentPost(
@@ -82,6 +91,9 @@ class RecruitmentPost {
       isJoined: hasJoined || authorId == loggedInUserId,
       isOwner: isOwner,
       locationNote: (data['location_note'] as String?)?.trim(),
+      isActive: data['is_active'] != false,
+      expiresAt: _tryParseDateTime(data['expires_at']),
+      hasCourt: courtId != null && courtId.isNotEmpty,
     );
   }
 
@@ -100,11 +112,16 @@ class RecruitmentPost {
   final bool isJoined;
   final bool isOwner;
   final String? locationNote;
+  final bool isActive;
+  final DateTime? expiresAt;
+  final bool hasCourt;
 
   RecruitmentPost copyWith({
     int? joinedPlayers,
     bool? isJoined,
     String? authorAvatarUrl,
+    bool? isActive,
+    DateTime? expiresAt,
   }) {
     return RecruitmentPost(
       id: id,
@@ -122,6 +139,9 @@ class RecruitmentPost {
       isJoined: isJoined ?? this.isJoined,
       isOwner: isOwner,
       locationNote: locationNote,
+      isActive: isActive ?? this.isActive,
+      expiresAt: expiresAt ?? this.expiresAt,
+      hasCourt: hasCourt,
     );
   }
 }

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -285,8 +285,7 @@ class _QuickAction extends StatelessWidget {
             ],
           ),
           child: Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
@@ -506,8 +505,9 @@ class _UpcomingCard extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final highlight = hasBooking;
     final textColor = highlight ? cs.onPrimary : cs.onSurface;
-    final subtitleColor =
-        highlight ? cs.onPrimary.withOpacity(0.8) : cs.onSurface.withOpacity(0.7);
+    final subtitleColor = highlight
+        ? cs.onPrimary.withOpacity(0.8)
+        : cs.onSurface.withOpacity(0.7);
 
     return InkWell(
       onTap: hasBooking ? onTap : null,
@@ -524,9 +524,7 @@ class _UpcomingCard extends StatelessWidget {
                   end: Alignment.bottomRight,
                 )
               : null,
-          color: highlight
-              ? null
-              : cs.surfaceVariant.withOpacity(0.65),
+          color: highlight ? null : cs.surfaceVariant.withOpacity(0.65),
           borderRadius: BorderRadius.circular(18),
           boxShadow: [
             if (highlight)

--- a/lib/pages/home/search_page.dart
+++ b/lib/pages/home/search_page.dart
@@ -9,74 +9,54 @@ class SearchPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final screenHeight = MediaQuery.of(context).size.height;
     final cs = Theme.of(context).colorScheme;
 
     return Scaffold(
-      body: Stack(
-        children: [
-          // List Sân
-          Container(
-              margin: EdgeInsets.only(top: screenHeight / 13),
-              padding: const EdgeInsets.only(top: 50, bottom: 40),
-              child: ListView(
-                children: [],
-              )),
-
-          // Title
-          Container(
-            height: screenHeight / 7,
-            decoration: BoxDecoration(
-              color: cs.primary,
+      appBar: AppBar(
+        title: const Text(
+          'Tìm kiếm sân',
+          style: TextStyle(fontSize: 22, fontWeight: FontWeight.w700),
+        ),
+        flexibleSpace: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [cs.primary, cs.primary.withOpacity(0.85)],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
             ),
-            child: Padding(
-              padding: const EdgeInsets.only(top: 35),
-              child: Center(
-                child: Text(
-                  'S E A R C H',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.onPrimary,
-                  ),
+          ),
+        ),
+        elevation: 0,
+        scrolledUnderElevation: 0,
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              MyTextfield(
+                hintText: "Tìm kiếm sân...",
+                controller: searchController,
+                prefixIcon: Icon(Icons.search_rounded, color: cs.primary),
+                suffixIcon: IconButton(
+                  icon: Icon(Icons.tune_rounded, color: cs.primary),
+                  onPressed: () {
+                    // Thêm logic filter nếu cần, hiện tại giữ nguyên
+                  },
                 ),
               ),
-            ),
-          ),
-          Padding(
-            padding: EdgeInsets.only(
-              top: screenHeight / 14,
-              left: 12,
-            ),
-            child: GestureDetector(
-              onTap: () => Navigator.pop(context),
-              child: Container(
-                child: Icon(
-                  Icons.arrow_back,
-                  color: Colors.white,
-                  size: 30,
+              const SizedBox(height: 20),
+              Expanded(
+                child: ListView(
+                  children: [
+                    // Nội dung list sân (giữ nguyên rỗng như code cũ)
+                  ],
                 ),
               ),
-            ),
+            ],
           ),
-
-          // Search Bar
-          Container(
-            margin: EdgeInsets.only(top: screenHeight / 38),
-            padding:
-                const EdgeInsets.only(top: 84, bottom: 40, right: 12, left: 12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                MyTextfield(
-                  hintText: "Search for courts...",
-                  controller: searchController,
-                  prefixIcon: Icon(Icons.search),
-                ),
-              ],
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/pages/social/create_post_page.dart
+++ b/lib/pages/social/create_post_page.dart
@@ -74,96 +74,202 @@ class _CreatePostPageState extends State<CreatePostPage> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Đăng bài cộng đồng')),
+      appBar: AppBar(
+        title: Text(
+          'Đăng bài mới',
+          style: textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+            letterSpacing: -0.5,
+          ),
+        ),
+        elevation: 0,
+        backgroundColor: cs.surface,
+        foregroundColor: cs.onSurface,
+        scrolledUnderElevation: 0,
+      ),
       body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.all(20),
-          children: [
-            TextField(
-              controller: _contentController,
-              maxLines: 5,
-              decoration: const InputDecoration(
-                labelText: 'Chia sẻ điều gì đó...',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: 20),
-            Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                ..._selectedImages.asMap().entries.map((entry) {
-                  final index = entry.key;
-                  final image = entry.value;
-                  return Stack(
-                    alignment: Alignment.topRight,
-                    children: [
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(18),
-                        child: Image.file(
-                          File(image.path),
-                          width: 120,
-                          height: 120,
-                          fit: BoxFit.cover,
-                        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+          child: Column(
+            children: [
+              Expanded(
+                child: ListView(
+                  children: [
+                    // Modern TextField
+                    Container(
+                      decoration: BoxDecoration(
+                        color: cs.surfaceVariant.withOpacity(0.4),
+                        borderRadius: BorderRadius.circular(24),
                       ),
-                      Positioned(
-                        top: 4,
-                        right: 4,
-                        child: InkWell(
-                          onTap: () => _removeImage(index),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: cs.errorContainer,
-                              shape: BoxShape.circle,
-                            ),
-                            padding: const EdgeInsets.all(4),
-                            child: Icon(Icons.close,
-                                size: 18, color: cs.onErrorContainer),
+                      child: TextField(
+                        controller: _contentController,
+                        maxLines: null,
+                        minLines: 4,
+                        keyboardType: TextInputType.multiline,
+                        decoration: InputDecoration(
+                          hintText: 'Chia sẻ suy nghĩ của bạn...',
+                          hintStyle: textTheme.bodyLarge?.copyWith(
+                            color: cs.onSurfaceVariant,
                           ),
+                          border: InputBorder.none,
+                          contentPadding: const EdgeInsets.all(20),
+                        ),
+                        style: textTheme.bodyLarge?.copyWith(
+                          height: 1.5,
                         ),
                       ),
+                    ),
+                    const SizedBox(height: 24),
+                    // Images section
+                    if (_selectedImages.isNotEmpty || true) ...[
+                      Text(
+                        'Ảnh đính kèm',
+                        style: textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
                     ],
-                  );
-                }).toList(),
-                GestureDetector(
-                  onTap: _pickImages,
-                  child: Container(
-                    width: 120,
-                    height: 120,
-                    decoration: BoxDecoration(
-                      color: cs.surfaceVariant.withOpacity(0.5),
-                      borderRadius: BorderRadius.circular(18),
-                      border: Border.all(color: cs.outlineVariant),
+                    GridView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 3,
+                        crossAxisSpacing: 12,
+                        mainAxisSpacing: 12,
+                        childAspectRatio: 1,
+                      ),
+                      itemCount: _selectedImages.length + 1,
+                      itemBuilder: (context, index) {
+                        if (index == _selectedImages.length) {
+                          // Add button
+                          return GestureDetector(
+                            onTap: _pickImages,
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: cs.surfaceVariant.withOpacity(0.3),
+                                borderRadius: BorderRadius.circular(24),
+                                border: Border.all(
+                                  color: cs.outlineVariant.withOpacity(0.5),
+                                  width: 1.5,
+                                ),
+                              ),
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(
+                                    Icons.add_photo_alternate_rounded,
+                                    size: 32,
+                                    color: cs.primary,
+                                  ),
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    'Thêm ảnh',
+                                    style: textTheme.labelMedium?.copyWith(
+                                      color: cs.primary,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        } else {
+                          // Image item
+                          final image = _selectedImages[index];
+                          return Container(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(24),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(0.1),
+                                  blurRadius: 8,
+                                  offset: const Offset(0, 4),
+                                ),
+                              ],
+                            ),
+                            child: Stack(
+                              alignment: Alignment.topRight,
+                              children: [
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(24),
+                                  child: Image.file(
+                                    File(image.path),
+                                    fit: BoxFit.cover,
+                                    width: double.infinity,
+                                    height: double.infinity,
+                                  ),
+                                ),
+                                Positioned(
+                                  top: 8,
+                                  right: 8,
+                                  child: GestureDetector(
+                                    onTap: () => _removeImage(index),
+                                    child: Container(
+                                      padding: const EdgeInsets.all(6),
+                                      decoration: BoxDecoration(
+                                        color: cs.error.withOpacity(0.9),
+                                        shape: BoxShape.circle,
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color: cs.error.withOpacity(0.3),
+                                            blurRadius: 4,
+                                          ),
+                                        ],
+                                      ),
+                                      child: Icon(
+                                        Icons.close_rounded,
+                                        size: 16,
+                                        color: cs.onError,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        }
+                      },
                     ),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: const [
-                        Icon(Icons.add_a_photo_outlined, size: 28),
-                        SizedBox(height: 8),
-                        Text('Thêm ảnh'),
-                      ],
-                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              // Submit button
+              FilledButton.icon(
+                onPressed: _isSubmitting ? null : _submit,
+                icon: _isSubmitting
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2.5,
+                          color: cs.onPrimary,
+                        ),
+                      )
+                    : const Icon(Icons.send_rounded),
+                label: Text(
+                  _isSubmitting ? 'Đang đăng...' : 'Đăng bài',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 16,
                   ),
                 ),
-              ],
-            ),
-            const SizedBox(height: 32),
-            FilledButton.icon(
-              onPressed: _isSubmitting ? null : _submit,
-              icon: _isSubmitting
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2.5),
-                    )
-                  : const Icon(Icons.send),
-              label: Text(_isSubmitting ? 'Đang đăng...' : 'Đăng bài'),
-              style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(52)),
-            ),
-          ],
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size.fromHeight(56),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(28),
+                  ),
+                  elevation: 2,
+                  shadowColor: cs.primary.withOpacity(0.3),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/pages/social/recruitment/recruitment_applicants_page.dart
+++ b/lib/pages/social/recruitment/recruitment_applicants_page.dart
@@ -1,0 +1,433 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../models/recruitment_applicant.dart';
+import '../../../models/recruitment_post.dart';
+import '../../../services/recruitment_service.dart';
+
+class RecruitmentApplicantsPage extends StatefulWidget {
+  const RecruitmentApplicantsPage({
+    super.key,
+    required this.post,
+  });
+
+  final RecruitmentPost post;
+
+  @override
+  State<RecruitmentApplicantsPage> createState() =>
+      _RecruitmentApplicantsPageState();
+}
+
+class _RecruitmentApplicantsPageState
+    extends State<RecruitmentApplicantsPage> {
+  final RecruitmentService _service = RecruitmentService();
+
+  late RecruitmentPost _post;
+  List<RecruitmentApplicant> _applicants = const [];
+  bool _isLoading = true;
+  bool _isClosing = false;
+  String? _error;
+  final Set<String> _updatingApplicantIds = <String>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _post = widget.post;
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      final applicants = await _service.fetchApplicants(_post.id);
+      final refreshedPost = await _service.getRecruitmentById(_post.id);
+      if (!mounted) return;
+      setState(() {
+        _applicants = applicants;
+        _post = refreshedPost;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = error.toString();
+      });
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _handleUpdateStatus(
+    RecruitmentApplicant applicant,
+    String status,
+  ) async {
+    if (_updatingApplicantIds.contains(applicant.id)) return;
+
+    setState(() {
+      _updatingApplicantIds.add(applicant.id);
+    });
+
+    try {
+      final updatedPost = await _service.updateApplicantStatus(
+        applicantId: applicant.id,
+        status: status,
+      );
+      final updatedApplicants = await _service.fetchApplicants(_post.id);
+      if (!mounted) return;
+      setState(() {
+        _post = updatedPost;
+        _applicants = updatedApplicants;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _updatingApplicantIds.remove(applicant.id);
+      });
+    }
+  }
+
+  Future<void> _handleCloseRecruitment() async {
+    if (!_post.isActive) return;
+
+    DateTime? expiresAt;
+
+    if (!_post.hasCourt) {
+      final now = DateTime.now();
+      final baseDate = _post.eventTime ?? now;
+      final initialTime = TimeOfDay.fromDateTime(baseDate);
+
+      final picked = await showTimePicker(
+        context: context,
+        initialTime: initialTime,
+        helpText: 'Chọn giờ đóng bài',
+      );
+
+      if (picked == null) {
+        return;
+      }
+
+      expiresAt = DateTime(
+        baseDate.year,
+        baseDate.month,
+        baseDate.day,
+        picked.hour,
+        picked.minute,
+      );
+    } else {
+      expiresAt = _post.eventTime ?? DateTime.now();
+    }
+
+    setState(() {
+      _isClosing = true;
+    });
+
+    try {
+      final updatedPost = await _service.closeRecruitment(
+        recruitmentId: _post.id,
+        expiresAt: expiresAt,
+      );
+      final updatedApplicants = await _service.fetchApplicants(_post.id);
+      if (!mounted) return;
+      setState(() {
+        _post = updatedPost;
+        _applicants = updatedApplicants;
+      });
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Đã đóng bài tuyển.')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isClosing = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final canManage = _post.isOwner;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Yêu cầu tham gia'),
+        actions: [
+          if (canManage && _post.isActive)
+            TextButton.icon(
+              onPressed: _isClosing ? null : _handleCloseRecruitment,
+              icon: _isClosing
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.lock_outline),
+              label: const Text('Đóng bài'),
+            ),
+        ],
+      ),
+      body: SafeArea(
+        child: RefreshIndicator(
+          onRefresh: _loadData,
+          child: _buildBody(canManage),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(bool canManage) {
+    if (!canManage) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Text('Bạn không có quyền quản lý bài tuyển này.'),
+        ),
+      );
+    }
+
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: _loadData,
+                child: const Text('Thử lại'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_applicants.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Text('Chưa có yêu cầu tham gia nào.'),
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      itemBuilder: (context, index) {
+        final applicant = _applicants[index];
+        return _ApplicantTile(
+          applicant: applicant,
+          isUpdating: _updatingApplicantIds.contains(applicant.id),
+          onAccept: () => _handleUpdateStatus(applicant, 'accepted'),
+          onReject: () => _handleUpdateStatus(applicant, 'rejected'),
+        );
+      },
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemCount: _applicants.length,
+    );
+  }
+}
+
+class _ApplicantTile extends StatelessWidget {
+  const _ApplicantTile({
+    required this.applicant,
+    required this.isUpdating,
+    required this.onAccept,
+    required this.onReject,
+  });
+
+  final RecruitmentApplicant applicant;
+  final bool isUpdating;
+  final VoidCallback onAccept;
+  final VoidCallback onReject;
+
+  Color _statusColor(BuildContext context) {
+    switch (applicant.status) {
+      case 'accepted':
+        return Theme.of(context).colorScheme.primaryContainer;
+      case 'rejected':
+        return Theme.of(context).colorScheme.errorContainer;
+      default:
+        return Theme.of(context).colorScheme.surfaceVariant;
+    }
+  }
+
+  Color _statusTextColor(BuildContext context) {
+    switch (applicant.status) {
+      case 'accepted':
+        return Theme.of(context).colorScheme.primary;
+      case 'rejected':
+        return Theme.of(context).colorScheme.error;
+      default:
+        return Theme.of(context).colorScheme.onSurfaceVariant;
+    }
+  }
+
+  String _statusLabel() {
+    switch (applicant.status) {
+      case 'accepted':
+        return 'Đã duyệt';
+      case 'rejected':
+        return 'Đã từ chối';
+      default:
+        return 'Chờ duyệt';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final playStyles = applicant.playStyles.join(', ');
+
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 24,
+                  backgroundColor: cs.primary,
+                  backgroundImage: applicant.avatarUrl != null
+                      ? NetworkImage(applicant.avatarUrl!)
+                      : null,
+                  child: applicant.avatarUrl == null
+                      ? Text(
+                          applicant.displayName.isNotEmpty
+                              ? applicant.displayName[0].toUpperCase()
+                              : '?',
+                          style: textTheme.titleMedium?.copyWith(
+                            color: cs.onPrimary,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        )
+                      : null,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        applicant.displayName,
+                        style: textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                              vertical: 6,
+                            ),
+                            decoration: BoxDecoration(
+                              color: _statusColor(context),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Text(
+                              _statusLabel(),
+                              style: textTheme.labelMedium?.copyWith(
+                                color: _statusTextColor(context),
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            DateFormat('dd/MM HH:mm').format(applicant.createdAt),
+                            style: textTheme.bodySmall?.copyWith(
+                              color: cs.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (applicant.level != null && applicant.level!.isNotEmpty) ...[
+              Text(
+                'Trình độ: ${applicant.level}',
+                style: textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 4),
+            ],
+            if (playStyles.isNotEmpty) ...[
+              Text(
+                'Lối đánh: $playStyles',
+                style: textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 4),
+            ],
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: _buildActions(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildActions(BuildContext context) {
+    if (applicant.status != 'pending') {
+      return [
+        Text(
+          applicant.status == 'accepted' ? 'Đã chấp nhận' : 'Đã từ chối',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ];
+    }
+
+    return [
+      TextButton.icon(
+        onPressed: isUpdating ? null : onReject,
+        icon: const Icon(Icons.close, color: Colors.red),
+        label: const Text('Từ chối'),
+      ),
+      const SizedBox(width: 8),
+      FilledButton.icon(
+        onPressed: isUpdating ? null : onAccept,
+        icon: isUpdating
+            ? const SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Icon(Icons.check_circle_outline),
+        label: const Text('Chấp nhận'),
+      ),
+    ];
+  }
+}

--- a/lib/pages/social/recruitment/recruitment_applicants_page.dart
+++ b/lib/pages/social/recruitment/recruitment_applicants_page.dart
@@ -18,8 +18,7 @@ class RecruitmentApplicantsPage extends StatefulWidget {
       _RecruitmentApplicantsPageState();
 }
 
-class _RecruitmentApplicantsPageState
-    extends State<RecruitmentApplicantsPage> {
+class _RecruitmentApplicantsPageState extends State<RecruitmentApplicantsPage> {
   final RecruitmentService _service = RecruitmentService();
 
   late RecruitmentPost _post;
@@ -301,18 +300,67 @@ class _ApplicantTile extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final playStyles = applicant.playStyles.join(', ');
 
-    return Card(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+    // Màu trạng thái rõ ràng + đậm đà
+    final Color statusBgColor;
+    final Color statusTextColor;
+    final IconData? statusIcon;
+
+    switch (applicant.status) {
+      case 'pending':
+        statusBgColor = Colors.orange.shade100;
+        statusTextColor = Colors.orange.shade800;
+        statusIcon = Icons.access_time_filled;
+        break;
+      case 'accepted':
+        statusBgColor = Colors.green.shade100;
+        statusTextColor = Colors.green.shade800;
+        statusIcon = Icons.check_circle;
+        break;
+      case 'rejected':
+        statusBgColor = Colors.red.shade50;
+        statusTextColor = Colors.red.shade700;
+        statusIcon = Icons.cancel;
+        break;
+      default:
+        statusBgColor = cs.primary.withOpacity(0.1);
+        statusTextColor = cs.primary;
+        statusIcon = null;
+    }
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(
+          color: applicant.status == 'rejected'
+              ? Colors.red.shade200.withOpacity(0.6)
+              : cs.outline.withOpacity(0.45),
+          width: applicant.status == 'rejected'
+              ? 1.8
+              : 1.4, // Viền đậm hơn khi bị từ chối
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: applicant.status == 'rejected'
+                ? Colors.red.shade100.withOpacity(0.3)
+                : cs.shadow.withOpacity(0.08),
+            blurRadius: 16,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(18),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // Header: Avatar + Info
             Row(
               children: [
                 CircleAvatar(
-                  radius: 24,
-                  backgroundColor: cs.primary,
+                  radius: 28,
+                  backgroundColor: cs.primary.withOpacity(0.15),
                   backgroundImage: applicant.avatarUrl != null
                       ? NetworkImage(applicant.avatarUrl!)
                       : null,
@@ -321,14 +369,14 @@ class _ApplicantTile extends StatelessWidget {
                           applicant.displayName.isNotEmpty
                               ? applicant.displayName[0].toUpperCase()
                               : '?',
-                          style: textTheme.titleMedium?.copyWith(
-                            color: cs.onPrimary,
+                          style: textTheme.titleLarge?.copyWith(
+                            color: cs.primary,
                             fontWeight: FontWeight.bold,
                           ),
                         )
                       : null,
                 ),
-                const SizedBox(width: 12),
+                const SizedBox(width: 16),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -336,34 +384,49 @@ class _ApplicantTile extends StatelessWidget {
                       Text(
                         applicant.displayName,
                         style: textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w700,
+                          fontWeight: FontWeight.w800,
+                          fontSize: 18,
                         ),
                       ),
-                      const SizedBox(height: 4),
+                      const SizedBox(height: 8),
                       Row(
                         children: [
+                          // Label trạng thái: ĐẬM, RÕ, CÓ ICON
                           Container(
                             padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                              vertical: 6,
-                            ),
+                                horizontal: 14, vertical: 8),
                             decoration: BoxDecoration(
-                              color: _statusColor(context),
-                              borderRadius: BorderRadius.circular(12),
+                              color: statusBgColor,
+                              borderRadius: BorderRadius.circular(24),
+                              border: Border.all(
+                                  color: statusTextColor.withOpacity(0.4),
+                                  width: 1.2),
                             ),
-                            child: Text(
-                              _statusLabel(),
-                              style: textTheme.labelMedium?.copyWith(
-                                color: _statusTextColor(context),
-                                fontWeight: FontWeight.w700,
-                              ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(statusIcon,
+                                    size: 16, color: statusTextColor),
+                                const SizedBox(width: 6),
+                                Text(
+                                  _statusLabel(),
+                                  style: textTheme.labelMedium?.copyWith(
+                                    color: statusTextColor,
+                                    fontWeight: FontWeight.w900,
+                                    fontSize: 13,
+                                    letterSpacing: 0.5,
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
-                          const SizedBox(width: 8),
+                          const SizedBox(width: 12),
                           Text(
-                            DateFormat('dd/MM HH:mm').format(applicant.createdAt),
+                            DateFormat('dd/MM HH:mm')
+                                .format(applicant.createdAt),
                             style: textTheme.bodySmall?.copyWith(
-                              color: cs.onSurfaceVariant,
+                              color: cs.onSurfaceVariant.withOpacity(0.85),
+                              fontWeight: FontWeight.w500,
                             ),
                           ),
                         ],
@@ -373,28 +436,135 @@ class _ApplicantTile extends StatelessWidget {
                 ),
               ],
             ),
-            const SizedBox(height: 8),
-            if (applicant.level != null && applicant.level!.isNotEmpty) ...[
-              Text(
-                'Trình độ: ${applicant.level}',
-                style: textTheme.bodyMedium,
+
+            const SizedBox(height: 16),
+
+            // Thông tin trình độ & lối đánh – phối màu đẹp, dễ nhìn
+            if (applicant.level != null && applicant.level!.isNotEmpty)
+              _infoRow(
+                icon: Icons.trending_up_rounded,
+                color: Colors.deepPurple.shade600,
+                label: 'Trình độ',
+                value: applicant.level!,
+                textTheme: textTheme,
               ),
-              const SizedBox(height: 4),
-            ],
-            if (playStyles.isNotEmpty) ...[
-              Text(
-                'Lối đánh: $playStyles',
-                style: textTheme.bodyMedium,
+
+            if (applicant.level != null && applicant.level!.isNotEmpty)
+              const SizedBox(height: 10),
+
+            if (playStyles.isNotEmpty)
+              _infoRow(
+                icon: Icons.sports_tennis_rounded,
+                color: Colors.teal.shade600,
+                label: 'Lối đánh',
+                value: playStyles,
+                textTheme: textTheme,
               ),
-              const SizedBox(height: 4),
-            ],
+
+            const SizedBox(height: 20),
+
+            // Nút hành động – đẹp, rõ chức năng
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
-              children: _buildActions(context),
+              children: _buildActions(context).map((widget) {
+                if (widget is TextButton) {
+                  final text = widget.child is Text
+                      ? (widget.child as Text).data ?? ''
+                      : '';
+
+                  if (text.contains('Chấp nhận') || text.contains('Đồng ý')) {
+                    return Padding(
+                      padding: const EdgeInsets.only(left: 10),
+                      child: FilledButton.icon(
+                        onPressed: widget.onPressed,
+                        icon: const Icon(Icons.check_circle_rounded, size: 20),
+                        label: Text(text,
+                            style:
+                                const TextStyle(fontWeight: FontWeight.w600)),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: Colors.green.shade600,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 22, vertical: 14),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(30)),
+                          elevation: 2,
+                        ),
+                      ),
+                    );
+                  }
+
+                  if (text.contains('Từ chối') || text.contains('Hủy')) {
+                    return Padding(
+                      padding: const EdgeInsets.only(left: 10),
+                      child: OutlinedButton.icon(
+                        onPressed: widget.onPressed,
+                        icon: const Icon(Icons.cancel_rounded, size: 20),
+                        label: Text(text,
+                            style: TextStyle(
+                                color: Colors.red.shade700,
+                                fontWeight: FontWeight.w600)),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: Colors.red.shade700,
+                          side:
+                              BorderSide(color: Colors.red.shade400, width: 2),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 22, vertical: 14),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(30)),
+                        ),
+                      ),
+                    );
+                  }
+                }
+                return Padding(
+                    padding: const EdgeInsets.only(left: 10), child: widget);
+              }).toList(),
             ),
           ],
         ),
       ),
+    );
+  }
+
+// Helper: Dòng thông tin đẹp + màu sắc hài hòa
+  Widget _infoRow({
+    required IconData icon,
+    required Color color,
+    required String label,
+    required String value,
+    required TextTheme textTheme,
+  }) {
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(6),
+          decoration: BoxDecoration(
+            color: color.withOpacity(0.12),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Icon(icon, size: 20, color: color),
+        ),
+        const SizedBox(width: 12),
+        Text(
+          '$label:',
+          style: textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: Colors.black87,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            value,
+            style: textTheme.bodyMedium?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w700,
+              fontSize: 15,
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/pages/social/recruitment/recruitment_applicants_page.dart
+++ b/lib/pages/social/recruitment/recruitment_applicants_page.dart
@@ -104,8 +104,8 @@ class _RecruitmentApplicantsPageState
 
     if (!_post.hasCourt) {
       final now = DateTime.now();
-      final baseDate = _post.eventTime ?? now;
-      final initialTime = TimeOfDay.fromDateTime(baseDate);
+      final baseDate = now;
+      final initialTime = TimeOfDay.fromDateTime(_post.eventTime ?? now);
 
       final picked = await showTimePicker(
         context: context,

--- a/lib/pages/social/recruitment_manager.dart
+++ b/lib/pages/social/recruitment_manager.dart
@@ -142,11 +142,6 @@ class RecruitmentManager extends ChangeNotifier {
           break;
         case 'create':
         case 'update':
-          final isActive = record.data['is_active'] != false;
-          if (!isActive) {
-            _removeRecruitment(record.id);
-            break;
-          }
           final updated = await _service.getRecruitmentById(record.id);
           final index =
               _recruitmentPosts.indexWhere((item) => item.id == updated.id);
@@ -199,34 +194,8 @@ class RecruitmentManager extends ChangeNotifier {
     final recruitment = _recruitmentPosts[index];
 
     try {
-      final pocketBase = await getPocketbaseInstance();
-      final currentUserId = pocketBase.authStore.record?.id;
-      final applicantUserId = _extractRelationId(record, 'user');
-
-      switch (event.action) {
-        case 'create':
-          final updated = recruitment.copyWith(
-            joinedPlayers: recruitment.joinedPlayers + 1,
-            isJoined: recruitment.isJoined ||
-                (currentUserId != null && currentUserId == applicantUserId),
-          );
-          _replaceRecruitmentAt(index, updated);
-          break;
-        case 'delete':
-          final newCount = recruitment.joinedPlayers > 1
-              ? recruitment.joinedPlayers - 1
-              : recruitment.joinedPlayers;
-          final updated = recruitment.copyWith(
-            joinedPlayers: newCount,
-            isJoined: currentUserId != null && currentUserId == applicantUserId
-                ? recruitment.isOwner
-                : recruitment.isJoined,
-          );
-          _replaceRecruitmentAt(index, updated);
-          break;
-        default:
-          break;
-      }
+      final updated = await _service.getRecruitmentById(recruitment.id);
+      _replaceRecruitmentAt(index, updated);
     } catch (error, stackTrace) {
       if (kDebugMode) {
         debugPrint('Failed to process applicant realtime event: $error');

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -95,66 +95,115 @@ class _SocialPageState extends State<SocialPage> {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
-        backgroundColor: cs.surfaceVariant.withOpacity(0.3),
+        backgroundColor: cs.surfaceVariant.withOpacity(0.1),
         appBar: AppBar(
           title: const Text(
             'Cộng đồng cầu lông',
-            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+            style: TextStyle(
+                fontSize: 22, fontWeight: FontWeight.w700, letterSpacing: -0.5),
           ),
           actions: [
             IconButton(
-              icon: const Icon(Icons.add_circle_outline),
+              icon: const Icon(Icons.add_circle_outline_rounded, size: 26),
               tooltip: 'Đăng bài',
               onPressed: () => _openCreatePost(context),
+              style: IconButton.styleFrom(
+                foregroundColor: cs.onPrimary,
+                backgroundColor: cs.primary.withOpacity(0.15),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+              ),
             ),
+            const SizedBox(width: 8),
             IconButton(
-              icon: const Icon(Icons.group, size: 30),
+              icon: const Icon(Icons.group_rounded, size: 28),
               tooltip: 'Tin nhắn',
               onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => MultiProvider(
-                          providers: [
-                            ChangeNotifierProvider(
-                              create: (_) => FriendRequestManager()..initialize(),
-                            ),
-                            ChangeNotifierProvider(
-                              create: (_) => FriendListManager()..initialize(),
-                            ),
-                            ChangeNotifierProvider(
-                              create: (_) => ChatListManager()..initialize(),
-                            ),
-                          ],
-                          child: const ChatHomePage(),
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => MultiProvider(
+                      providers: [
+                        ChangeNotifierProvider(
+                          create: (_) => FriendRequestManager()..initialize(),
                         ),
-                      ),
-                    );
+                        ChangeNotifierProvider(
+                          create: (_) => FriendListManager()..initialize(),
+                        ),
+                        ChangeNotifierProvider(
+                          create: (_) => ChatListManager()..initialize(),
+                        ),
+                      ],
+                      child: const ChatHomePage(),
+                    ),
+                  ),
+                );
               },
+              style: IconButton.styleFrom(
+                foregroundColor: cs.onPrimary,
+                backgroundColor: cs.primary.withOpacity(0.15),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+              ),
             ),
-            const SizedBox(width: 6),
+            const SizedBox(width: 12),
           ],
           bottom: TabBar(
             tabs: [
-              Tab(text: 'Community'),
-              Tab(text: 'Recruitment'),
+              Tab(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.people_alt_rounded, size: 20),
+                    const SizedBox(width: 8),
+                    Text('Community'),
+                  ],
+                ),
+              ),
+              Tab(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.person_search_rounded, size: 20),
+                    const SizedBox(width: 8),
+                    Text('Recruitment'),
+                  ],
+                ),
+              ),
             ],
             // Chữ tab đang chọn
-            labelStyle: tt.titleSmall?.copyWith(
+            labelStyle: tt.titleMedium?.copyWith(
               fontWeight: FontWeight.w700,
-              fontSize: 16, // ← tăng kích thước chữ
+              fontSize: 16,
             ),
             // Chữ tab chưa chọn
-            unselectedLabelStyle: tt.titleSmall?.copyWith(
-              fontSize: 16, // ← giữ cùng size cho đồng đều
+            unselectedLabelStyle: tt.titleMedium?.copyWith(
+              fontSize: 16,
               fontWeight: FontWeight.w500,
             ),
             labelColor: cs.onPrimary,
-            unselectedLabelColor: cs.onPrimary.withOpacity(0.65),
-            indicator: UnderlineTabIndicator(
-              borderSide: BorderSide(color: cs.onPrimary, width: 2.4),
-              insets: const EdgeInsets.symmetric(horizontal: 16),
+            unselectedLabelColor: cs.onPrimary.withOpacity(0.75),
+            indicator: BoxDecoration(
+              borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
+              color: cs.primary.withOpacity(0.3),
+            ),
+            indicatorSize: TabBarIndicatorSize.tab,
+            indicatorColor: Colors.transparent,
+            dividerColor: cs.onPrimary.withOpacity(0.15),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+            overlayColor: WidgetStateProperty.all(cs.primary.withOpacity(0.1)),
+          ),
+          flexibleSpace: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [cs.primary, cs.primary.withOpacity(0.85)],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
             ),
           ),
+          elevation: 0,
+          scrolledUnderElevation: 0,
+          shadowColor: Colors.transparent,
         ),
         body: SafeArea(
           child: TabBarView(
@@ -179,7 +228,7 @@ class _SocialPageState extends State<SocialPage> {
         slivers: [
           SliverToBoxAdapter(
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
+              padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
               child: _buildCreatePostCard(context, avatarUrl),
             ),
           ),
@@ -238,6 +287,7 @@ class _SocialPageState extends State<SocialPage> {
     final cs = Theme.of(context).colorScheme;
     return DecoratedBox(
       decoration: BoxDecoration(
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.3)),
         color: cs.surface,
         borderRadius: BorderRadius.circular(20),
         boxShadow: [
@@ -249,28 +299,44 @@ class _SocialPageState extends State<SocialPage> {
         ],
       ),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding:
+            const EdgeInsets.only(top: 16, left: 16, right: 16, bottom: 20),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // Header: Tiêu đề + nút Viết bài (được làm gọn và tinh tế hơn)
             Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
                   'Chia sẻ điều mới mẻ',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleMedium
-                      ?.copyWith(fontWeight: FontWeight.w600),
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 18,
+                        height: 1.2,
+                      ),
                 ),
-                TextButton.icon(
+                const Spacer(),
+                // Nút "Viết bài" được làm kiểu chip hiện đại, có hiệu ứng ripple đẹp
+                FilledButton.tonalIcon(
                   onPressed: () => _openCreatePost(context),
-                  icon: const Icon(Icons.edit_outlined),
+                  icon: const Icon(Icons.edit_outlined, size: 18),
                   label: const Text('Viết bài'),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 10),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    elevation: 0,
+                    shadowColor: Colors.transparent,
+                  ),
                 ),
               ],
             ),
-            const SizedBox(height: 12),
+
+            const SizedBox(height: 16), // Tăng khoảng cách cho thoáng
+
+            // CreatePostBar được tối ưu giao diện (dùng bản mình đã cải thiện trước đó)
             CreatePostBar(
               onCreatePost: () => _openCreatePost(context),
               onPickPhoto: () => _openCreatePost(context),
@@ -281,11 +347,14 @@ class _SocialPageState extends State<SocialPage> {
                   ),
                 );
               },
-              avatarImageProvider: (avatarUrl != null && avatarUrl.isNotEmpty)
-                  ? NetworkImage(avatarUrl)
+              avatarImageProvider: (avatarUrl != null && avatarUrl!.isNotEmpty)
+                  ? NetworkImage(avatarUrl!)
                   : null,
               hintText: 'Bạn đang nghĩ gì thế?',
-              elevation: 0,
+              elevation: 4, // bật lại elevation nhẹ để nổi
+              compact: false,
+              // Tùy chọn: thêm chút màu chủ đạo nếu muốn nổi bật hơn
+              // primaryColor: Colors.blue,
             ),
           ],
         ),

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -9,6 +9,7 @@ import 'package:badminton_booking_app/models/recruitment_post.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_home_page.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_list_manager.dart';
 import 'package:badminton_booking_app/pages/social/create_post_page.dart';
+import 'package:badminton_booking_app/pages/social/recruitment/recruitment_applicants_page.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/recruitment_page.dart';
 import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
@@ -337,6 +338,7 @@ class _SocialPageState extends State<SocialPage> {
             playTime: post.eventTime,
             locationNote: post.locationNote,
             onJoin: () async {
+              if (!post.isActive) return;
               try {
                 await manager.joinRecruitment(post.id);
               } catch (error) {
@@ -349,6 +351,16 @@ class _SocialPageState extends State<SocialPage> {
             isJoined: post.isJoined,
             isOwner: post.isOwner,
             isJoinLoading: manager.isJoining(post.id),
+            isActive: post.isActive,
+            onManage: post.isOwner
+                ? () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => RecruitmentApplicantsPage(post: post),
+                      ),
+                    );
+                  }
+                : null,
           );
         },
         childCount: manager.recruitmentPosts.length,

--- a/lib/pages/user/user_detail.dart
+++ b/lib/pages/user/user_detail.dart
@@ -145,15 +145,17 @@ class _UserDetailState extends State<UserDetail> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('D E T A I L'),
+        title: const Text('Thông tin cá nhân'),
         centerTitle: true,
         actions: [
           IconButton(
             onPressed: _isLoading ? null : _loadDetails,
-            icon: const Icon(Icons.refresh),
+            icon: const Icon(Icons.refresh_rounded),
             tooltip: 'Tải lại',
           ),
         ],
+        elevation: 0,
+        scrolledUnderElevation: 0,
       ),
       body: SafeArea(
         child: _buildBody(),
@@ -204,7 +206,6 @@ class _UserDetailState extends State<UserDetail> {
           _buildField(
             'Tên đăng nhập',
             _usernameController,
-            helperText: 'Tên tài khoản PocketBase.',
             readOnly: true,
           ),
           _buildField(
@@ -245,15 +246,22 @@ class _UserDetailState extends State<UserDetail> {
           const SizedBox(height: 20),
           SizedBox(
             width: double.infinity,
-            child: ElevatedButton(
+            child: FilledButton.icon(
               onPressed: _isSaving ? null : _saveDetails,
-              child: _isSaving
+              icon: _isSaving
                   ? const SizedBox(
                       height: 20,
                       width: 20,
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
-                  : const Text('LƯU THAY ĐỔI'),
+                  : const Icon(Icons.save_rounded),
+              label: Text(_isSaving ? 'Đang lưu...' : 'LƯU THAY ĐỔI'),
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
             ),
           ),
         ],
@@ -270,7 +278,7 @@ class _UserDetailState extends State<UserDetail> {
     VoidCallback? onTap,
   }) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 20),
+      padding: const EdgeInsets.only(bottom: 24),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -278,7 +286,7 @@ class _UserDetailState extends State<UserDetail> {
             label,
             style: Theme.of(context)
                 .textTheme
-                .titleSmall
+                .titleMedium
                 ?.copyWith(fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: 8),
@@ -289,18 +297,22 @@ class _UserDetailState extends State<UserDetail> {
             decoration: InputDecoration(
               hintText: hintText,
               helperText: helperText,
+              filled: true,
+              fillColor:
+                  Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.3),
               border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide.none,
               ),
               focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(16),
                 borderSide: BorderSide(
                   color: Theme.of(context).colorScheme.primary,
                   width: 2,
                 ),
               ),
               contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                  const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
             ),
           ),
         ],
@@ -321,7 +333,7 @@ class _UserDetailState extends State<UserDetail> {
     }
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: 20),
+      padding: const EdgeInsets.only(bottom: 24),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -329,7 +341,7 @@ class _UserDetailState extends State<UserDetail> {
             label,
             style: Theme.of(context)
                 .textTheme
-                .titleSmall
+                .titleMedium
                 ?.copyWith(fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: 8),
@@ -338,11 +350,22 @@ class _UserDetailState extends State<UserDetail> {
                 value != null && dropdownOptions.contains(value) ? value : null,
             decoration: InputDecoration(
               hintText: hintText,
+              filled: true,
+              fillColor:
+                  Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.3),
               border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide.none,
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide(
+                  color: Theme.of(context).colorScheme.primary,
+                  width: 2,
+                ),
               ),
               contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                  const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
             ),
             hint: Text(hintText),
             items: dropdownOptions
@@ -371,30 +394,41 @@ class _UserDetailState extends State<UserDetail> {
     }
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: 20),
+      padding: const EdgeInsets.only(bottom: 24),
       child: InputDecorator(
         decoration: InputDecoration(
           labelText: 'Lối chơi yêu thích',
+          filled: true,
+          fillColor:
+              Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.3),
           border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide(
+              color: Theme.of(context).colorScheme.primary,
+              width: 2,
+            ),
           ),
           contentPadding:
-              const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             if (_selectedPlayStyles.isEmpty)
               Padding(
-                padding: const EdgeInsets.only(bottom: 8),
+                padding: const EdgeInsets.only(bottom: 12),
                 child: Text(
                   'Vui lòng chọn một hoặc nhiều lựa chọn bên dưới.',
                   style: TextStyle(color: Theme.of(context).hintColor),
                 ),
               ),
             Wrap(
-              spacing: 8,
-              runSpacing: 8,
+              spacing: 12,
+              runSpacing: 12,
               children: options.map((String option) {
                 final bool isSelected = _selectedPlayStyles.contains(option);
                 return FilterChip(
@@ -415,6 +449,13 @@ class _UserDetailState extends State<UserDetail> {
                       }
                     });
                   },
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                  selectedColor:
+                      Theme.of(context).colorScheme.primary.withOpacity(0.15),
                 );
               }).toList(),
             ),

--- a/lib/services/recruitment_service.dart
+++ b/lib/services/recruitment_service.dart
@@ -1,9 +1,12 @@
+import 'package:badminton_booking_app/models/recruitment_applicant.dart';
 import 'package:badminton_booking_app/models/recruitment_post.dart';
 import 'package:badminton_booking_app/models/user_booking_view.dart';
+import 'package:badminton_booking_app/utils/pocketbase_utils.dart';
 import 'package:badminton_booking_app/utils/recruitment_dictionary.dart';
 import 'package:pocketbase/pocketbase.dart';
 
 import 'pocketbase_client.dart';
+import 'user_service.dart';
 
 class RecruitmentServiceException implements Exception {
   RecruitmentServiceException(this.message);
@@ -31,7 +34,7 @@ class RecruitmentService {
             sort: '-created',
             expand: 'author,court',
             filter:
-                "is_active = true && (expires_at = '' || expires_at = null || expires_at >= '${DateTime.now().toUtc().toIso8601String()}')",
+                "(expires_at = '' || expires_at = null || expires_at >= '${DateTime.now().toUtc().toIso8601String()}')",
           );
 
       final applicantsMap = await _fetchApplicantsMap(
@@ -70,6 +73,7 @@ class RecruitmentService {
         body: {
           'recruitment': recruitmentId,
           'user': currentUserId,
+          'status': 'pending',
         },
       );
     } on ClientException catch (error) {
@@ -110,6 +114,119 @@ class RecruitmentService {
       throw RecruitmentServiceException(
         'Không thể tải thông tin bài tuyển. Vui lòng thử lại.',
       );
+    }
+  }
+
+  Future<List<RecruitmentApplicant>> fetchApplicants(
+    String recruitmentId,
+  ) async {
+    final pocketBase = await getPocketbaseInstance();
+    final userDetailsService = UserDetailsService();
+
+    try {
+      final result = await pocketBase.collection(recruitmentApplicantsCollection).getList(
+            page: 1,
+            perPage: 200,
+            filter: "recruitment='${_escapeFilterValue(recruitmentId)}'",
+            expand: 'user',
+            sort: '-created',
+          );
+
+      final applicants = <RecruitmentApplicant>[];
+
+      for (final record in result.items) {
+        final expandedUser = resolveExpandedRecord(record.expand?['user']);
+        final userData = expandedUser?.data;
+        final userId = (record.data['user'] as String?) ?? expandedUser?.id;
+        if (userId == null || userId.isEmpty) continue;
+
+        final details = await userDetailsService.getByUserIdWithClient(
+          pocketBase,
+          userId,
+        );
+
+        final avatarUrl = details?.avatarUrl ??
+            resolveFileUrl(pocketBase, expandedUser, userData?['avatar']);
+        final levelLabel = details?.level != null
+            ? RecruitmentDictionary.skillLabelFromValue(details!.level)
+            : null;
+        final playStyles = (details?.playStyle ?? const [])
+            .map(RecruitmentDictionary.playStyleLabelFromValue)
+            .whereType<String>()
+            .toList(growable: false);
+
+        applicants.add(
+          RecruitmentApplicant(
+            id: record.id,
+            userId: userId,
+            displayName: sanitizeDisplayName(
+              userData?['username'] as String? ?? userData?['email'] as String?,
+            ),
+            status: (record.data['status'] as String?) ?? 'pending',
+            createdAt: DateTime.parse(record.data['created'] as String),
+            avatarUrl: avatarUrl,
+            level: levelLabel,
+            playStyles: playStyles,
+          ),
+        );
+      }
+
+      return applicants;
+    } catch (error) {
+      throw RecruitmentServiceException(
+        'Không thể tải danh sách yêu cầu tham gia. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<RecruitmentPost> updateApplicantStatus({
+    required String applicantId,
+    required String status,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+
+    try {
+      final record = await pocketBase
+          .collection(recruitmentApplicantsCollection)
+          .update(applicantId, body: {
+        'status': status,
+      });
+
+      final recruitmentId = record.data['recruitment'] as String?;
+      if (recruitmentId == null || recruitmentId.isEmpty) {
+        throw RecruitmentServiceException('Không tìm thấy bài tuyển liên quan.');
+      }
+
+      return getRecruitmentById(recruitmentId);
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (_) {
+      throw RecruitmentServiceException('Không thể cập nhật trạng thái yêu cầu.');
+    }
+  }
+
+  Future<RecruitmentPost> closeRecruitment({
+    required String recruitmentId,
+    DateTime? expiresAt,
+  }) async {
+    final pocketBase = await getPocketbaseInstance();
+    try {
+      final record = await pocketBase
+          .collection(recruitmentPostsCollection)
+          .update(recruitmentId, body: {
+        'is_active': false,
+        'expires_at': expiresAt?.toUtc().toIso8601String(),
+      });
+
+      return RecruitmentPost.fromRecord(
+        record: record,
+        pocketBase: pocketBase,
+        currentUserId: pocketBase.authStore.record?.id,
+      );
+    } on ClientException catch (error) {
+      throw RecruitmentServiceException(_mapClientError(error));
+    } catch (_) {
+      throw RecruitmentServiceException('Không thể đóng bài tuyển.');
     }
   }
 


### PR DESCRIPTION
## Summary
- add recruitment applicant model plus service support for fetching requests, updating statuses, and closing posts with optional expiry
- create an owner-only management screen to review join requests with user skill/play-style details and accept or reject them
- update recruitment cards and feed to show closed status, disable joining, and link to the management screen

## Testing
- not run (Dart/Flutter CLI not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692591bf259c832bb3c897c9982b7f02)