### PR TITLE
Add recruitment expiration controls and fix manage button

### DIFF
--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -71,6 +71,8 @@ class RecruitmentPost {
 
     final joinedCount = acceptedApplicants + 1; // tính cả chủ bài
     final hasJoined = applicantUserIds.contains(loggedInUserId);
+    final expiresAt = _tryParseDateTime(data['expires_at']);
+    final isExpired = expiresAt != null && expiresAt.isBefore(DateTime.now());
 
     return RecruitmentPost(
       id: record.id,
@@ -91,8 +93,8 @@ class RecruitmentPost {
       isJoined: hasJoined || authorId == loggedInUserId,
       isOwner: isOwner,
       locationNote: (data['location_note'] as String?)?.trim(),
-      isActive: data['is_active'] != false,
-      expiresAt: _tryParseDateTime(data['expires_at']),
+      isActive: data['is_active'] != false && !isExpired,
+      expiresAt: expiresAt,
       hasCourt: courtId != null && courtId.isNotEmpty,
     );
   }

--- a/lib/pages/social/recruitment/recruitment_applicants_page.dart
+++ b/lib/pages/social/recruitment/recruitment_applicants_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../../../models/recruitment_applicant.dart';
 import '../../../models/recruitment_post.dart';
 import '../../../services/recruitment_service.dart';
+import '../../../services/pocketbase_client.dart';
 
 class RecruitmentApplicantsPage extends StatefulWidget {
   const RecruitmentApplicantsPage({
@@ -26,13 +27,23 @@ class _RecruitmentApplicantsPageState extends State<RecruitmentApplicantsPage> {
   bool _isLoading = true;
   bool _isClosing = false;
   String? _error;
+  String? _currentUserId;
   final Set<String> _updatingApplicantIds = <String>{};
 
   @override
   void initState() {
     super.initState();
     _post = widget.post;
+    _loadCurrentUser();
     _loadData();
+  }
+
+  Future<void> _loadCurrentUser() async {
+    final client = await getPocketbaseInstance();
+    if (!mounted) return;
+    setState(() {
+      _currentUserId = client.authStore.record?.id;
+    });
   }
 
   Future<void> _loadData() async {
@@ -161,7 +172,8 @@ class _RecruitmentApplicantsPageState extends State<RecruitmentApplicantsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final canManage = _post.isOwner;
+    final canManage =
+        _post.isOwner || (_currentUserId != null && _post.authorId == _currentUserId);
     return Scaffold(
       appBar: AppBar(
         title: const Text('Yêu cầu tham gia'),

--- a/lib/pages/social/recruitment/recruitment_form_manager.dart
+++ b/lib/pages/social/recruitment/recruitment_form_manager.dart
@@ -25,6 +25,7 @@ class RecruitmentFormManager with ChangeNotifier {
   bool _isLoadingCourts = false;
   bool _isSubmitting = false;
   DateTime _selectedDateTime = DateTime.now().add(const Duration(hours: 2));
+  late DateTime _selectedExpiresAt = _selectedDateTime;
   List<BookedCourtOption> _bookedCourts = const [];
   BookedCourtOption? _selectedCourt;
   String? _courtMessage;
@@ -36,6 +37,7 @@ class RecruitmentFormManager with ChangeNotifier {
   bool get isLoadingCourts => _isLoadingCourts;
   bool get isSubmitting => _isSubmitting;
   DateTime get selectedDateTime => _selectedDateTime;
+  DateTime get selectedExpiresAt => _selectedExpiresAt;
   List<BookedCourtOption> get bookedCourts => _bookedCourts;
   BookedCourtOption? get selectedCourt => _selectedCourt;
   String? get courtMessage => _courtMessage;
@@ -65,11 +67,19 @@ class RecruitmentFormManager with ChangeNotifier {
 
   Future<void> updateSelectedDateTime(DateTime value) async {
     _selectedDateTime = value;
+    if (_selectedExpiresAt.isBefore(value)) {
+      _selectedExpiresAt = value;
+    }
     if (_hasBookedCourt) {
       await _loadBookedCourts();
     } else {
       notifyListeners();
     }
+  }
+
+  void updateExpiresAt(DateTime value) {
+    _selectedExpiresAt = value;
+    notifyListeners();
   }
 
   void updateSelectedCourt(String? bookingId) {
@@ -131,6 +141,7 @@ class RecruitmentFormManager with ChangeNotifier {
         note: noteController.text,
         courtId: _selectedCourt?.courtId,
         locationNote: _selectedCourt?.bookingView.courtLocation,
+        expiresAt: _selectedExpiresAt,
       );
       return result;
     } finally {

--- a/lib/pages/social/recruitment/recruitment_page.dart
+++ b/lib/pages/social/recruitment/recruitment_page.dart
@@ -8,25 +8,30 @@ import 'package:badminton_booking_app/pages/social/recruitment/widgets/play_styl
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/skill_level_selector.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/submit_button.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class RecruitmentFormPage extends StatelessWidget {
   const RecruitmentFormPage({super.key});
 
-  Future<void> _pickDateTime(BuildContext context) async {
-    final manager = context.read<RecruitmentFormManager>();
-    final initialDate = manager.selectedDateTime;
+  Future<void> _pickDateTime(
+    BuildContext context, {
+    required DateTime initialDateTime,
+    required Future<void> Function(DateTime) onSelected,
+    String? dateHelpText,
+  }) async {
     final date = await showDatePicker(
       context: context,
-      initialDate: initialDate,
+      initialDate: initialDateTime,
       firstDate: DateTime.now(),
       lastDate: DateTime.now().add(const Duration(days: 30)),
+      helpText: dateHelpText,
     );
     if (date == null) return;
 
     final time = await showTimePicker(
       context: context,
-      initialTime: TimeOfDay.fromDateTime(initialDate),
+      initialTime: TimeOfDay.fromDateTime(initialDateTime),
     );
     if (time == null) return;
 
@@ -37,7 +42,7 @@ class RecruitmentFormPage extends StatelessWidget {
       time.hour,
       time.minute,
     );
-    await manager.updateSelectedDateTime(newDateTime);
+    await onSelected(newDateTime);
   }
 
   @override
@@ -49,6 +54,7 @@ class RecruitmentFormPage extends StatelessWidget {
           final manager = context.watch<RecruitmentFormManager>();
           final cs = Theme.of(context).colorScheme;
           final textTheme = Theme.of(context).textTheme;
+          final dateFormatter = DateFormat('HH:mm - dd/MM/yyyy');
 
           return Scaffold(
             appBar: AppBar(title: const Text('Tạo bài tuyển thành viên')),
@@ -60,6 +66,23 @@ class RecruitmentFormPage extends StatelessWidget {
                   children: [
                     IntroCard(cs: cs, textTheme: textTheme),
                     const SizedBox(height: 24),
+
+                    Text('Giờ đánh dự kiến', style: textTheme.titleMedium),
+                    const SizedBox(height: 12),
+                    GestureDetector(
+                      onTap: () => _pickDateTime(
+                        context,
+                        initialDateTime: manager.selectedDateTime,
+                        onSelected: manager.updateSelectedDateTime,
+                        dateHelpText: 'Chọn ngày giờ đánh',
+                      ),
+                      child: _DateTimeField(
+                        label: 'Giờ đánh dự kiến',
+                        value: dateFormatter.format(manager.selectedDateTime),
+                        cs: cs,
+                      ),
+                    ),
+                    const SizedBox(height: 20),
 
                     SwitchListTile.adaptive(
                       contentPadding: EdgeInsets.zero,
@@ -80,16 +103,34 @@ class RecruitmentFormPage extends StatelessWidget {
                                     child: CircularProgressIndicator(),
                                   ),
                                 )
-                              : CourtInfoSection(
-                                  selectedCourtId:
-                                      manager.selectedCourt?.id,
-                                  availableCourts: manager.bookedCourts,
-                                  selectedDateTime: manager.selectedDateTime,
-                                  onCourtChanged: manager.updateSelectedCourt,
-                                  onPickDateTime: () => _pickDateTime(context),
-                                  message: manager.courtMessage,
-                                )
+                            : CourtInfoSection(
+                                selectedCourtId:
+                                    manager.selectedCourt?.id,
+                                availableCourts: manager.bookedCourts,
+                                onCourtChanged: manager.updateSelectedCourt,
+                                message: manager.courtMessage,
+                              )
                           : const NoCourtInfoBox(),
+                    ),
+
+                    const SizedBox(height: 24),
+                    Text('Thời gian tự đóng bài', style: textTheme.titleMedium),
+                    const SizedBox(height: 12),
+                    GestureDetector(
+                      onTap: () => _pickDateTime(
+                        context,
+                        initialDateTime: manager.selectedExpiresAt,
+                        onSelected: (value) async {
+                          manager.updateExpiresAt(value);
+                        },
+                        dateHelpText: 'Chọn thời gian đóng bài',
+                      ),
+                      child: _DateTimeField(
+                        label:
+                            'Bài đăng sẽ tự đóng vào thời điểm này (theo giờ địa phương)',
+                        value: dateFormatter.format(manager.selectedExpiresAt),
+                        cs: cs,
+                      ),
                     ),
 
                     const SizedBox(height: 24),
@@ -142,6 +183,40 @@ class RecruitmentFormPage extends StatelessWidget {
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+class _DateTimeField extends StatelessWidget {
+  const _DateTimeField({
+    required this.label,
+    required this.value,
+    required this.cs,
+  });
+
+  final String label;
+  final String value;
+  final ColorScheme cs;
+
+  @override
+  Widget build(BuildContext context) {
+    return InputDecorator(
+      decoration: InputDecoration(
+        labelText: label,
+        filled: true,
+        fillColor: cs.surfaceVariant.withOpacity(0.6),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide.none,
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(child: Text(value)),
+          const Icon(Icons.calendar_month_outlined),
+        ],
       ),
     );
   }

--- a/lib/pages/social/recruitment/widgets/court_info_section.dart
+++ b/lib/pages/social/recruitment/widgets/court_info_section.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
-
 import '../../../../services/recruitment_service.dart';
 
 class CourtInfoSection extends StatelessWidget {
@@ -8,17 +6,13 @@ class CourtInfoSection extends StatelessWidget {
     super.key,
     required this.selectedCourtId,
     required this.availableCourts,
-    required this.selectedDateTime,
     required this.onCourtChanged,
-    required this.onPickDateTime,
     this.message,
   });
 
   final String? selectedCourtId;
   final List<BookedCourtOption> availableCourts;
-  final DateTime selectedDateTime;
   final ValueChanged<String?> onCourtChanged;
-  final VoidCallback onPickDateTime;
   final String? message;
 
   @override
@@ -53,20 +47,6 @@ class CourtInfoSection extends StatelessWidget {
                 .toList(growable: false),
             onChanged: onCourtChanged,
           ),
-        const SizedBox(height: 16),
-        GestureDetector(
-          onTap: onPickDateTime,
-          child: InputDecorator(
-            decoration: _inputDecoration(cs, 'Giờ đánh dự kiến'),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(DateFormat('HH:mm - dd/MM/yyyy').format(selectedDateTime)),
-                const Icon(Icons.calendar_month_outlined),
-              ],
-            ),
-          ),
-        ),
       ],
     );
   }

--- a/lib/services/recruitment_service.dart
+++ b/lib/services/recruitment_service.dart
@@ -34,7 +34,7 @@ class RecruitmentService {
             sort: '-created',
             expand: 'author,court',
             filter:
-                "(expires_at = '' || expires_at = null || expires_at >= '${DateTime.now().toUtc().toIso8601String()}')",
+                "is_active = true && (expires_at = '' || expires_at = null || expires_at >= '${DateTime.now().toUtc().toIso8601String()}')",
           );
 
       final applicantsMap = await _fetchApplicantsMap(
@@ -273,6 +273,7 @@ class RecruitmentService {
     String? note,
     String? courtId,
     String? locationNote,
+    DateTime? expiresAt,
   }) async {
     final pocketBase = await getPocketbaseInstance();
     final currentUserId = pocketBase.authStore.record?.id;
@@ -292,6 +293,7 @@ class RecruitmentService {
           'court': hasBookedCourt ? courtId : null,
           'location_note': locationNote,
           'is_active': true,
+          'expires_at': expiresAt?.toUtc().toIso8601String(),
         },
       );
 


### PR DESCRIPTION
## Summary
- separate play time selection from the booked-court toggle on the recruitment form and add an auto-close time picker
- persist the selected expiration time to recruitment posts and treat expired posts as inactive
- ensure the close-post action appears on the management page for post owners even when ownership metadata is missing

## Testing
- dart format lib/pages/social/recruitment/recruitment_page.dart lib/pages/social/recruitment/widgets/court_info_section.dart lib/pages/social/recruitment/recruitment_applicants_page.dart lib/models/recruitment_post.dart lib/pages/social/recruitment/recruitment_form_manager.dart lib/services/recruitment_service.dart *(fails: dart command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926c45a5804832b891a0ed624a046b1)