### PR TITLE
Integrate booking realtime into booking service

### DIFF
--- a/lib/components/my_court_time.dart
+++ b/lib/components/my_court_time.dart
@@ -1,4 +1,5 @@
 // lib/components/my_court_time.dart
+import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -72,6 +73,8 @@ class _CourtTimelineState extends State<CourtTimeline> {
   late final ScrollController _leftColumnCtrl;
   final ScrollController _gridVerticalCtrl = ScrollController();
 
+  Timer? _nowTimer;
+
   bool _horizontalSyncing = false;
   bool _verticalSyncing = false;
 
@@ -109,6 +112,8 @@ class _CourtTimelineState extends State<CourtTimeline> {
     _gridCtrl.addListener(_handleGridHorizontalScroll);
     _leftColumnCtrl.addListener(_handleLeftVerticalScroll);
     _gridVerticalCtrl.addListener(_handleGridVerticalScroll);
+
+    _startNowTimer();
   }
 
   @override
@@ -144,7 +149,24 @@ class _CourtTimelineState extends State<CourtTimeline> {
     _gridVerticalCtrl
       ..removeListener(_handleGridVerticalScroll)
       ..dispose();
+    _nowTimer?.cancel();
     super.dispose();
+  }
+
+  void _startNowTimer() {
+    _nowTimer?.cancel();
+    _nowTimer = Timer.periodic(const Duration(minutes: 1), (_) {
+      if (!mounted) return;
+      setState(() {
+        _nowLocal = DateTime.now();
+        _todayLocal = DateTime(
+          _nowLocal.year,
+          _nowLocal.month,
+          _nowLocal.day,
+        );
+        _statusMatrix = _buildStatusMatrix();
+      });
+    });
   }
 
   void _handleHeaderScroll() {

--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
+import 'package:pocketbase/pocketbase.dart';
 
 import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court_detail.dart';
@@ -20,6 +21,7 @@ class BookingManager extends ChangeNotifier {
     _selectedDate = _normalizeDate(DateTime.now());
 
     Future.microtask(() => loadBookings());
+    Future.microtask(_setupRealtimeSubscription);
   }
 
   final CourtDetailData detailData;
@@ -30,6 +32,8 @@ class BookingManager extends ChangeNotifier {
   DateTime _selectedDate = DateTime.now();
   int _selectedUnitGroupIndex = 0;
   String? _currentUserId;
+
+  bool _isDisposed = false;
 
   bool _isLoading = false;
   bool _isSubmittingHeldBookings = false;
@@ -45,6 +49,8 @@ class BookingManager extends ChangeNotifier {
 
   final Map<String, _BookingCacheEntry> _bookingCacheByKey =
       <String, _BookingCacheEntry>{};
+
+  UnsubscribeFunc? _bookingRealtimeUnsubscribe;
 
   DateTime get selectedDate => _selectedDate;
   int get selectedUnitGroupIndex => _selectedUnitGroupIndex;
@@ -138,6 +144,17 @@ class BookingManager extends ChangeNotifier {
     unawaited(loadBookings(forceRefresh: true));
   }
 
+  @override
+  void dispose() {
+    _isDisposed = true;
+    final unsubscribe = _bookingRealtimeUnsubscribe;
+    _bookingRealtimeUnsubscribe = null;
+    if (unsubscribe != null) {
+      unawaited(unsubscribe());
+    }
+    super.dispose();
+  }
+
   Future<void> changeDate(DateTime date) async {
     final normalized = _normalizeDate(date);
     if (normalized.isAtSameMomentAs(_selectedDate)) {
@@ -147,6 +164,7 @@ class BookingManager extends ChangeNotifier {
     _friendlyErrorMessage = null;
     notifyListeners();
     await loadBookings();
+    await _setupRealtimeSubscription();
   }
 
   Future<void> changeCourtUnitGroup(int groupIndex) async {
@@ -198,6 +216,34 @@ class BookingManager extends ChangeNotifier {
   }
 
   Future<void> refreshBookings() => loadBookings(forceRefresh: true);
+
+  Future<void> _setupRealtimeSubscription() async {
+    try {
+      final previous = _bookingRealtimeUnsubscribe;
+      _bookingRealtimeUnsubscribe = null;
+      if (previous != null) {
+        await previous();
+      }
+
+      _bookingRealtimeUnsubscribe = await _bookingService.subscribeBookings(
+        courtId: detailData.court.id,
+        date: _selectedDate,
+        onEvent: _handleBookingRealtimeEvent,
+      );
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to initialize booking realtime: $error');
+        debugPrint(stackTrace.toString());
+      }
+    }
+  }
+
+  Future<void> _handleBookingRealtimeEvent(
+    RecordSubscriptionEvent event,
+  ) async {
+    if (_isDisposed) return;
+    await loadBookings(forceRefresh: true);
+  }
 
   Future<void> holdSlot(SelectedSlot slot) async {
     if (_currentUserId == null || _currentUserId!.isEmpty) {

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -46,6 +46,27 @@ class BookingService {
     }
   }
 
+  Future<UnsubscribeFunc> subscribeBookings({
+    required String courtId,
+    required DateTime date,
+    required RecordSubscriptionCallback onEvent,
+  }) async {
+    final pb = await getPocketbaseInstance();
+
+    final dayStart = DateTime(date.year, date.month, date.day).toUtc();
+    final dayEnd = dayStart.add(const Duration(days: 1));
+
+    final escapedCourt = _escapeFilterValue(courtId);
+    final filter =
+        "court_id='$escapedCourt' && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'";
+
+    return pb.collection(collection).subscribe(
+          '*',
+          onEvent,
+          filter: filter,
+        );
+  }
+
   Future<List<UserBookingView>> listUserBookings({
     required String userId,
     DateTime? startTimeInclusive,


### PR DESCRIPTION
## Summary
- move booking realtime subscription into the existing BookingService instead of a separate helper
- adjust BookingManager to use the unified service for realtime lifecycle management

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928e42b9b88832bb72d7754937a26f0)