### PR TITLE
Add partner suggestion UI to social page

### DIFF
--- a/lib/components/player_suggestion_card.dart
+++ b/lib/components/player_suggestion_card.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+class PlayerSuggestionCard extends StatelessWidget {
+  const PlayerSuggestionCard({
+    super.key,
+    required this.name,
+    required this.level,
+    required this.matchScore,
+    required this.playTags,
+    required this.intensityLabel,
+    required this.onProfileTap,
+    required this.onInviteTap,
+    this.avatarColor,
+    this.avatarInitial,
+  });
+
+  final String name;
+  final String level;
+  final int matchScore;
+  final List<String> playTags;
+  final String intensityLabel;
+  final Color? avatarColor;
+  final String? avatarInitial;
+  final VoidCallback onProfileTap;
+  final VoidCallback onInviteTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.35)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 16,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                radius: 26,
+                backgroundColor: avatarColor ?? cs.primary.withOpacity(0.15),
+                child: Text(
+                  (avatarInitial ?? name[0]).toUpperCase(),
+                  style: tt.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: cs.primary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            name,
+                            style: tt.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: cs.primary.withOpacity(0.12),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            'Match: $matchScore%',
+                            style: tt.labelMedium?.copyWith(
+                              color: cs.primary,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Row(
+                      children: [
+                        Icon(Icons.star_rate_rounded,
+                            size: 18, color: cs.secondary),
+                        const SizedBox(width: 6),
+                        Text(
+                          level,
+                          style: tt.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        ...playTags.map(
+                          (tag) => Chip(
+                            label: Text(tag),
+                            backgroundColor: cs.secondaryContainer,
+                            side: BorderSide(
+                              color: cs.secondaryContainer.withOpacity(0.4),
+                            ),
+                            labelStyle: tt.labelMedium?.copyWith(
+                              color: cs.onSecondaryContainer,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                        Chip(
+                          avatar: Icon(Icons.local_fire_department_rounded,
+                              color: cs.onTertiary, size: 18),
+                          label: Text('Intensity: $intensityLabel'),
+                          backgroundColor: cs.tertiaryContainer,
+                          labelStyle: tt.labelMedium?.copyWith(
+                            color: cs.onTertiaryContainer,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: onProfileTap,
+                  icon: const Icon(Icons.remove_red_eye_outlined, size: 18),
+                  label: const Text('Xem hồ sơ'),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: FilledButton.icon(
+                  onPressed: onInviteTap,
+                  icon: const Icon(Icons.handshake_rounded, size: 18),
+                  label: const Text('Gửi lời mời'),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/player_suggestion_card.dart
+++ b/lib/components/player_suggestion_card.dart
@@ -29,152 +29,202 @@ class PlayerSuggestionCard extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 8),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: cs.surface,
+    // Gradient cho match score dựa trên giá trị (hiện đại hóa visual feedback)
+    Color matchColor = matchScore >= 80
+        ? cs.primary
+        : (matchScore >= 50 ? cs.secondary : cs.error);
+
+    return Card(
+      elevation: 2, // Elevation nhẹ cho shadow hiện đại
+      shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: cs.outlineVariant.withOpacity(0.35)),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.04),
-            blurRadius: 16,
-            offset: const Offset(0, 10),
-          ),
-        ],
+        side: BorderSide(
+            color: cs.outline.withOpacity(0.4),
+            width: 1), // Thêm border cho card
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              CircleAvatar(
-                radius: 26,
-                backgroundColor: avatarColor ?? cs.primary.withOpacity(0.15),
-                child: Text(
-                  (avatarInitial ?? name[0]).toUpperCase(),
-                  style: tt.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                    color: cs.primary,
+      margin: const EdgeInsets.symmetric(
+          vertical: 8, horizontal: 4), // Tăng vertical margin cho spacing
+      child: Padding(
+        padding: const EdgeInsets.all(16), // Tăng padding cho thoáng hơn
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  radius: 28, // Tăng kích thước avatar cho nổi bật
+                  backgroundColor: avatarColor ?? cs.primary.withOpacity(0.15),
+                  child: Text(
+                    (avatarInitial ?? name[0]).toUpperCase(),
+                    style: tt.titleLarge?.copyWith(
+                      // Tăng font size
+                      fontWeight: FontWeight.bold,
+                      color: cs.primary,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 14),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            name,
-                            style: tt.titleMedium?.copyWith(
-                              fontWeight: FontWeight.w700,
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              name,
+                              style: tt.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 18, // Tăng size cho hiện đại
+                              ),
                             ),
                           ),
-                        ),
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 12, vertical: 6),
-                          decoration: BoxDecoration(
-                            color: cs.primary.withOpacity(0.12),
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Text(
-                            'Match: $matchScore%',
-                            style: tt.labelMedium?.copyWith(
-                              color: cs.primary,
-                              fontWeight: FontWeight.w700,
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 6),
+                            decoration: BoxDecoration(
+                              gradient: LinearGradient(
+                                // Thêm gradient cho badge
+                                colors: [
+                                  matchColor.withOpacity(
+                                      0.15), // Giảm opacity để bớt rối mắt
+                                  matchColor.withOpacity(0.03)
+                                ],
+                              ),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Text(
+                              'Match: $matchScore%',
+                              style: tt.labelMedium?.copyWith(
+                                color:
+                                    matchColor.withOpacity(0.8), // Mềm mại hơn
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
                           ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 6),
-                    Row(
-                      children: [
-                        Icon(Icons.star_rate_rounded,
-                            size: 18, color: cs.secondary),
-                        const SizedBox(width: 6),
-                        Text(
-                          level,
-                          style: tt.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.w600,
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.star_rate_rounded,
+                            size: 18,
+                            color: cs.secondary
+                                .withOpacity(0.8), // Giảm opacity để hài hòa
                           ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 10),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: [
-                        ...playTags.map(
-                          (tag) => Chip(
-                            label: Text(tag),
-                            backgroundColor: cs.secondaryContainer,
-                            side: BorderSide(
-                              color: cs.secondaryContainer.withOpacity(0.4),
-                            ),
-                            labelStyle: tt.labelMedium?.copyWith(
-                              color: cs.onSecondaryContainer,
+                          const SizedBox(width: 6),
+                          Text(
+                            level,
+                            style: tt.bodyMedium?.copyWith(
                               fontWeight: FontWeight.w600,
+                              color: cs.onSurfaceVariant
+                                  .withOpacity(0.9), // Màu tinh tế hơn
                             ),
                           ),
-                        ),
-                        Chip(
-                          avatar: Icon(Icons.local_fire_department_rounded,
-                              color: cs.onTertiary, size: 18),
-                          label: Text('Intensity: $intensityLabel'),
-                          backgroundColor: cs.tertiaryContainer,
-                          labelStyle: tt.labelMedium?.copyWith(
-                            color: cs.onTertiaryContainer,
-                            fontWeight: FontWeight.w700,
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        alignment: WrapAlignment
+                            .start, // Lệch về bên trái (align left)
+                        children: [
+                          ...playTags.map(
+                            (tag) => Chip(
+                              label: Text(tag),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 4), // Tăng padding để tag lớn hơn
+                              backgroundColor: cs.secondaryContainer
+                                  .withOpacity(
+                                      0.5), // Giảm opacity để bớt rối mắt
+                              side: BorderSide.none,
+                              labelStyle: tt.labelMedium?.copyWith(
+                                // Tăng từ labelSmall lên labelMedium để chữ lớn hơn
+                                color: cs.onSecondaryContainer.withOpacity(0.9),
+                                fontWeight: FontWeight.w600,
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(
+                                    16), // Radius lớn hơn cho chip
+                              ),
+                            ),
                           ),
-                        ),
-                      ],
-                    ),
-                  ],
+                          Chip(
+                            avatar: Icon(
+                              Icons.local_fire_department_rounded,
+                              color: cs.onTertiary
+                                  .withOpacity(0.8), // Giảm opacity
+                              size: 18,
+                            ),
+                            label: Text('Intensity: $intensityLabel'),
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 4), // Tăng padding tương tự
+                            backgroundColor: cs.tertiaryContainer
+                                .withOpacity(0.5), // Giảm opacity
+                            side: BorderSide.none,
+                            labelStyle: tt.labelMedium?.copyWith(
+                              // Tăng size chữ
+                              color: cs.onTertiaryContainer.withOpacity(0.9),
+                              fontWeight: FontWeight.bold,
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 14),
-          Row(
-            children: [
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: onProfileTap,
-                  icon: const Icon(Icons.remove_red_eye_outlined, size: 18),
-                  label: const Text('Xem hồ sơ'),
-                  style: OutlinedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton.icon(
+                    // Chuyển sang FilledButton để nổi bật hơn (thay vì OutlinedButton)
+                    onPressed: onProfileTap,
+                    icon: const Icon(
+                      Icons.remove_red_eye_outlined,
+                      size: 18,
+                      color: Colors.black54,
+                    ),
+                    label: const Text('Xem hồ sơ'),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 12, horizontal: 16),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16)),
+                      backgroundColor: cs.primaryContainer
+                          .withOpacity(0.8), // Giảm opacity nhẹ để hài hòa
+                      foregroundColor: cs.onPrimaryContainer,
                     ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: FilledButton.icon(
-                  onPressed: onInviteTap,
-                  icon: const Icon(Icons.handshake_rounded, size: 18),
-                  label: const Text('Gửi lời mời'),
-                  style: FilledButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton.icon(
+                    onPressed: onInviteTap,
+                    icon: const Icon(Icons.handshake_rounded, size: 18),
+                    label: const Text('Gửi lời mời'),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 12, horizontal: 16),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16)),
                     ),
                   ),
                 ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:badminton_booking_app/components/create_post.dart';
 import 'package:badminton_booking_app/components/my_post.dart';
+import 'package:badminton_booking_app/components/player_suggestion_card.dart';
 import 'package:badminton_booking_app/components/post_comments_sheet.dart';
 import 'package:badminton_booking_app/components/recruitment_post_card.dart';
 import 'package:badminton_booking_app/models/community_post.dart';
@@ -93,7 +94,7 @@ class _SocialPageState extends State<SocialPage> {
     final avatarUrl = userManager.avatarUrl;
 
     return DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
         backgroundColor: cs.surfaceVariant.withOpacity(0.1),
         appBar: AppBar(
@@ -169,6 +170,16 @@ class _SocialPageState extends State<SocialPage> {
                   ],
                 ),
               ),
+              Tab(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.handshake_rounded, size: 20),
+                    const SizedBox(width: 8),
+                    Text('Gợi ý bạn chơi'),
+                  ],
+                ),
+              ),
             ],
             // Chữ tab đang chọn
             labelStyle: tt.titleMedium?.copyWith(
@@ -205,14 +216,15 @@ class _SocialPageState extends State<SocialPage> {
           scrolledUnderElevation: 0,
           shadowColor: Colors.transparent,
         ),
-        body: SafeArea(
-          child: TabBarView(
-            children: [
-              _buildPostsTab(context, manager, avatarUrl),
-              _buildRecruitmentTab(context, manager),
-            ],
+          body: SafeArea(
+            child: TabBarView(
+              children: [
+                _buildPostsTab(context, manager, avatarUrl),
+                _buildRecruitmentTab(context, manager),
+                _buildPartnerSuggestionTab(context),
+              ],
+            ),
           ),
-        ),
       ),
     );
   }
@@ -277,6 +289,193 @@ class _SocialPageState extends State<SocialPage> {
             ),
           ),
           _buildRecruitmentSection(manager),
+          const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPartnerSuggestionTab(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    final suggestions = <_PartnerSuggestion>[
+      const _PartnerSuggestion(
+        name: 'Minh Anh',
+        level: 'Intermediate',
+        matchScore: 87,
+        playTags: ['Đánh đơn', 'Phản công nhanh'],
+        intensity: 'Medium',
+        colorSeed: Colors.blue,
+      ),
+      const _PartnerSuggestion(
+        name: 'Hải Đăng',
+        level: 'Advanced',
+        matchScore: 92,
+        playTags: ['Đánh đôi', 'Phòng thủ chắc'],
+        intensity: 'High',
+        colorSeed: Colors.deepOrange,
+      ),
+      const _PartnerSuggestion(
+        name: 'Khánh Chi',
+        level: 'Beginner',
+        matchScore: 73,
+        playTags: ['Học hỏi', 'Giao lưu nhẹ nhàng'],
+        intensity: 'Low',
+        colorSeed: Colors.teal,
+      ),
+    ];
+
+    final invites = <_CourtInvite>[
+      const _CourtInvite(
+        hostName: 'Anh Quân',
+        courtName: 'Sân Nhật Hoa',
+        playTime: '19:00 - Thứ 5',
+        note: 'Cần thêm 2 người, mức Intermediate, đánh đôi.',
+      ),
+      const _CourtInvite(
+        hostName: 'Lan Chi',
+        courtName: 'Sân Thống Nhất',
+        playTime: '08:00 - Chủ nhật',
+        note: 'Giao lưu nhẹ nhàng, ưu tiên nữ.',
+      ),
+    ];
+
+    return RefreshIndicator(
+      onRefresh: () async => Future<void>.delayed(const Duration(milliseconds: 800)),
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: cs.primary.withOpacity(0.15),
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        child: Icon(Icons.handshake_rounded,
+                            color: cs.primary, size: 26),
+                      ),
+                      const SizedBox(width: 14),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Gợi ý bạn chơi phù hợp',
+                              style: tt.titleLarge?.copyWith(
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              'Khám phá những partner hợp gu, match score được chuẩn hoá từ 0 - 100%.',
+                              style: tt.bodyMedium?.copyWith(
+                                color: cs.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 14),
+                  DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: cs.primaryContainer,
+                      borderRadius: BorderRadius.circular(18),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(14),
+                      child: Row(
+                        children: [
+                          Icon(Icons.tips_and_updates_rounded,
+                              color: cs.onPrimaryContainer),
+                          const SizedBox(width: 10),
+                          Expanded(
+                            child: Text(
+                              'Gửi lời mời kết bạn hoặc mời vào sân trực tiếp từ danh sách gợi ý.',
+                              style: tt.bodyMedium?.copyWith(
+                                color: cs.onPrimaryContainer,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            sliver: SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final suggestion = suggestions[index];
+                  return PlayerSuggestionCard(
+                    name: suggestion.name,
+                    level: suggestion.level,
+                    matchScore: suggestion.matchScore,
+                    playTags: suggestion.playTags,
+                    intensityLabel: suggestion.intensity,
+                    avatarColor: suggestion.colorSeed.withOpacity(0.16),
+                    avatarInitial: suggestion.name.characters.first,
+                    onProfileTap: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Xem hồ sơ ${suggestion.name}'),
+                        ),
+                      );
+                    },
+                    onInviteTap: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content:
+                              Text('Đã gửi lời mời kết bạn cho ${suggestion.name}'),
+                        ),
+                      );
+                    },
+                  );
+                },
+                childCount: suggestions.length,
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 24, 20, 8),
+              child: Row(
+                children: [
+                  Icon(Icons.mail_outline_rounded,
+                      color: cs.onSurfaceVariant.withOpacity(0.8)),
+                  const SizedBox(width: 10),
+                  Text(
+                    'Lời mời vào sân bạn nhận được',
+                    style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            sliver: SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) => _InviteCard(invite: invites[index]),
+                childCount: invites.length,
+              ),
+            ),
+          ),
           const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
         ],
       ),
@@ -567,6 +766,173 @@ class _SocialPageState extends State<SocialPage> {
               size: 42,
               color: cs.primary,
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PartnerSuggestion {
+  const _PartnerSuggestion({
+    required this.name,
+    required this.level,
+    required this.matchScore,
+    required this.playTags,
+    required this.intensity,
+    required this.colorSeed,
+  });
+
+  final String name;
+  final String level;
+  final int matchScore;
+  final List<String> playTags;
+  final String intensity;
+  final Color colorSeed;
+}
+
+class _CourtInvite {
+  const _CourtInvite({
+    required this.hostName,
+    required this.courtName,
+    required this.playTime,
+    required this.note,
+  });
+
+  final String hostName;
+  final String courtName;
+  final String playTime;
+  final String note;
+}
+
+class _InviteCard extends StatelessWidget {
+  const _InviteCard({required this.invite});
+
+  final _CourtInvite invite;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.35)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 14,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: cs.secondary.withOpacity(0.12),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(Icons.sports_tennis_rounded,
+                    color: cs.secondary, size: 22),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      invite.courtName,
+                      style: tt.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Chủ sân: ${invite.hostName} • ${invite.playTime}',
+                      style: tt.bodySmall?.copyWith(
+                        color: cs.onSurfaceVariant,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: cs.secondaryContainer,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  'Lời mời',
+                  style: tt.labelMedium?.copyWith(
+                    color: cs.onSecondaryContainer,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            invite.note,
+            style: tt.bodyMedium?.copyWith(
+              color: cs.onSurface,
+            ),
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Xem chi tiết lời mời tại ${invite.courtName}'),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.event_available_rounded, size: 18),
+                  label: const Text('Xem lời mời'),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Đã phản hồi lời mời của ${invite.hostName}'),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.reply_rounded, size: 18),
+                  label: const Text('Phản hồi sau'),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -149,13 +149,18 @@ class _SocialPageState extends State<SocialPage> {
             const SizedBox(width: 12),
           ],
           bottom: TabBar(
+            isScrollable: true,
+            padding: const EdgeInsets.only(
+                left: 8), // hơi cách mép trái 1 chút cho đẹp
+            labelPadding: const EdgeInsets.only(
+                right: 24), // chỉ chừa khoảng cách bên phải mỗi tab
             tabs: [
               Tab(
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [
+                  children: const [
                     Icon(Icons.people_alt_rounded, size: 20),
-                    const SizedBox(width: 8),
+                    SizedBox(width: 8),
                     Text('Community'),
                   ],
                 ),
@@ -163,9 +168,9 @@ class _SocialPageState extends State<SocialPage> {
               Tab(
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [
+                  children: const [
                     Icon(Icons.person_search_rounded, size: 20),
-                    const SizedBox(width: 8),
+                    SizedBox(width: 8),
                     Text('Recruitment'),
                   ],
                 ),
@@ -173,20 +178,19 @@ class _SocialPageState extends State<SocialPage> {
               Tab(
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [
+                  children: const [
                     Icon(Icons.handshake_rounded, size: 20),
-                    const SizedBox(width: 8),
-                    Text('Gợi ý bạn chơi'),
+                    SizedBox(width: 8),
+                    Text('Partner'),
                   ],
                 ),
               ),
             ],
-            // Chữ tab đang chọn
+            // các phần còn lại giữ nguyên
             labelStyle: tt.titleMedium?.copyWith(
               fontWeight: FontWeight.w700,
               fontSize: 16,
             ),
-            // Chữ tab chưa chọn
             unselectedLabelStyle: tt.titleMedium?.copyWith(
               fontSize: 16,
               fontWeight: FontWeight.w500,
@@ -194,13 +198,13 @@ class _SocialPageState extends State<SocialPage> {
             labelColor: cs.onPrimary,
             unselectedLabelColor: cs.onPrimary.withOpacity(0.75),
             indicator: BoxDecoration(
-              borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(12)),
               color: cs.primary.withOpacity(0.3),
             ),
             indicatorSize: TabBarIndicatorSize.tab,
             indicatorColor: Colors.transparent,
             dividerColor: cs.onPrimary.withOpacity(0.15),
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
             overlayColor: WidgetStateProperty.all(cs.primary.withOpacity(0.1)),
           ),
           flexibleSpace: Container(
@@ -216,15 +220,15 @@ class _SocialPageState extends State<SocialPage> {
           scrolledUnderElevation: 0,
           shadowColor: Colors.transparent,
         ),
-          body: SafeArea(
-            child: TabBarView(
-              children: [
-                _buildPostsTab(context, manager, avatarUrl),
-                _buildRecruitmentTab(context, manager),
-                _buildPartnerSuggestionTab(context),
-              ],
-            ),
+        body: SafeArea(
+          child: TabBarView(
+            children: [
+              _buildPostsTab(context, manager, avatarUrl),
+              _buildRecruitmentTab(context, manager),
+              _buildPartnerSuggestionTab(context),
+            ],
           ),
+        ),
       ),
     );
   }
@@ -342,7 +346,8 @@ class _SocialPageState extends State<SocialPage> {
     ];
 
     return RefreshIndicator(
-      onRefresh: () async => Future<void>.delayed(const Duration(milliseconds: 800)),
+      onRefresh: () async =>
+          Future<void>.delayed(const Duration(milliseconds: 800)),
       child: CustomScrollView(
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
@@ -440,8 +445,8 @@ class _SocialPageState extends State<SocialPage> {
                     onInviteTap: () {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content:
-                              Text('Đã gửi lời mời kết bạn cho ${suggestion.name}'),
+                          content: Text(
+                              'Đã gửi lời mời kết bạn cho ${suggestion.name}'),
                         ),
                       );
                     },
@@ -461,7 +466,8 @@ class _SocialPageState extends State<SocialPage> {
                   const SizedBox(width: 10),
                   Text(
                     'Lời mời vào sân bạn nhận được',
-                    style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+                    style:
+                        tt.titleMedium?.copyWith(fontWeight: FontWeight.w800),
                   ),
                 ],
               ),
@@ -898,7 +904,8 @@ class _InviteCard extends StatelessWidget {
                   onPressed: () {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                        content: Text('Xem chi tiết lời mời tại ${invite.courtName}'),
+                        content: Text(
+                            'Xem chi tiết lời mời tại ${invite.courtName}'),
                       ),
                     );
                   },
@@ -918,7 +925,8 @@ class _InviteCard extends StatelessWidget {
                   onPressed: () {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                        content: Text('Đã phản hồi lời mời của ${invite.hostName}'),
+                        content:
+                            Text('Đã phản hồi lời mời của ${invite.hostName}'),
                       ),
                     );
                   },

--- a/recommender_system/app.py
+++ b/recommender_system/app.py
@@ -1,5 +1,4 @@
-from typing import List, Optional
-from typing import Any, Dict
+from typing import List, Optional, Any, Dict
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
@@ -9,35 +8,46 @@ from pocketbase_client import (
     get_all_other_user_details,
 )
 
-# ---------- MODELS ----------
+
+# ---------- DOMAIN MODELS ----------
+
 
 class UserDetails(BaseModel):
     id: str
     user_id: str
+
+    # Basic profile
     fullname: Optional[str] = None
     avatar: Optional[str] = None
     gender: Optional[str] = None
-    birthday: Optional[str] = None  # tạm để string
+    birthday: Optional[str] = None  # keep string for now
 
+    # Skill / play information
     level: Optional[str] = None
     level_numeric: int
 
-    match_types: List[str] = []
-    play_style_tags: List[str] = []
-    preferred_role_doubles: Optional[str] = None
-    intensity: Optional[str] = None
+    match_types: List[str] = []  # ["singles", "doubles", "mixed"]
+    play_style_tags: List[str] = []  # ["attacking", "defensive", ...]
+    preferred_role_doubles: Optional[str] = None  # "front", "back", "flexible"
+    intensity: Optional[str] = None  # "casual", "semi_competitive", "competitive"
 
+    # Experience & habit
     experience_years: Optional[float] = None
     plays_per_week: Optional[float] = None
     home_court: Optional[str] = None
 
     @classmethod
     def from_pb_record(cls, record: Dict[str, Any]) -> "UserDetails":
+        """
+        Chuẩn hoá mapping từ PocketBase record sang UserDetails.
+
+        - Bắt buộc có level_numeric (để đảm bảo model có thể ghép).
+        - Các field còn lại để optional, không có thì gán None / [].
+        """
         raw_level_numeric = record.get("level_numeric")
 
         if raw_level_numeric is None:
-            # Có thể chọn raise error hoặc gán default
-            # Ở đây mình raise luôn cho dễ debug
+            # Bắt buộc phải có level_numeric để ghép trình độ
             raise ValueError("Record user_details thiếu trường 'level_numeric'")
 
         return cls(
@@ -48,7 +58,7 @@ class UserDetails(BaseModel):
             gender=record.get("gender"),
             birthday=record.get("birthday"),
             level=record.get("level"),
-            level_numeric=int(raw_level_numeric),  # ép kiểu int rõ ràng
+            level_numeric=int(raw_level_numeric),
             match_types=list(record.get("match_types") or []),
             play_style_tags=list(record.get("play_style_tags") or []),
             preferred_role_doubles=record.get("preferred_role_doubles"),
@@ -64,84 +74,224 @@ class MatchCandidate(BaseModel):
     score: float
 
 
-# ---------- RECOMMENDER LOGIC ----------
+# ---------- SCORING CONFIG ----------
 
-def intensity_value(intensity: str | None) -> int:
+
+class ScoringWeights(BaseModel):
+    """
+    Cho phép cấu hình trọng số cho từng nhóm tiêu chí.
+
+    Mặc định tổng điểm tối đa ~100, để sau này dễ scale / hiển thị %.
+    """
+
+    # Max weights cho từng nhóm
+    level: float = 40.0
+    play_style: float = 25.0
+    doubles_role: float = 15.0
+    intensity: float = 10.0
+    home_court: float = 5.0
+    habit: float = 5.0  # plays_per_week / experience_years
+
+    # Ngưỡng chênh lệch trình độ cho phép (quá lớn thì loại luôn)
+    max_level_diff: int = 3  # nếu chênh > 3 level thì coi như rất khó hợp
+
+
+DEFAULT_WEIGHTS = ScoringWeights()
+
+
+# ---------- SCORING HELPERS ----------
+
+
+def _intensity_value(intensity: str | None) -> int:
     if intensity == "casual":
         return 1
     if intensity == "semi_competitive":
         return 2
     if intensity == "competitive":
         return 3
-    return 2  # default trung bình
+    return 2  # default trung bình nếu thiếu dữ liệu
 
 
-def compute_match_score(me: UserDetails, other: UserDetails) -> float:
-    score = 0.0
+def _jaccard(a: List[str], b: List[str]) -> float:
+    set_a = set(a)
+    set_b = set(b)
+    if not set_a and not set_b:
+        return 0.0
+    intersection = len(set_a & set_b)
+    union = len(set_a | set_b)
+    if union == 0:
+        return 0.0
+    return intersection / union
 
-    # 1. Trình độ (40 điểm)
-    diff_level = abs(me.level_numeric - other.level_numeric)
-    if diff_level == 0:
-        score += 40
-    elif diff_level == 1:
-        score += 30
-    elif diff_level == 2:
-        score += 10
+
+# ---------- SCORING BY ASPECT ----------
+
+
+def _score_level(me: UserDetails, other: UserDetails, w: ScoringWeights) -> float:
+    """
+    Chênh lệch trình độ càng ít càng tốt.
+    diff = 0  -> 100% điểm level
+    diff = 1  -> 0.75
+    diff = 2  -> 0.4
+    diff >= 3 -> 0.0
+    """
+    diff = abs(me.level_numeric - other.level_numeric)
+
+    if diff == 0:
+        factor = 1.0
+    elif diff == 1:
+        factor = 0.75
+    elif diff == 2:
+        factor = 0.4
     else:
-        score -= 100
+        factor = 0.0
 
-    # 2. Lối đánh (30 điểm)
-    set_a = set(me.play_style_tags)
-    set_b = set(other.play_style_tags)
-    if set_a or set_b:
-        intersection = len(set_a & set_b)
-        union = len(set_a | set_b)
-        jaccard = 0.0 if union == 0 else intersection / union
-        score += jaccard * 30.0
+    return factor * w.level
 
-    # 3. Vai trò trong đôi (15 điểm)
+
+def _score_play_style(me: UserDetails, other: UserDetails, w: ScoringWeights) -> float:
+    """
+    Dùng Jaccard similarity trên play_style_tags, nhân với trọng số.
+    """
+    jaccard = _jaccard(me.play_style_tags, other.play_style_tags)
+    return jaccard * w.play_style
+
+
+def _score_doubles_role(me: UserDetails, other: UserDetails, w: ScoringWeights) -> float:
+    """
+    Ghép đôi: front/back là combo tốt nhất.
+    Cả hai flexible thì cũng khá ổn.
+    Cùng role (front-front/back-back) thì vẫn có điểm nhưng thấp.
+    """
     role_a = me.preferred_role_doubles
     role_b = other.preferred_role_doubles
-    if role_a and role_b:
-        if (role_a == "front" and role_b == "back") or (
-            role_a == "back" and role_b == "front"
-        ):
-            score += 15
-        elif role_a == role_b:
-            score += 5
-        elif role_a == "flexible" or role_b == "flexible":
-            score += 10
 
-    # 4. Mức độ try-hard (10 điểm)
-    int_a = intensity_value(me.intensity)
-    int_b = intensity_value(other.intensity)
-    diff_int = abs(int_a - int_b)
-    if diff_int == 0:
-        score += 10
-    elif diff_int == 1:
-        score += 5
+    if not role_a or not role_b:
+        return 0.0
+
+    # perfect complement
+    if (role_a == "front" and role_b == "back") or (
+        role_a == "back" and role_b == "front"
+    ):
+        factor = 1.0
+    # cả hai đều flexible
+    elif role_a == "flexible" and role_b == "flexible":
+        factor = 0.8
+    # một flexible, một front/back
+    elif role_a == "flexible" or role_b == "flexible":
+        factor = 0.7
+    # cùng role (front-front / back-back)
+    elif role_a == role_b:
+        factor = 0.4
     else:
-        score -= 5
+        factor = 0.0
 
-    # 5. Cùng sân (5 điểm)
+    return factor * w.doubles_role
+
+
+def _score_intensity(me: UserDetails, other: UserDetails, w: ScoringWeights) -> float:
+    """
+    Mức độ try-hard tương đồng thì tốt.
+    diff = 0 -> full
+    diff = 1 -> 0.5
+    diff >=2 -> 0
+    """
+    int_a = _intensity_value(me.intensity)
+    int_b = _intensity_value(other.intensity)
+    diff_int = abs(int_a - int_b)
+
+    if diff_int == 0:
+        factor = 1.0
+    elif diff_int == 1:
+        factor = 0.5
+    else:
+        factor = 0.0
+
+    return factor * w.intensity
+
+
+def _score_home_court(me: UserDetails, other: UserDetails, w: ScoringWeights) -> float:
     if me.home_court and other.home_court and me.home_court == other.home_court:
-        score += 5
+        return w.home_court
+    return 0.0
+
+
+def _score_habit(me: UserDetails, other: UserDetails, w: ScoringWeights) -> float:
+    """
+    Thói quen chơi: dựa trên plays_per_week & experience_years.
+    Ở mức demo: chỉ kiểm tra plays_per_week, chênh lệch ít thì cộng điểm.
+    """
+    plays_a = me.plays_per_week or 0
+    plays_b = other.plays_per_week or 0
+
+    if plays_a == 0 or plays_b == 0:
+        # không có dữ liệu thì không cộng điểm
+        return 0.0
+
+    diff = abs(plays_a - plays_b)
+
+    if diff <= 1:
+        factor = 1.0
+    elif diff <= 3:
+        factor = 0.5
+    else:
+        factor = 0.0
+
+    return factor * w.habit
+
+
+# ---------- OVERALL SCORE ----------
+
+
+def compute_match_score(
+    me: UserDetails,
+    other: UserDetails,
+    weights: ScoringWeights = DEFAULT_WEIGHTS,
+) -> float:
+    """
+    Tính tổng điểm ghép cặp giữa 2 người chơi.
+    Trả về số thực, càng cao càng hợp.
+    """
+
+    # Nếu chênh trình độ quá lớn thì cho score = 0 luôn để loại sớm.
+    if abs(me.level_numeric - other.level_numeric) > weights.max_level_diff:
+        return 0.0
+
+    score = 0.0
+
+    score += _score_level(me, other, weights)
+    score += _score_play_style(me, other, weights)
+    score += _score_doubles_role(me, other, weights)
+    score += _score_intensity(me, other, weights)
+    score += _score_home_court(me, other, weights)
+    score += _score_habit(me, other, weights)
 
     return score
 
 
-def recommend_partners(me: UserDetails, others: List[UserDetails], limit: int = 10) -> List[MatchCandidate]:
+def recommend_partners(
+    me: UserDetails,
+    others: List[UserDetails],
+    limit: int = 10,
+    weights: ScoringWeights = DEFAULT_WEIGHTS,
+) -> List[MatchCandidate]:
+    """
+    Tính score cho toàn bộ 'others' và trả về top N ứng viên.
+    """
     candidates: List[MatchCandidate] = []
+
     for other in others:
-        s = compute_match_score(me, other)
-        if s > 0:
-            candidates.append(MatchCandidate(user=other, score=s))
+        s = compute_match_score(me, other, weights=weights)
+        if s <= 0:
+            continue
+        candidates.append(MatchCandidate(user=other, score=s))
 
     candidates.sort(key=lambda c: c.score, reverse=True)
     return candidates[:limit]
 
 
 # ---------- FASTAPI APP ----------
+
 
 app = FastAPI(title="Badminton Recommendation Service")
 
@@ -152,7 +302,7 @@ async def health_check():
 
 
 @app.get("/recommend/players", response_model=List[MatchCandidate])
-async def recommend_players(user_id: str, limit: int = 10):
+async def recommend_players_endpoint(user_id: str, limit: int = 10):
     """
     Gợi ý người chơi dựa trên dữ liệu thật từ PocketBase (collection user_details).
 
@@ -162,7 +312,10 @@ async def recommend_players(user_id: str, limit: int = 10):
     # 1. Lấy user_details của current user
     me_record = await get_user_details_by_user_id(user_id)
     if not me_record:
-        raise HTTPException(status_code=404, detail="User details not found for this user_id")
+        raise HTTPException(
+            status_code=404,
+            detail="User details not found for this user_id",
+        )
 
     me = UserDetails.from_pb_record(me_record)
 


### PR DESCRIPTION
## Summary
- add a new "Gợi ý bạn chơi" tab on the social page with refreshable layout
- build reusable player suggestion cards showing avatar, level, match score, play style tags, and actions
- surface incoming court invite cards alongside the partner suggestions section