### PR TITLE
Add recruitment expiry scheduling and UI updates

### DIFF
--- a/lib/components/recruitment_post_card.dart
+++ b/lib/components/recruitment_post_card.dart
@@ -18,6 +18,7 @@ class RecruitmentPostCard extends StatelessWidget {
   final bool isOwner;
   final bool isJoinLoading;
   final bool isActive;
+  final String? currentUserStatus;
   final VoidCallback? onManage;
 
   const RecruitmentPostCard({
@@ -38,6 +39,7 @@ class RecruitmentPostCard extends StatelessWidget {
     this.isOwner = false,
     this.isJoinLoading = false,
     this.isActive = true,
+    this.currentUserStatus,
     this.onManage,
   });
 
@@ -250,7 +252,11 @@ class RecruitmentPostCard extends StatelessWidget {
   Widget _buildActionButton(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
-    final bool isDisabled = !isActive || isJoined || isOwner || isJoinLoading;
+    final bool hasApplication =
+        currentUserStatus != null && currentUserStatus != 'cancelled';
+
+    final bool isDisabled =
+        !isActive || isOwner || isJoinLoading || hasApplication;
 
     return FilledButton.icon(
       onPressed: isDisabled ? null : onJoin,
@@ -271,11 +277,15 @@ class RecruitmentPostCard extends StatelessWidget {
               ),
             )
           : Icon(
-              isActive
-                  ? (isJoined
+              !isActive
+                  ? Icons.lock_rounded
+                  : currentUserStatus == 'accepted' || isJoined
                       ? Icons.check_circle_rounded
-                      : Icons.add_circle_rounded)
-                  : Icons.lock_rounded,
+                      : currentUserStatus == 'rejected'
+                          ? Icons.cancel_rounded
+                          : currentUserStatus == 'pending'
+                              ? Icons.hourglass_top_rounded
+                              : Icons.add_circle_rounded,
               size: 22,
             ),
       label: Text(
@@ -283,9 +293,13 @@ class RecruitmentPostCard extends StatelessWidget {
             ? 'Bài của bạn'
             : !isActive
                 ? 'Đã đóng'
-                : isJoined
-                    ? 'Đã tham gia'
-                    : 'Tham gia',
+                : currentUserStatus == 'pending'
+                    ? 'Chờ duyệt'
+                    : currentUserStatus == 'accepted' || isJoined
+                        ? 'Đã tham gia'
+                        : currentUserStatus == 'rejected'
+                            ? 'Từ chối'
+                            : 'Tham gia',
         style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
       ),
     );

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -18,6 +18,7 @@ class RecruitmentPost {
     required this.eventTime,
     required this.courtName,
     required this.isJoined,
+    this.currentUserStatus,
     required this.isOwner,
     required this.locationNote,
     required this.isActive,
@@ -57,12 +58,24 @@ class RecruitmentPost {
     final courtName = _sanitizeName(courtData?['name'] as String?);
     final courtId = (data['court'] as String?) ?? courtRecord?.id;
 
-    final applicantUserIds = applicants
-        .map((rec) =>
-            (rec.data['user'] as String?) ?? rec.getStringValue('user'))
-        .where((id) => id != null && id.isNotEmpty)
-        .cast<String>()
-        .toList();
+    final applicantUserIds = <String>[];
+    String? currentUserStatus;
+
+    for (final rec in applicants) {
+      final userId =
+          (rec.data['user'] as String?) ?? rec.getStringValue('user') ?? '';
+      if (userId.isEmpty) continue;
+
+      applicantUserIds.add(userId);
+
+      // Nếu đây là request của chính user đang đăng nhập
+      if (loggedInUserId != null &&
+          loggedInUserId.isNotEmpty &&
+          userId == loggedInUserId &&
+          currentUserStatus == null) {
+        currentUserStatus = (rec.data['status'] as String?) ?? 'pending';
+      }
+    }
 
     final acceptedApplicants = applicants.where((rec) {
       final status = (rec.data['status'] as String?) ?? 'pending';
@@ -70,11 +83,19 @@ class RecruitmentPost {
     }).length;
 
     final joinedCount = acceptedApplicants + 1; // tính cả chủ bài
-    final hasJoined = applicantUserIds.contains(loggedInUserId);
+
+    // Chỉ coi là "đã tham gia" khi đã được accepted hoặc là chủ bài
+    final hasJoined = currentUserStatus == 'accepted' || isOwner;
 
     final expiresAt = _tryParseDateTime(data['expires_at']);
-    final isActive = (data['is_active'] != false) &&
-        (expiresAt == null || expiresAt.isAfter(DateTime.now()));
+    final bool isActiveFlag = (data['is_active'] as bool?) ?? true;
+    final now = DateTime.now();
+
+// expires_at <= now coi là đã hết hạn
+    final bool isExpired = expiresAt != null && !expiresAt.isAfter(now);
+
+// chỉ "đang tuyển" khi DB còn active và chưa hết hạn
+    final bool isActive = isActiveFlag && !isExpired;
 
     return RecruitmentPost(
       id: record.id,
@@ -93,6 +114,7 @@ class RecruitmentPost {
       eventTime: _tryParseDateTime(data['event_time']),
       courtName: courtName,
       isJoined: hasJoined || authorId == loggedInUserId,
+      currentUserStatus: currentUserStatus,
       isOwner: isOwner,
       locationNote: (data['location_note'] as String?)?.trim(),
       isActive: isActive,
@@ -114,6 +136,7 @@ class RecruitmentPost {
   final DateTime? eventTime;
   final String? courtName;
   final bool isJoined;
+  final String? currentUserStatus;
   final bool isOwner;
   final String? locationNote;
   final bool isActive;
@@ -126,6 +149,7 @@ class RecruitmentPost {
     String? authorAvatarUrl,
     bool? isActive,
     DateTime? expiresAt,
+    String? currentUserStatus,
   }) {
     return RecruitmentPost(
       id: id,
@@ -141,6 +165,7 @@ class RecruitmentPost {
       eventTime: eventTime,
       courtName: courtName,
       isJoined: isJoined ?? this.isJoined,
+      currentUserStatus: currentUserStatus ?? this.currentUserStatus,
       isOwner: isOwner,
       locationNote: locationNote,
       isActive: isActive ?? this.isActive,

--- a/lib/models/recruitment_post.dart
+++ b/lib/models/recruitment_post.dart
@@ -72,6 +72,10 @@ class RecruitmentPost {
     final joinedCount = acceptedApplicants + 1; // tính cả chủ bài
     final hasJoined = applicantUserIds.contains(loggedInUserId);
 
+    final expiresAt = _tryParseDateTime(data['expires_at']);
+    final isActive = (data['is_active'] != false) &&
+        (expiresAt == null || expiresAt.isAfter(DateTime.now()));
+
     return RecruitmentPost(
       id: record.id,
       authorId: authorId,
@@ -91,8 +95,8 @@ class RecruitmentPost {
       isJoined: hasJoined || authorId == loggedInUserId,
       isOwner: isOwner,
       locationNote: (data['location_note'] as String?)?.trim(),
-      isActive: data['is_active'] != false,
-      expiresAt: _tryParseDateTime(data['expires_at']),
+      isActive: isActive,
+      expiresAt: expiresAt,
       hasCourt: courtId != null && courtId.isNotEmpty,
     );
   }

--- a/lib/pages/social/recruitment/recruitment_form_manager.dart
+++ b/lib/pages/social/recruitment/recruitment_form_manager.dart
@@ -25,6 +25,7 @@ class RecruitmentFormManager with ChangeNotifier {
   bool _isLoadingCourts = false;
   bool _isSubmitting = false;
   DateTime _selectedDateTime = DateTime.now().add(const Duration(hours: 2));
+  DateTime _expiresAt = DateTime.now().add(const Duration(hours: 2));
   List<BookedCourtOption> _bookedCourts = const [];
   BookedCourtOption? _selectedCourt;
   String? _courtMessage;
@@ -36,6 +37,7 @@ class RecruitmentFormManager with ChangeNotifier {
   bool get isLoadingCourts => _isLoadingCourts;
   bool get isSubmitting => _isSubmitting;
   DateTime get selectedDateTime => _selectedDateTime;
+  DateTime get expiresAt => _expiresAt;
   List<BookedCourtOption> get bookedCourts => _bookedCourts;
   BookedCourtOption? get selectedCourt => _selectedCourt;
   String? get courtMessage => _courtMessage;
@@ -65,11 +67,21 @@ class RecruitmentFormManager with ChangeNotifier {
 
   Future<void> updateSelectedDateTime(DateTime value) async {
     _selectedDateTime = value;
+    if (_expiresAt.isBefore(value)) {
+      _expiresAt = value;
+    }
     if (_hasBookedCourt) {
       await _loadBookedCourts();
     } else {
       notifyListeners();
     }
+  }
+
+  void updateExpiresAt(DateTime value) {
+    _expiresAt = value.isBefore(DateTime.now())
+        ? DateTime.now().add(const Duration(minutes: 30))
+        : value;
+    notifyListeners();
   }
 
   void updateSelectedCourt(String? bookingId) {
@@ -125,6 +137,7 @@ class RecruitmentFormManager with ChangeNotifier {
       final result = await _service.createRecruitmentPost(
         hasBookedCourt: _hasBookedCourt,
         playTime: _selectedDateTime,
+        expiresAt: _expiresAt,
         needMembers: _memberCount,
         playStyleLabel: _selectedPlayStyleLabel,
         skillLevelLabel: _selectedSkillLevelLabel,

--- a/lib/pages/social/recruitment/recruitment_page.dart
+++ b/lib/pages/social/recruitment/recruitment_page.dart
@@ -8,6 +8,7 @@ import 'package:badminton_booking_app/pages/social/recruitment/widgets/play_styl
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/skill_level_selector.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/widgets/submit_button.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class RecruitmentFormPage extends StatelessWidget {
@@ -40,6 +41,35 @@ class RecruitmentFormPage extends StatelessWidget {
     await manager.updateSelectedDateTime(newDateTime);
   }
 
+  Future<void> _pickCloseDateTime(BuildContext context) async {
+    final manager = context.read<RecruitmentFormManager>();
+    final initialDate = manager.expiresAt;
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initialDate,
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 30)),
+    );
+
+    if (date == null) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(initialDate),
+    );
+
+    if (time == null) return;
+
+    final newDateTime = DateTime(
+      date.year,
+      date.month,
+      date.day,
+      time.hour,
+      time.minute,
+    );
+    manager.updateExpiresAt(newDateTime);
+  }
+
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
@@ -59,6 +89,20 @@ class RecruitmentFormPage extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     IntroCard(cs: cs, textTheme: textTheme),
+                    const SizedBox(height: 24),
+
+                    _DateTimeField(
+                      label: 'Giờ đánh dự kiến',
+                      value: manager.selectedDateTime,
+                      onTap: () => _pickDateTime(context),
+                    ),
+                    const SizedBox(height: 12),
+                    _DateTimeField(
+                      label: 'Thời gian đóng bài',
+                      value: manager.expiresAt,
+                      helperText: 'Đến giờ này bài sẽ tự động đóng.',
+                      onTap: () => _pickCloseDateTime(context),
+                    ),
                     const SizedBox(height: 24),
 
                     SwitchListTile.adaptive(
@@ -84,9 +128,7 @@ class RecruitmentFormPage extends StatelessWidget {
                                   selectedCourtId:
                                       manager.selectedCourt?.id,
                                   availableCourts: manager.bookedCourts,
-                                  selectedDateTime: manager.selectedDateTime,
                                   onCourtChanged: manager.updateSelectedCourt,
-                                  onPickDateTime: () => _pickDateTime(context),
                                   message: manager.courtMessage,
                                 )
                           : const NoCourtInfoBox(),
@@ -143,6 +185,52 @@ class RecruitmentFormPage extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+}
+
+class _DateTimeField extends StatelessWidget {
+  const _DateTimeField({
+    required this.label,
+    required this.value,
+    required this.onTap,
+    this.helperText,
+  });
+
+  final String label;
+  final DateTime value;
+  final String? helperText;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        GestureDetector(
+          onTap: onTap,
+          child: InputDecorator(
+            decoration: InputDecoration(
+              labelText: label,
+              helperText: helperText,
+              filled: true,
+              fillColor: cs.surfaceVariant.withOpacity(0.6),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide.none,
+              ),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(DateFormat('HH:mm - dd/MM/yyyy').format(value)),
+                const Icon(Icons.calendar_month_outlined),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/social/recruitment/widgets/court_info_section.dart
+++ b/lib/pages/social/recruitment/widgets/court_info_section.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
-
 import '../../../../services/recruitment_service.dart';
 
 class CourtInfoSection extends StatelessWidget {
@@ -8,17 +6,13 @@ class CourtInfoSection extends StatelessWidget {
     super.key,
     required this.selectedCourtId,
     required this.availableCourts,
-    required this.selectedDateTime,
     required this.onCourtChanged,
-    required this.onPickDateTime,
     this.message,
   });
 
   final String? selectedCourtId;
   final List<BookedCourtOption> availableCourts;
-  final DateTime selectedDateTime;
   final ValueChanged<String?> onCourtChanged;
-  final VoidCallback onPickDateTime;
   final String? message;
 
   @override
@@ -53,20 +47,6 @@ class CourtInfoSection extends StatelessWidget {
                 .toList(growable: false),
             onChanged: onCourtChanged,
           ),
-        const SizedBox(height: 16),
-        GestureDetector(
-          onTap: onPickDateTime,
-          child: InputDecorator(
-            decoration: _inputDecoration(cs, 'Giờ đánh dự kiến'),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(DateFormat('HH:mm - dd/MM/yyyy').format(selectedDateTime)),
-                const Icon(Icons.calendar_month_outlined),
-              ],
-            ),
-          ),
-        ),
       ],
     );
   }

--- a/lib/pages/social/recruitment_manager.dart
+++ b/lib/pages/social/recruitment_manager.dart
@@ -38,7 +38,7 @@ class RecruitmentManager extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final results = await _service.fetchActivePosts();
+      final results = await _service.fetchRecruitmentPosts();
       _recruitmentPosts = results;
     } on RecruitmentServiceException catch (error) {
       _recruitmentError = error.message;

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -408,6 +408,13 @@ class _SocialPageState extends State<SocialPage> {
             locationNote: post.locationNote,
             onJoin: () async {
               if (!post.isActive) return;
+
+              // Nếu đã có status (pending/accepted/rejected) thì không join lại
+              if (post.currentUserStatus != null &&
+                  post.currentUserStatus != 'cancelled') {
+                return;
+              }
+
               try {
                 await manager.joinRecruitment(post.id);
               } catch (error) {
@@ -421,6 +428,7 @@ class _SocialPageState extends State<SocialPage> {
             isOwner: post.isOwner,
             isJoinLoading: manager.isJoining(post.id),
             isActive: post.isActive,
+            currentUserStatus: post.currentUserStatus,
             onManage: post.isOwner
                 ? () {
                     Navigator.of(context).push(

--- a/lib/services/recruitment_service.dart
+++ b/lib/services/recruitment_service.dart
@@ -17,10 +17,11 @@ class RecruitmentServiceException implements Exception {
 
 class RecruitmentService {
   static const String recruitmentPostsCollection = 'recruitment_posts';
-  static const String recruitmentApplicantsCollection = 'recruitment_applicants';
+  static const String recruitmentApplicantsCollection =
+      'recruitment_applicants';
   static const String bookingsCollection = 'court_bookings';
 
-  Future<List<RecruitmentPost>> fetchActivePosts({
+  Future<List<RecruitmentPost>> fetchRecruitmentPosts({
     int page = 1,
     int perPage = 30,
   }) async {
@@ -28,16 +29,13 @@ class RecruitmentService {
     final currentUserId = pocketBase.authStore.record?.id;
 
     try {
-      final result = await pocketBase
-          .collection(recruitmentPostsCollection)
-          .getList(
-            page: page,
-            perPage: perPage,
-            sort: '-created',
-            expand: 'author,court',
-            filter:
-                "is_active = true && (expires_at = '' || expires_at = null || expires_at >= '${DateTime.now().toUtc().toIso8601String()}')",
-          );
+      final result =
+          await pocketBase.collection(recruitmentPostsCollection).getList(
+                page: page,
+                perPage: perPage,
+                sort: '-created',
+                expand: 'author,court',
+              );
 
       final applicantsMap = await _fetchApplicantsMap(
         pocketBase: pocketBase,
@@ -126,13 +124,14 @@ class RecruitmentService {
     final userDetailsService = UserDetailsService();
 
     try {
-      final result = await pocketBase.collection(recruitmentApplicantsCollection).getList(
-            page: 1,
-            perPage: 200,
-            filter: "recruitment='${_escapeFilterValue(recruitmentId)}'",
-            expand: 'user',
-            sort: '-created',
-          );
+      final result =
+          await pocketBase.collection(recruitmentApplicantsCollection).getList(
+                page: 1,
+                perPage: 200,
+                filter: "recruitment='${_escapeFilterValue(recruitmentId)}'",
+                expand: 'user',
+                sort: '-created',
+              );
 
       final applicants = <RecruitmentApplicant>[];
 
@@ -196,14 +195,16 @@ class RecruitmentService {
 
       final recruitmentId = record.data['recruitment'] as String?;
       if (recruitmentId == null || recruitmentId.isEmpty) {
-        throw RecruitmentServiceException('Không tìm thấy bài tuyển liên quan.');
+        throw RecruitmentServiceException(
+            'Không tìm thấy bài tuyển liên quan.');
       }
 
       return getRecruitmentById(recruitmentId);
     } on ClientException catch (error) {
       throw RecruitmentServiceException(_mapClientError(error));
     } catch (_) {
-      throw RecruitmentServiceException('Không thể cập nhật trạng thái yêu cầu.');
+      throw RecruitmentServiceException(
+          'Không thể cập nhật trạng thái yêu cầu.');
     }
   }
 
@@ -284,13 +285,16 @@ class RecruitmentService {
     }
 
     try {
-      final record = await pocketBase.collection(recruitmentPostsCollection).create(
+      final record =
+          await pocketBase.collection(recruitmentPostsCollection).create(
         body: {
           'author': currentUserId,
           'content': note?.trim(),
           'need_members': needMembers,
-          'play_style': RecruitmentDictionary.playStyleValueFromLabel(playStyleLabel),
-          'skill_level': RecruitmentDictionary.skillValueFromLabel(skillLevelLabel),
+          'play_style':
+              RecruitmentDictionary.playStyleValueFromLabel(playStyleLabel),
+          'skill_level':
+              RecruitmentDictionary.skillValueFromLabel(skillLevelLabel),
           'event_time': playTime.toUtc().toIso8601String(),
           'expires_at': expiresAt.toUtc().toIso8601String(),
           'court': hasBookedCourt ? courtId : null,
@@ -326,11 +330,12 @@ class RecruitmentService {
         .join(' || ');
 
     try {
-      final result = await pocketBase.collection(recruitmentApplicantsCollection).getList(
-            page: 1,
-            perPage: 500,
-            filter: filters,
-          );
+      final result =
+          await pocketBase.collection(recruitmentApplicantsCollection).getList(
+                page: 1,
+                perPage: 500,
+                filter: filters,
+              );
 
       final map = <String, List<RecordModel>>{};
       for (final record in result.items) {

--- a/lib/services/recruitment_service.dart
+++ b/lib/services/recruitment_service.dart
@@ -28,13 +28,15 @@ class RecruitmentService {
     final currentUserId = pocketBase.authStore.record?.id;
 
     try {
-      final result = await pocketBase.collection(recruitmentPostsCollection).getList(
+      final result = await pocketBase
+          .collection(recruitmentPostsCollection)
+          .getList(
             page: page,
             perPage: perPage,
             sort: '-created',
             expand: 'author,court',
             filter:
-                "(expires_at = '' || expires_at = null || expires_at >= '${DateTime.now().toUtc().toIso8601String()}')",
+                "is_active = true && (expires_at = '' || expires_at = null || expires_at >= '${DateTime.now().toUtc().toIso8601String()}')",
           );
 
       final applicantsMap = await _fetchApplicantsMap(
@@ -267,6 +269,7 @@ class RecruitmentService {
   Future<RecruitmentPost> createRecruitmentPost({
     required bool hasBookedCourt,
     required DateTime playTime,
+    required DateTime expiresAt,
     required int needMembers,
     required String playStyleLabel,
     required String skillLevelLabel,
@@ -289,6 +292,7 @@ class RecruitmentService {
           'play_style': RecruitmentDictionary.playStyleValueFromLabel(playStyleLabel),
           'skill_level': RecruitmentDictionary.skillValueFromLabel(skillLevelLabel),
           'event_time': playTime.toUtc().toIso8601String(),
+          'expires_at': expiresAt.toUtc().toIso8601String(),
           'court': hasBookedCourt ? courtId : null,
           'location_note': locationNote,
           'is_active': true,


### PR DESCRIPTION
## Summary
- Separate the play time picker from the booked court toggle and add a closing time selector when creating recruitment posts
- Send the chosen closing time to PocketBase and treat expired recruitment posts as inactive
- Ensure closed posts display the inactive state and disable joining actions

## Testing
- Not run (Flutter/Dart SDK not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926cf83a65c832ba620a53621f4ef42)