### PR TITLE
Add realtime booking updates and timeline clock refresh

### DIFF
--- a/lib/components/my_court_time.dart
+++ b/lib/components/my_court_time.dart
@@ -1,4 +1,5 @@
 // lib/components/my_court_time.dart
+import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -79,6 +80,7 @@ class _CourtTimelineState extends State<CourtTimeline> {
   late List<List<CourtSlotStatus>> _statusMatrix;
   late DateTime _nowLocal;
   late DateTime _todayLocal;
+  Timer? _clockTicker;
 
   _DragOperation _currentDragOp = _DragOperation.none;
   final Set<_CellCoordinate> _draggedCells = <_CellCoordinate>{};
@@ -104,6 +106,7 @@ class _CourtTimelineState extends State<CourtTimeline> {
     _nowLocal = DateTime.now();
     _todayLocal = DateTime(_nowLocal.year, _nowLocal.month, _nowLocal.day);
     _statusMatrix = _buildStatusMatrix();
+    _startClockTicker();
 
     _headerCtrl.addListener(_handleHeaderScroll);
     _gridCtrl.addListener(_handleGridHorizontalScroll);
@@ -144,7 +147,21 @@ class _CourtTimelineState extends State<CourtTimeline> {
     _gridVerticalCtrl
       ..removeListener(_handleGridVerticalScroll)
       ..dispose();
+    _clockTicker?.cancel();
     super.dispose();
+  }
+
+  void _startClockTicker() {
+    _clockTicker?.cancel();
+    _clockTicker = Timer.periodic(const Duration(minutes: 1), (_) {
+      if (!mounted) return;
+      setState(() {
+        _nowLocal = DateTime.now();
+        _todayLocal =
+            DateTime(_nowLocal.year, _nowLocal.month, _nowLocal.day);
+        _statusMatrix = _buildStatusMatrix();
+      });
+    });
   }
 
   void _handleHeaderScroll() {

--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -3,9 +3,11 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
+import 'package:pocketbase/pocketbase.dart';
 
 import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court_detail.dart';
+import 'package:badminton_booking_app/services/booking_realtime_service.dart';
 import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
 
@@ -26,6 +28,7 @@ class BookingManager extends ChangeNotifier {
   final Duration slotDuration;
   final int unitGroupSize;
   final BookingService _bookingService;
+  final BookingRealtimeService _realtimeService = BookingRealtimeService();
 
   DateTime _selectedDate = DateTime.now();
   int _selectedUnitGroupIndex = 0;
@@ -45,6 +48,12 @@ class BookingManager extends ChangeNotifier {
 
   final Map<String, _BookingCacheEntry> _bookingCacheByKey =
       <String, _BookingCacheEntry>{};
+
+  @override
+  void dispose() {
+    _realtimeService.dispose();
+    super.dispose();
+  }
 
   DateTime get selectedDate => _selectedDate;
   int get selectedUnitGroupIndex => _selectedUnitGroupIndex;
@@ -190,6 +199,7 @@ class BookingManager extends ChangeNotifier {
       _syncSelectedSlotsWithBookings();
       _isLoading = false;
       notifyListeners();
+      unawaited(_subscribeToRealtime());
     } catch (error) {
       _isLoading = false;
       _friendlyErrorMessage = _describeFriendlyError(error);
@@ -198,6 +208,46 @@ class BookingManager extends ChangeNotifier {
   }
 
   Future<void> refreshBookings() => loadBookings(forceRefresh: true);
+
+  Future<void> _subscribeToRealtime() async {
+    await _realtimeService.subscribeToBookings(
+      courtId: detailData.court.id,
+      date: _selectedDate,
+      onChange: _handleRealtimeEvent,
+    );
+  }
+
+  void _handleRealtimeEvent(RealtimeEvent event) {
+    final record = event.record;
+    if (record == null) return;
+
+    final incoming = CourtBooking.fromRecord(record);
+    final updated = List<CourtBooking>.from(_loadedBookings);
+
+    switch (event.action) {
+      case 'delete':
+        updated.removeWhere((item) => item.id == incoming.id);
+        break;
+      case 'create':
+        updated.add(incoming);
+        break;
+      case 'update':
+        final index = updated.indexWhere((item) => item.id == incoming.id);
+        if (index >= 0) {
+          updated[index] = incoming;
+        } else {
+          updated.add(incoming);
+        }
+        break;
+      default:
+        return;
+    }
+
+    _loadedBookings = updated;
+    _updateCache(_loadedBookings, _selectedDate);
+    _syncSelectedSlotsWithBookings();
+    notifyListeners();
+  }
 
   Future<void> holdSlot(SelectedSlot slot) async {
     if (_currentUserId == null || _currentUserId!.isEmpty) {

--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -217,7 +217,7 @@ class BookingManager extends ChangeNotifier {
     );
   }
 
-  void _handleRealtimeEvent(RealtimeEvent event) {
+  void _handleRealtimeEvent(RecordSubscriptionEvent event) {
     final record = event.record;
     if (record == null) return;
 
@@ -325,43 +325,55 @@ class BookingManager extends ChangeNotifier {
   }
 
   Future<void> submitHeldBookings() async {
-    if (_heldBookingsBySlot.isEmpty) {
-      return;
-    }
+    if (_heldBookingsBySlot.isEmpty) return;
 
     _isSubmittingHeldBookings = true;
     notifyListeners();
 
+    // ✅ LẤY SNAPSHOT TRƯỚC KHI BẮT ĐẦU, TRÁNH BỊ REALTIME LÀM THAY ĐỔI MAP
+    final bookingsToSubmit = _heldBookingsBySlot.values.toList(growable: false);
+
+    final updatedBookings = <CourtBooking>[];
+    final processedBookingIds = <String>{};
+
     try {
-      final updatedBookings = <CourtBooking>[];
-      final processedBookingIds = <String>{};
-      for (final booking in _heldBookingsBySlot.values) {
-        if (processedBookingIds.contains(booking.id)) {
-          continue;
-        }
+      // 1) Cập nhật trạng thái trên server
+      for (final booking in bookingsToSubmit) {
+        if (processedBookingIds.contains(booking.id)) continue;
         final updated = await _bookingService.submitForApproval(booking.id);
         processedBookingIds.add(booking.id);
         updatedBookings.add(updated);
       }
 
+      // 2) Cập nhật lại list local
       final updatedList = List<CourtBooking>.from(_loadedBookings);
       for (final updated in updatedBookings) {
-        final index = updatedList.indexWhere((item) => item.id == updated.id);
-        if (index >= 0) {
+        final index = updatedList.indexWhere((b) => b.id == updated.id);
+        if (index != -1) {
           updatedList[index] = updated;
+        } else {
+          updatedList.add(updated);
         }
       }
 
       _loadedBookings = updatedList;
       _updateCache(_loadedBookings, _selectedDate);
+
+      // Sau khi submit xong, mình chủ động clear lựa chọn hiện tại
       _heldBookingsBySlot.clear();
       _selectedSlots.clear();
       notifyListeners();
-      await loadBookings(forceRefresh: true);
-    } catch (error) {
-      _isSubmittingHeldBookings = false;
-      notifyListeners();
-      throw BookingManagerException(_describeFriendlyError(error));
+
+      // 3) Refresh lại ngầm, nếu lỗi thì log nhưng KHÔNG báo lỗi cho user
+      unawaited(
+        loadBookings(forceRefresh: true).catchError((error, stack) {
+          if (kDebugMode) {
+            print('loadBookings after submitHeldBookings failed: $error');
+          }
+        }),
+      );
+    } on BookingServiceException catch (error) {
+      throw BookingManagerException(error.message);
     } finally {
       _isSubmittingHeldBookings = false;
       notifyListeners();

--- a/lib/pages/court/booking_page.dart
+++ b/lib/pages/court/booking_page.dart
@@ -518,7 +518,7 @@ class _BookingPageViewState extends State<_BookingPageView> {
                       width: 22,
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
-                  : const Text('Chuyển sang thanh toán'),
+                  : const Text('Xác nhận'),
             ),
           ),
           const SizedBox(height: 10),

--- a/lib/services/booking_realtime_service.dart
+++ b/lib/services/booking_realtime_service.dart
@@ -4,34 +4,42 @@ import 'booking_service.dart';
 import 'pocketbase_client.dart';
 
 class BookingRealtimeService {
-  RealtimeSubscription? _subscription;
+  /// Hàm hủy subscribe do PocketBase trả về
+  UnsubscribeFunc? _unsubscribe;
 
   Future<void> subscribeToBookings({
     required String courtId,
     required DateTime date,
-    required void Function(RealtimeEvent event) onChange,
+    required void Function(RecordSubscriptionEvent event) onChange,
   }) async {
     final pb = await getPocketbaseInstance();
+
+    // Hủy đăng ký cũ (nếu có)
     await unsubscribe();
 
+    // Tính khoảng thời gian trong ngày
     final dayStart = DateTime(date.year, date.month, date.day).toUtc();
     final dayEnd = dayStart.add(const Duration(days: 1));
 
+    // Filter theo sân + khoảng thời gian trong ngày
     final escapedCourt = _escapeFilterValue(courtId);
     final filter =
         "court_id='$escapedCourt' && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'";
 
-    _subscription = await pb.collection(BookingService.collection).subscribe(
-      filter,
-      (event) => onChange(event),
-    );
+    // SDK mới: topic là '*', filter truyền qua named param
+    _unsubscribe = await pb.collection(BookingService.collection).subscribe(
+          '*', // lắng nghe tất cả record của collection này
+          (event) => onChange(event),
+          filter: filter,
+        );
   }
 
   Future<void> unsubscribe() async {
-    if (_subscription == null) return;
-    final pb = await getPocketbaseInstance();
-    await pb.collection(BookingService.collection).unsubscribe(_subscription!);
-    _subscription = null;
+    final unsub = _unsubscribe;
+    _unsubscribe = null;
+    if (unsub != null) {
+      await unsub(); // gọi hàm hủy do PocketBase trả về
+    }
   }
 
   Future<void> dispose() async {

--- a/lib/services/booking_realtime_service.dart
+++ b/lib/services/booking_realtime_service.dart
@@ -1,0 +1,44 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import 'booking_service.dart';
+import 'pocketbase_client.dart';
+
+class BookingRealtimeService {
+  RealtimeSubscription? _subscription;
+
+  Future<void> subscribeToBookings({
+    required String courtId,
+    required DateTime date,
+    required void Function(RealtimeEvent event) onChange,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    await unsubscribe();
+
+    final dayStart = DateTime(date.year, date.month, date.day).toUtc();
+    final dayEnd = dayStart.add(const Duration(days: 1));
+
+    final escapedCourt = _escapeFilterValue(courtId);
+    final filter =
+        "court_id='$escapedCourt' && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'";
+
+    _subscription = await pb.collection(BookingService.collection).subscribe(
+      filter,
+      (event) => onChange(event),
+    );
+  }
+
+  Future<void> unsubscribe() async {
+    if (_subscription == null) return;
+    final pb = await getPocketbaseInstance();
+    await pb.collection(BookingService.collection).unsubscribe(_subscription!);
+    _subscription = null;
+  }
+
+  Future<void> dispose() async {
+    await unsubscribe();
+  }
+
+  String _escapeFilterValue(String value) {
+    return value.replaceAll("'", "\\'");
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable booking realtime service that subscribes to PocketBase updates filtered by court and date
- integrate realtime refreshes into `BookingManager`, keeping caches and selections in sync on create/update/delete events
- refresh the court timeline every minute with a periodic timer so past slots lock automatically

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a65913834832bb3e77379057de449)