### PR TITLE
Implement invitation flow for recruitment and booking slots

### DIFF
--- a/lib/components/player_suggestion_card.dart
+++ b/lib/components/player_suggestion_card.dart
@@ -30,11 +30,12 @@ class PlayerSuggestionCard extends StatelessWidget {
     final tt = Theme.of(context).textTheme;
 
     // Gradient cho match score dựa trên giá trị (hiện đại hóa visual feedback)
+    final Color highMatchColor = const Color(0xFF66BB6A); // xanh lá nhạt dễ nhìn
     Color matchColor = matchScore >= 80
-        ? cs.primary
+        ? highMatchColor
         : (matchScore >= 50 ? cs.secondary : cs.error);
     Color matchTextColor = matchScore >= 80
-        ? cs.onPrimary
+        ? const Color(0xFF1B5E20)
         : (matchScore >= 50
             ? cs.onSecondary
             : matchColor.withOpacity(0.8));

--- a/lib/models/chat_room.dart
+++ b/lib/models/chat_room.dart
@@ -85,6 +85,9 @@ DateTime? _parseDateTime(dynamic value) {
 }
 
 String _resolveDisplayName(RecordModel userRecord) {
+  final fullname = userRecord.getStringValue('fullname').trim();
+  if (fullname.isNotEmpty) return fullname;
+
   final username = userRecord.getStringValue('username');
   if (username.isNotEmpty) return username;
 

--- a/lib/models/chat_room.dart
+++ b/lib/models/chat_room.dart
@@ -42,7 +42,15 @@ class ChatRoom {
     String avatarText = '??';
 
     if (otherUser is RecordModel) {
-      otherUserName = _resolveDisplayName(otherUser);
+      final expandedDetails =
+          (otherUser.expand['user_details_via_user_id'] as List<dynamic>?)
+              ?.whereType<RecordModel>()
+              .toList(growable: false);
+      final details =
+          (expandedDetails != null && expandedDetails.isNotEmpty)
+              ? expandedDetails.first
+              : null;
+      otherUserName = _resolveDisplayName(otherUser, details: details);
       avatarText = _initials(otherUserName);
     }
 
@@ -84,7 +92,12 @@ DateTime? _parseDateTime(dynamic value) {
   return null;
 }
 
-String _resolveDisplayName(RecordModel userRecord) {
+String _resolveDisplayName(RecordModel userRecord, {RecordModel? details}) {
+  final fullnameFromDetails = details?.getStringValue('fullname').trim();
+  if (fullnameFromDetails != null && fullnameFromDetails.isNotEmpty) {
+    return fullnameFromDetails;
+  }
+
   final fullname = userRecord.getStringValue('fullname').trim();
   if (fullname.isNotEmpty) return fullname;
 

--- a/lib/models/invitation.dart
+++ b/lib/models/invitation.dart
@@ -1,0 +1,129 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../utils/pocketbase_utils.dart';
+
+enum InvitationType { recruitment, booking, proposed }
+
+class Invitation {
+  Invitation({
+    required this.id,
+    required this.fromUserId,
+    required this.toUserId,
+    required this.type,
+    required this.status,
+    this.fromUserName,
+    this.fromAvatarUrl,
+    this.recruitmentId,
+    this.bookingId,
+    this.courtId,
+    this.courtName,
+    this.startTime,
+    this.endTime,
+    this.message,
+  });
+
+  factory Invitation.fromRecord(RecordModel record, PocketBase pb) {
+    final data = record.data;
+
+    final fromUserRecord = resolveExpandedRecord(record.expand?['from_user']);
+    final fromUserData = fromUserRecord?.data;
+    final fromUserId = (data['from_user'] as String?) ?? fromUserRecord?.id ?? '';
+    final fromName = sanitizeDisplayName(
+      (fromUserData?['username'] as String?) ??
+          (fromUserData?['email'] as String?),
+    );
+
+    final recruitmentRecord = resolveExpandedRecord(record.expand?['recruitment']);
+    final recruitmentData = recruitmentRecord?.data;
+    final bookingRecord = resolveExpandedRecord(record.expand?['booking']);
+    final bookingData = bookingRecord?.data;
+
+    final courtFromRecruitment = resolveExpandedRecord(recruitmentRecord?.expand?['court']);
+    final courtFromBooking = resolveExpandedRecord(bookingRecord?.expand?['court_id']);
+    final courtRecord =
+        resolveExpandedRecord(record.expand?['court']) ?? courtFromRecruitment ?? courtFromBooking;
+    final courtData = courtRecord?.data;
+
+    return Invitation(
+      id: record.id,
+      fromUserId: fromUserId,
+      toUserId: (data['to_user'] as String?) ?? '',
+      type: _mapType(data['type'] as String?),
+      status: (data['status'] as String?) ?? 'pending',
+      fromUserName: fromName,
+      fromAvatarUrl: resolveFileUrl(pb, fromUserRecord, fromUserData?['avatar']),
+      recruitmentId: (data['recruitment'] as String?) ?? recruitmentRecord?.id,
+      bookingId: (data['booking'] as String?) ?? bookingRecord?.id,
+      courtId: (data['court'] as String?) ??
+          courtRecord?.id ??
+          (recruitmentData?['court'] as String?) ??
+          (bookingData?['court_id'] as String?),
+      courtName: sanitizeDisplayName(
+        (courtData?['name'] as String?) ??
+            (recruitmentData?['court_name'] as String?) ??
+            (bookingData?['court_name'] as String?),
+      ),
+      startTime: _tryParseDate(data['start_time'] ?? bookingData?['start_time'] ??
+          recruitmentData?['event_time']),
+      endTime: _tryParseDate(data['end_time'] ?? bookingData?['end_time']),
+      message: (data['message'] as String?)?.trim(),
+    );
+  }
+
+  final String id;
+  final String fromUserId;
+  final String toUserId;
+  final InvitationType type;
+  final String status;
+  final String? fromUserName;
+  final String? fromAvatarUrl;
+  final String? recruitmentId;
+  final String? bookingId;
+  final String? courtId;
+  final String? courtName;
+  final DateTime? startTime;
+  final DateTime? endTime;
+  final String? message;
+
+  bool get isPending => status == 'pending';
+
+  Invitation copyWith({String? status}) {
+    return Invitation(
+      id: id,
+      fromUserId: fromUserId,
+      toUserId: toUserId,
+      type: type,
+      status: status ?? this.status,
+      fromUserName: fromUserName,
+      fromAvatarUrl: fromAvatarUrl,
+      recruitmentId: recruitmentId,
+      bookingId: bookingId,
+      courtId: courtId,
+      courtName: courtName,
+      startTime: startTime,
+      endTime: endTime,
+      message: message,
+    );
+  }
+}
+
+InvitationType _mapType(String? raw) {
+  switch (raw) {
+    case 'booking':
+      return InvitationType.booking;
+    case 'proposed':
+      return InvitationType.proposed;
+    case 'recruitment':
+    default:
+      return InvitationType.recruitment;
+  }
+}
+
+DateTime? _tryParseDate(dynamic value) {
+  if (value == null) return null;
+  if (value is DateTime) return value.toLocal();
+  if (value is String && value.isNotEmpty) {
+    return DateTime.tryParse(value)?.toLocal();
+  }
+  return null;
+}

--- a/lib/models/invitation.dart
+++ b/lib/models/invitation.dart
@@ -11,8 +11,11 @@ class Invitation {
     required this.toUserId,
     required this.type,
     required this.status,
+    this.viewerId,
     this.fromUserName,
     this.fromAvatarUrl,
+    this.toUserName,
+    this.toAvatarUrl,
     this.recruitmentId,
     this.bookingId,
     this.courtId,
@@ -22,7 +25,11 @@ class Invitation {
     this.message,
   });
 
-  factory Invitation.fromRecord(RecordModel record, PocketBase pb) {
+  factory Invitation.fromRecord(
+    RecordModel record,
+    PocketBase pb, {
+    String? viewerId,
+  }) {
     final data = record.data;
 
     final fromUserRecord = resolveExpandedRecord(record.expand?['from_user']);
@@ -32,6 +39,9 @@ class Invitation {
       (fromUserData?['username'] as String?) ??
           (fromUserData?['email'] as String?),
     );
+
+    final toUserRecord = resolveExpandedRecord(record.expand?['to_user']);
+    final toUserData = toUserRecord?.data;
 
     final recruitmentRecord = resolveExpandedRecord(record.expand?['recruitment']);
     final recruitmentData = recruitmentRecord?.data;
@@ -50,8 +60,14 @@ class Invitation {
       toUserId: (data['to_user'] as String?) ?? '',
       type: _mapType(data['type'] as String?),
       status: (data['status'] as String?) ?? 'pending',
+      viewerId: viewerId,
       fromUserName: fromName,
       fromAvatarUrl: resolveFileUrl(pb, fromUserRecord, fromUserData?['avatar']),
+      toUserName: sanitizeDisplayName(
+        (toUserData?['username'] as String?) ??
+            (toUserData?['email'] as String?),
+      ),
+      toAvatarUrl: resolveFileUrl(pb, toUserRecord, toUserData?['avatar']),
       recruitmentId: (data['recruitment'] as String?) ?? recruitmentRecord?.id,
       bookingId: (data['booking'] as String?) ?? bookingRecord?.id,
       courtId: (data['court'] as String?) ??
@@ -75,8 +91,11 @@ class Invitation {
   final String toUserId;
   final InvitationType type;
   final String status;
+  final String? viewerId;
   final String? fromUserName;
   final String? fromAvatarUrl;
+  final String? toUserName;
+  final String? toAvatarUrl;
   final String? recruitmentId;
   final String? bookingId;
   final String? courtId;
@@ -85,6 +104,7 @@ class Invitation {
   final DateTime? endTime;
   final String? message;
 
+  bool get isOutgoing => viewerId != null && viewerId == fromUserId;
   bool get isPending => status == 'pending';
 
   Invitation copyWith({String? status}) {
@@ -94,8 +114,11 @@ class Invitation {
       toUserId: toUserId,
       type: type,
       status: status ?? this.status,
+      viewerId: viewerId,
       fromUserName: fromUserName,
       fromAvatarUrl: fromAvatarUrl,
+      toUserName: toUserName,
+      toAvatarUrl: toAvatarUrl,
       recruitmentId: recruitmentId,
       bookingId: bookingId,
       courtId: courtId,

--- a/lib/models/user_booking_view.dart
+++ b/lib/models/user_booking_view.dart
@@ -70,6 +70,15 @@ class UserBookingView {
   final String? courtLocation;
   final String? courtCoverImageUrl;
   final String? courtUnitLabel;
+
+  String get id => booking.id;
+  String get courtId => booking.courtId;
+  String get courtUnitId => booking.courtUnitId;
+  DateTime get startTime => booking.startTime;
+  DateTime get endTime => booking.endTime;
+  BookingStatus get status => booking.status;
+  DateTime? get lockedUntil => booking.lockedUntil;
+  String? get note => booking.note;
 }
 
 RecordModel? _resolveExpandedRecord(dynamic expanded) {

--- a/lib/pages/social/invitation/invitation_manager.dart
+++ b/lib/pages/social/invitation/invitation_manager.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../models/court.dart';
+import '../../../models/invitation.dart';
+import '../../../models/recruitment_post.dart';
+import '../../../models/user_booking_view.dart';
+import '../../../services/invitation_service.dart';
+
+class InvitationManager extends ChangeNotifier {
+  InvitationManager({InvitationService? service})
+      : _service = service ?? InvitationService();
+
+  final InvitationService _service;
+
+  List<Invitation> _invitations = const <Invitation>[];
+  bool _isLoading = false;
+  String? _error;
+
+  List<Invitation> get invitations => _invitations;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  Future<void> refreshIncoming() async {
+    if (_isLoading) return;
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      _invitations = await _service.fetchIncoming();
+    } catch (err) {
+      _error = err.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> respond(Invitation invitation, {required bool accept}) async {
+    try {
+      final updated = await _service.respond(invitation: invitation, accept: accept);
+      _invitations = _invitations
+          .map((item) => item.id == invitation.id ? updated : item)
+          .toList(growable: false);
+    } catch (err) {
+      _error = err.toString();
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<InvitationComposerData> loadComposerData() {
+    return _service.loadComposerData();
+  }
+
+  Future<Invitation> sendRecruitmentInvite({
+    required String toUserId,
+    required String recruitmentId,
+    String? message,
+  }) async {
+    final invitation = await _service.sendRecruitmentInvite(
+      toUserId: toUserId,
+      recruitmentId: recruitmentId,
+      message: message,
+    );
+    await refreshIncoming();
+    return invitation;
+  }
+
+  Future<Invitation> sendBookingInvite({
+    required String toUserId,
+    required UserBookingView booking,
+    String? message,
+  }) async {
+    final invitation = await _service.sendBookingInvite(
+      toUserId: toUserId,
+      booking: booking,
+      message: message,
+    );
+    await refreshIncoming();
+    return invitation;
+  }
+
+  Future<Invitation> sendProposedInvite({
+    required String toUserId,
+    required DateTime startTime,
+    DateTime? endTime,
+    String? courtId,
+    String? message,
+  }) async {
+    final invitation = await _service.sendProposedInvite(
+      toUserId: toUserId,
+      startTime: startTime,
+      endTime: endTime,
+      courtId: courtId,
+      message: message,
+    );
+    await refreshIncoming();
+    return invitation;
+  }
+
+  List<Court> mapCourts(List<Court> courts) => courts;
+  List<RecruitmentPost> mapRecruitments(List<RecruitmentPost> posts) => posts;
+  List<UserBookingView> mapBookings(List<UserBookingView> bookings) => bookings;
+}

--- a/lib/pages/social/invitation/invitation_sheet.dart
+++ b/lib/pages/social/invitation/invitation_sheet.dart
@@ -170,43 +170,46 @@ class _InvitationSheetState extends State<InvitationSheet> {
             ),
             const Divider(),
           ],
-          Text('Đề xuất slot mới', style: Theme.of(context).textTheme.titleMedium),
-          const SizedBox(height: 8),
-          DropdownButtonFormField<String>(
-            value: _selectedCourt,
-            items: courts
-                .map(
-                  (court) => DropdownMenuItem(
-                    value: court.id,
-                    child: Text(court.name),
+          if (_selectedRecruitment == null) ...[
+            Text('Đề xuất slot mới', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            DropdownButtonFormField<String>(
+              value: _selectedCourt,
+              items: courts
+                  .map(
+                    (court) => DropdownMenuItem(
+                      value: court.id,
+                      child: Text(court.name),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (value) => setState(() => _selectedCourt = value),
+              decoration: const InputDecoration(labelText: 'Chọn sân'),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: _DateField(
+                    label: 'Bắt đầu',
+                    value: _proposedStart,
+                    onChanged: (value) => setState(() => _proposedStart = value),
                   ),
-                )
-                .toList(),
-            onChanged: (value) => setState(() => _selectedCourt = value),
-            decoration: const InputDecoration(labelText: 'Chọn sân'),
-          ),
-          const SizedBox(height: 12),
-          Row(
-            children: [
-              Expanded(
-                child: _DateField(
-                  label: 'Bắt đầu',
-                  value: _proposedStart,
-                  onChanged: (value) => setState(() => _proposedStart = value),
                 ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: _DateField(
-                  label: 'Kết thúc (tuỳ chọn)',
-                  value: _proposedEnd ?? _proposedStart.add(const Duration(hours: 2)),
-                  onChanged: (value) => setState(() => _proposedEnd = value),
-                  optional: true,
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _DateField(
+                    label: 'Kết thúc (tuỳ chọn)',
+                    value:
+                        _proposedEnd ?? _proposedStart.add(const Duration(hours: 2)),
+                    onChanged: (value) => setState(() => _proposedEnd = value),
+                    optional: true,
+                  ),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
+              ],
+            ),
+            const SizedBox(height: 12),
+          ],
           TextField(
             decoration: const InputDecoration(labelText: 'Ghi chú gửi kèm'),
             onChanged: (value) => _note = value,
@@ -229,8 +232,8 @@ class _InvitationSheetState extends State<InvitationSheet> {
     final toUserId = widget.toUser.user.id;
 
     try {
-      if (_data!.recruitments.isNotEmpty) {
-        final recruitmentId = _selectedRecruitment ?? _data!.recruitments.first.id;
+      if (_selectedRecruitment != null) {
+        final recruitmentId = _selectedRecruitment!;
         await widget.manager.sendRecruitmentInvite(
           toUserId: toUserId,
           recruitmentId: recruitmentId,

--- a/lib/pages/social/invitation/invitation_sheet.dart
+++ b/lib/pages/social/invitation/invitation_sheet.dart
@@ -47,12 +47,13 @@ class _InvitationSheetState extends State<InvitationSheet> {
       final data = await widget.manager.loadComposerData();
       setState(() {
         _data = data;
-        _selectedRecruitment = data.recruitments.length == 1
-            ? data.recruitments.first.id
-            : null;
-        _selectedBooking = data.bookings.length == 1
-            ? data.bookings.first
-            : null;
+
+        if (data.recruitments.length == 1) {
+          _selectedRecruitment = data.recruitments.first.id;
+        } else if (data.recruitments.isEmpty && data.bookings.length == 1) {
+          _selectedBooking = data.bookings.first;
+        }
+
         _selectedCourt = data.courts.isNotEmpty ? data.courts.first.id : null;
       });
     } catch (err) {
@@ -141,6 +142,7 @@ class _InvitationSheetState extends State<InvitationSheet> {
                 onChanged: (value) {
                   setState(() {
                     _selectedRecruitment = value;
+                    _selectedBooking = null;
                   });
                 },
                 title: Text(post.courtName ?? 'Chưa chọn sân'),
@@ -151,7 +153,7 @@ class _InvitationSheetState extends State<InvitationSheet> {
             ),
             const Divider(),
           ],
-          if (recruitments.isEmpty && bookings.isNotEmpty) ...[
+          if (bookings.isNotEmpty) ...[
             Text('Booking hiện có', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             ...bookings.map(
@@ -239,7 +241,7 @@ class _InvitationSheetState extends State<InvitationSheet> {
           recruitmentId: recruitmentId,
           message: _note,
         );
-      } else if (_data!.bookings.isNotEmpty) {
+      } else if (_selectedBooking != null || _data!.bookings.isNotEmpty) {
         final booking = _selectedBooking ?? _data!.bookings.first;
         await widget.manager.sendBookingInvite(
           toUserId: toUserId,

--- a/lib/pages/social/invitation/invitation_sheet.dart
+++ b/lib/pages/social/invitation/invitation_sheet.dart
@@ -1,0 +1,347 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../models/court.dart';
+import '../../../models/friend_search_result.dart';
+import '../../../models/invitation.dart';
+import '../../../models/recruitment_post.dart';
+import '../../../models/user_booking_view.dart';
+import 'invitation_manager.dart';
+
+class InvitationSheet extends StatefulWidget {
+  const InvitationSheet({super.key, required this.toUser, required this.manager});
+
+  final FriendSearchResult toUser;
+  final InvitationManager manager;
+
+  @override
+  State<InvitationSheet> createState() => _InvitationSheetState();
+}
+
+class _InvitationSheetState extends State<InvitationSheet> {
+  InvitationComposerData? _data;
+  bool _isLoading = false;
+  String? _error;
+
+  String? _selectedRecruitment;
+  UserBookingView? _selectedBooking;
+  String? _selectedCourt;
+  DateTime _proposedStart = DateTime.now().add(const Duration(hours: 1));
+  DateTime? _proposedEnd;
+  String? _note;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      final data = await widget.manager.loadComposerData();
+      setState(() {
+        _data = data;
+        _selectedRecruitment = data.recruitments.length == 1
+            ? data.recruitments.first.id
+            : null;
+        _selectedBooking = data.bookings.length == 1
+            ? data.bookings.first
+            : null;
+        _selectedCourt = data.courts.isNotEmpty ? data.courts.first.id : null;
+      });
+    } catch (err) {
+      setState(() {
+        _error = err.toString();
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            blurRadius: 20,
+            offset: const Offset(0, -8),
+          ),
+        ],
+      ),
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+        top: 16,
+        left: 20,
+        right: 20,
+      ),
+      child: _isLoading
+          ? const SizedBox(
+              height: 240,
+              child: Center(child: CircularProgressIndicator()),
+            )
+          : _error != null
+              ? _ErrorState(message: _error!, onRetry: _loadData)
+              : _buildContent(context, cs),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, ColorScheme cs) {
+    final data = _data!;
+    final recruitments = data.recruitments;
+    final bookings = data.bookings;
+    final courts = data.courts;
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: cs.primary.withOpacity(0.12),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Icon(Icons.handshake_rounded, color: cs.primary),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'Mời ${widget.toUser.displayName} vào slot',
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleLarge
+                      ?.copyWith(fontWeight: FontWeight.w800),
+                ),
+              )
+            ],
+          ),
+          const SizedBox(height: 16),
+          if (recruitments.isNotEmpty) ...[
+            Text('Bài tuyển đang mở', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            ...recruitments.map(
+              (post) => RadioListTile<String>(
+                value: post.id,
+                groupValue: _selectedRecruitment,
+                onChanged: (value) {
+                  setState(() {
+                    _selectedRecruitment = value;
+                  });
+                },
+                title: Text(post.courtName ?? 'Chưa chọn sân'),
+                subtitle: Text(
+                  _formatSlot(post.eventTime, null) ?? 'Bài tuyển chưa chọn giờ',
+                ),
+              ),
+            ),
+            const Divider(),
+          ],
+          if (recruitments.isEmpty && bookings.isNotEmpty) ...[
+            Text('Booking hiện có', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            ...bookings.map(
+              (booking) => RadioListTile<UserBookingView>(
+                value: booking,
+                groupValue: _selectedBooking,
+                onChanged: (value) {
+                  setState(() {
+                    _selectedBooking = value;
+                    _selectedRecruitment = null;
+                  });
+                },
+                title: Text(booking.courtName ?? 'Sân chưa rõ'),
+                subtitle: Text(_formatSlot(booking.startTime, booking.endTime) ?? ''),
+              ),
+            ),
+            const Divider(),
+          ],
+          Text('Đề xuất slot mới', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<String>(
+            value: _selectedCourt,
+            items: courts
+                .map(
+                  (court) => DropdownMenuItem(
+                    value: court.id,
+                    child: Text(court.name),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) => setState(() => _selectedCourt = value),
+            decoration: const InputDecoration(labelText: 'Chọn sân'),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _DateField(
+                  label: 'Bắt đầu',
+                  value: _proposedStart,
+                  onChanged: (value) => setState(() => _proposedStart = value),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _DateField(
+                  label: 'Kết thúc (tuỳ chọn)',
+                  value: _proposedEnd ?? _proposedStart.add(const Duration(hours: 2)),
+                  onChanged: (value) => setState(() => _proposedEnd = value),
+                  optional: true,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            decoration: const InputDecoration(labelText: 'Ghi chú gửi kèm'),
+            onChanged: (value) => _note = value,
+            maxLines: 2,
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: _handleSubmit,
+            icon: const Icon(Icons.send_rounded),
+            label: const Text('Gửi lời mời'),
+            style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _handleSubmit() async {
+    if (_data == null) return;
+    final toUserId = widget.toUser.user.id;
+
+    try {
+      if (_data!.recruitments.isNotEmpty) {
+        final recruitmentId = _selectedRecruitment ?? _data!.recruitments.first.id;
+        await widget.manager.sendRecruitmentInvite(
+          toUserId: toUserId,
+          recruitmentId: recruitmentId,
+          message: _note,
+        );
+      } else if (_data!.bookings.isNotEmpty) {
+        final booking = _selectedBooking ?? _data!.bookings.first;
+        await widget.manager.sendBookingInvite(
+          toUserId: toUserId,
+          booking: booking,
+          message: _note,
+        );
+      } else {
+        await widget.manager.sendProposedInvite(
+          toUserId: toUserId,
+          startTime: _proposedStart,
+          endTime: _proposedEnd,
+          courtId: _selectedCourt,
+          message: _note,
+        );
+      }
+
+      if (mounted) Navigator.of(context).pop();
+    } catch (err) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(err.toString())),
+      );
+    }
+  }
+
+  String? _formatSlot(DateTime? start, DateTime? end) {
+    if (start == null) return null;
+    final formatter = DateFormat('HH:mm dd/MM');
+    if (end == null) return formatter.format(start);
+    return '${formatter.format(start)} - ${formatter.format(end)}';
+  }
+}
+
+class _DateField extends StatelessWidget {
+  const _DateField({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    this.optional = false,
+  });
+
+  final String label;
+  final DateTime value;
+  final bool optional;
+  final ValueChanged<DateTime> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = TextEditingController(
+      text: DateFormat('HH:mm dd/MM').format(value),
+    );
+
+    return TextField(
+      controller: controller,
+      readOnly: true,
+      decoration: InputDecoration(labelText: label),
+      onTap: () async {
+        final date = await showDatePicker(
+          context: context,
+          initialDate: value,
+          firstDate: DateTime.now().subtract(const Duration(days: 1)),
+          lastDate: DateTime.now().add(const Duration(days: 60)),
+        );
+        if (date == null) return;
+        final time = await showTimePicker(
+          context: context,
+          initialTime: TimeOfDay.fromDateTime(value),
+        );
+        final result = DateTime(
+          date.year,
+          date.month,
+          date.day,
+          time?.hour ?? value.hour,
+          time?.minute ?? value.minute,
+        );
+        onChanged(result);
+      },
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 220,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            message,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: onRetry,
+            icon: const Icon(Icons.refresh_rounded),
+            label: const Text('Thử lại'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/social/invitation/invitation_sheet.dart
+++ b/lib/pages/social/invitation/invitation_sheet.dart
@@ -6,6 +6,7 @@ import '../../../models/friend_search_result.dart';
 import '../../../models/invitation.dart';
 import '../../../models/recruitment_post.dart';
 import '../../../models/user_booking_view.dart';
+import '../../../services/invitation_service.dart';
 import 'invitation_manager.dart';
 
 class InvitationSheet extends StatefulWidget {

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -6,10 +6,13 @@ import 'package:badminton_booking_app/components/player_suggestion_card.dart';
 import 'package:badminton_booking_app/components/post_comments_sheet.dart';
 import 'package:badminton_booking_app/components/recruitment_post_card.dart';
 import 'package:badminton_booking_app/models/community_post.dart';
+import 'package:badminton_booking_app/models/invitation.dart';
 import 'package:badminton_booking_app/models/recruitment_post.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_home_page.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_list_manager.dart';
 import 'package:badminton_booking_app/pages/social/create_post_page.dart';
+import 'package:badminton_booking_app/pages/social/invitation/invitation_manager.dart';
+import 'package:badminton_booking_app/pages/social/invitation/invitation_sheet.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/recruitment_applicants_page.dart';
 import 'package:badminton_booking_app/pages/social/recruitment/recruitment_page.dart';
 import 'package:badminton_booking_app/pages/social/partner_suggestion_manager.dart';
@@ -22,7 +25,6 @@ import 'package:badminton_booking_app/pages/social/chat/friend_request_manager.d
 import 'package:provider/provider.dart';
 
 import '../../models/friend_search_result.dart';
-import '../../services/friend_request_service.dart';
 
 class SocialPage extends StatefulWidget {
   const SocialPage({super.key});
@@ -33,24 +35,26 @@ class SocialPage extends StatefulWidget {
 
 class _SocialPageState extends State<SocialPage> {
   late final PartnerSuggestionManager _partnerManager;
-  late final FriendRequestService _friendRequestService;
+  late final InvitationManager _invitationManager;
   final Set<String> _pendingRequests = <String>{};
 
   @override
   void initState() {
     super.initState();
     _partnerManager = PartnerSuggestionManager();
-    _friendRequestService = FriendRequestService();
+    _invitationManager = InvitationManager();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       context.read<SocialManager>().loadInitial();
       _partnerManager.loadSuggestions();
+      _invitationManager.refreshIncoming();
     });
   }
 
   @override
   void dispose() {
     _partnerManager.dispose();
+    _invitationManager.dispose();
     super.dispose();
   }
 
@@ -254,7 +258,7 @@ class _SocialPageState extends State<SocialPage> {
               _buildPostsTab(context, manager, avatarUrl),
               _buildRecruitmentTab(context, manager),
               _buildPartnerSuggestionTab(context, _partnerManager),
-              _buildCourtInvitesTab(context),
+              _buildCourtInvitesTab(context, _invitationManager),
             ],
           ),
         ),
@@ -451,8 +455,10 @@ class _SocialPageState extends State<SocialPage> {
                           avatarInitial: suggestion.friend.initials,
                           onProfileTap: () =>
                               _openProfile(context, suggestion.friend),
-                          onInviteTap: () =>
-                              _sendFriendRequest(context, suggestion.friend),
+                          onInviteTap: () => _openInviteSheet(
+                            context: context,
+                            friend: suggestion.friend,
+                          ),
                         );
                       },
                       childCount: suggestions.length,
@@ -476,80 +482,105 @@ class _SocialPageState extends State<SocialPage> {
         .join(' ');
   }
 
-  Widget _buildCourtInvitesTab(BuildContext context) {
+  Widget _buildCourtInvitesTab(
+    BuildContext context,
+    InvitationManager invitationManager,
+  ) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
-    final invites = <_CourtInvite>[
-      const _CourtInvite(
-        hostName: 'Anh Quân',
-        courtName: 'Sân Nhật Hoa',
-        playTime: '19:00 - Thứ 5',
-        note: 'Cần thêm 2 người, mức Intermediate, đánh đôi.',
-      ),
-      const _CourtInvite(
-        hostName: 'Lan Chi',
-        courtName: 'Sân Thống Nhất',
-        playTime: '08:00 - Chủ nhật',
-        note: 'Giao lưu nhẹ nhàng, ưu tiên nữ.',
-      ),
-    ];
-
     return RefreshIndicator(
-      onRefresh: () async {},
-      child: CustomScrollView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        slivers: [
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
-              child: Row(
-                children: [
-                  Container(
-                    padding: const EdgeInsets.all(12),
-                    decoration: BoxDecoration(
-                      color: cs.primary.withOpacity(0.12),
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                    child: Icon(Icons.mail_outline_rounded,
-                        color: cs.primary, size: 26),
-                  ),
-                  const SizedBox(width: 14),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Lời mời vào sân',
-                          style: tt.titleLarge?.copyWith(
-                            fontWeight: FontWeight.w800,
-                          ),
+      onRefresh: invitationManager.refreshIncoming,
+      child: AnimatedBuilder(
+        animation: invitationManager,
+        builder: (context, _) {
+          final invites = invitationManager.invitations;
+
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: cs.primary.withOpacity(0.12),
+                          borderRadius: BorderRadius.circular(16),
                         ),
-                        const SizedBox(height: 4),
-                        Text(
-                          'Theo dõi các lời mời chơi gần đây và phản hồi nhanh chóng.',
-                          style: tt.bodyMedium?.copyWith(
-                            color: cs.onSurfaceVariant,
-                          ),
+                        child: Icon(Icons.mail_outline_rounded,
+                            color: cs.primary, size: 26),
+                      ),
+                      const SizedBox(width: 14),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Lời mời vào sân',
+                              style: tt.titleLarge?.copyWith(
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              'Theo dõi các lời mời chơi gần đây và phản hồi nhanh chóng.',
+                              style: tt.bodyMedium?.copyWith(
+                                color: cs.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
-            ),
-          ),
-          SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            sliver: SliverList.separated(
-              itemBuilder: (context, index) =>
-                  _InviteCard(invite: invites[index]),
-              separatorBuilder: (_, __) => const SizedBox(height: 8),
-              itemCount: invites.length,
-            ),
-          ),
-          const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
-        ],
+              if (invitationManager.isLoading)
+                const SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Center(child: CircularProgressIndicator()),
+                )
+              else if (invitationManager.error != null)
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: _PartnerErrorState(
+                    message: invitationManager.error!,
+                    onRetry: invitationManager.refreshIncoming,
+                  ),
+                )
+              else if (invites.isEmpty)
+                const SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Center(
+                    child: Text('Chưa có lời mời nào.'),
+                  ),
+                )
+              else
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverList.separated(
+                    itemBuilder: (context, index) => _InviteCard(
+                      invite: invites[index],
+                      onAccept: () => invitationManager.respond(
+                        invites[index],
+                        accept: true,
+                      ),
+                      onReject: () => invitationManager.respond(
+                        invites[index],
+                        accept: false,
+                      ),
+                    ),
+                    separatorBuilder: (_, __) => const SizedBox(height: 8),
+                    itemCount: invites.length,
+                  ),
+                ),
+              const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
+            ],
+          );
+        },
       ),
     );
   }
@@ -562,10 +593,10 @@ class _SocialPageState extends State<SocialPage> {
     );
   }
 
-  Future<void> _sendFriendRequest(
-    BuildContext context,
-    FriendSearchResult friend,
-  ) async {
+  Future<void> _openInviteSheet({
+    required BuildContext context,
+    required FriendSearchResult friend,
+  }) async {
     final userId = friend.user.id;
     if (_pendingRequests.contains(userId)) return;
 
@@ -574,14 +605,15 @@ class _SocialPageState extends State<SocialPage> {
     });
 
     try {
-      await _friendRequestService.sendFriendRequest(userId);
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Đã gửi lời mời kết bạn cho ${friend.displayName}'),
-          ),
-        );
-      }
+      await showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        backgroundColor: Colors.transparent,
+        builder: (_) => InvitationSheet(
+          toUser: friend,
+          manager: _invitationManager,
+        ),
+      );
     } catch (err) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -888,24 +920,16 @@ class _SocialPageState extends State<SocialPage> {
   }
 }
 
-class _CourtInvite {
-  const _CourtInvite({
-    required this.hostName,
-    required this.courtName,
-    required this.playTime,
-    required this.note,
+class _InviteCard extends StatelessWidget {
+  const _InviteCard({
+    required this.invite,
+    required this.onAccept,
+    required this.onReject,
   });
 
-  final String hostName;
-  final String courtName;
-  final String playTime;
-  final String note;
-}
-
-class _InviteCard extends StatelessWidget {
-  const _InviteCard({required this.invite});
-
-  final _CourtInvite invite;
+  final Invitation invite;
+  final VoidCallback onAccept;
+  final VoidCallback onReject;
 
   @override
   Widget build(BuildContext context) {
@@ -954,14 +978,14 @@ class _InviteCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      invite.courtName,
+                      invite.courtName ?? 'Slot đang chờ xác nhận',
                       style: tt.titleMedium?.copyWith(
                         fontWeight: FontWeight.w800,
                       ),
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      'Chủ sân: ${invite.hostName} • ${invite.playTime}',
+                      _subtitle(invite),
                       style: tt.bodySmall?.copyWith(
                         color: cs.onSurfaceVariant,
                         fontWeight: FontWeight.w600,
@@ -980,7 +1004,7 @@ class _InviteCard extends StatelessWidget {
                   padding:
                       const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                   child: Text(
-                    'Lời mời',
+                    _typeLabel(invite.type),
                     style: tt.labelMedium?.copyWith(
                       color: cs.primary,
                       fontWeight: FontWeight.w900,
@@ -992,66 +1016,101 @@ class _InviteCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 10),
-          Text(
-            invite.note,
-            style: tt.bodyMedium?.copyWith(
-              color: cs.onSurface.withOpacity(0.9),
-              fontWeight: FontWeight.w600,
+          if (invite.message?.isNotEmpty == true)
+            Text(
+              invite.message!,
+              style: tt.bodyMedium?.copyWith(
+                color: cs.onSurface.withOpacity(0.9),
+                fontWeight: FontWeight.w600,
+              ),
             ),
-          ),
+          if (invite.startTime != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              _formatTime(invite),
+              style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+            ),
+          ],
           const SizedBox(height: 14),
-          Row(
-            children: [
-              Expanded(
-                child: FilledButton.tonalIcon(
-                  onPressed: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                            'Xem chi tiết lời mời tại ${invite.courtName}'),
+          if (invite.isPending)
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton.tonalIcon(
+                    onPressed: onAccept,
+                    icon: const Icon(Icons.event_available_rounded, size: 18),
+                    label: const Text('Chấp nhận'),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      backgroundColor: cs.primary,
+                      foregroundColor: cs.onPrimary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
                       ),
-                    );
-                  },
-                  icon: const Icon(Icons.event_available_rounded, size: 18),
-                  label: const Text('Xem lời mời'),
-                  style: FilledButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    backgroundColor: cs.primary,
-                    foregroundColor: cs.onPrimary,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
                     ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content:
-                            Text('Đã phản hồi lời mời của ${invite.hostName}'),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: onReject,
+                    icon: const Icon(Icons.reply_rounded, size: 18),
+                    label: const Text('Từ chối'),
+                    style: OutlinedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      side: BorderSide(color: cs.primary.withOpacity(0.35)),
+                      foregroundColor: cs.primary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
                       ),
-                    );
-                  },
-                  icon: const Icon(Icons.reply_rounded, size: 18),
-                  label: const Text('Phản hồi sau'),
-                  style: OutlinedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    side: BorderSide(color: cs.primary.withOpacity(0.35)),
-                    foregroundColor: cs.primary,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
                     ),
                   ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            )
+          else
+            Text(
+              invite.status == 'accepted'
+                  ? 'Bạn đã chấp nhận lời mời này.'
+                  : 'Bạn đã từ chối lời mời này.',
+              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+            ),
         ],
       ),
     );
+  }
+
+  String _subtitle(Invitation invite) {
+    final host = invite.fromUserName ?? 'Người chơi';
+    final slot = _formatTime(invite);
+    return '$host • ${slot ?? 'Slot đang chờ cập nhật'}';
+  }
+
+  String _typeLabel(InvitationType type) {
+    switch (type) {
+      case InvitationType.booking:
+        return 'Booking có sẵn';
+      case InvitationType.proposed:
+        return 'Lời mời dự kiến';
+      case InvitationType.recruitment:
+        return 'Theo bài tuyển';
+    }
+  }
+
+  String _formatTime(Invitation invite) {
+    if (invite.startTime == null) return 'Thời gian đang đề xuất';
+    final start = invite.startTime!;
+    final end = invite.endTime;
+    final timeString = '${start.hour.toString().padLeft(2, '0')}:${start.minute.toString().padLeft(2, '0')}';
+    if (end == null) {
+      return '$timeString - ${_formatDate(start)}';
+    }
+    final endStr = '${end.hour.toString().padLeft(2, '0')}:${end.minute.toString().padLeft(2, '0')}';
+    return '$timeString - $endStr • ${_formatDate(start)}';
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}';
   }
 }
 

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -564,14 +564,18 @@ class _SocialPageState extends State<SocialPage> {
                   sliver: SliverList.separated(
                     itemBuilder: (context, index) => _InviteCard(
                       invite: invites[index],
-                      onAccept: () => invitationManager.respond(
-                        invites[index],
-                        accept: true,
-                      ),
-                      onReject: () => invitationManager.respond(
-                        invites[index],
-                        accept: false,
-                      ),
+                      onAccept: invites[index].isOutgoing
+                          ? null
+                          : () => invitationManager.respond(
+                                invites[index],
+                                accept: true,
+                              ),
+                      onReject: invites[index].isOutgoing
+                          ? null
+                          : () => invitationManager.respond(
+                                invites[index],
+                                accept: false,
+                              ),
                     ),
                     separatorBuilder: (_, __) => const SizedBox(height: 8),
                     itemCount: invites.length,
@@ -928,13 +932,14 @@ class _InviteCard extends StatelessWidget {
   });
 
   final Invitation invite;
-  final VoidCallback onAccept;
-  final VoidCallback onReject;
+  final VoidCallback? onAccept;
+  final VoidCallback? onReject;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
+    final isOutgoing = invite.isOutgoing;
 
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 6),
@@ -985,7 +990,7 @@ class _InviteCard extends StatelessWidget {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      _subtitle(invite),
+                      _subtitle(invite, isOutgoing),
                       style: tt.bodySmall?.copyWith(
                         color: cs.onSurfaceVariant,
                         fontWeight: FontWeight.w600,
@@ -1032,7 +1037,7 @@ class _InviteCard extends StatelessWidget {
             ),
           ],
           const SizedBox(height: 14),
-          if (invite.isPending)
+          if (!isOutgoing && invite.isPending)
             Row(
               children: [
                 Expanded(
@@ -1069,19 +1074,16 @@ class _InviteCard extends StatelessWidget {
               ],
             )
           else
-            Text(
-              invite.status == 'accepted'
-                  ? 'Bạn đã chấp nhận lời mời này.'
-                  : 'Bạn đã từ chối lời mời này.',
-              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
-            ),
+            _StatusLabel(invite: invite, isOutgoing: isOutgoing),
         ],
       ),
     );
   }
 
-  String _subtitle(Invitation invite) {
-    final host = invite.fromUserName ?? 'Người chơi';
+  String _subtitle(Invitation invite, bool isOutgoing) {
+    final host = isOutgoing
+        ? 'Bạn đã mời ${invite.toUserName ?? 'người chơi'}'
+        : invite.fromUserName ?? 'Người chơi';
     final slot = _formatTime(invite);
     return '$host • ${slot ?? 'Slot đang chờ cập nhật'}';
   }
@@ -1111,6 +1113,41 @@ class _InviteCard extends StatelessWidget {
 
   String _formatDate(DateTime date) {
     return '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}';
+  }
+}
+
+class _StatusLabel extends StatelessWidget {
+  const _StatusLabel({required this.invite, required this.isOutgoing});
+
+  final Invitation invite;
+  final bool isOutgoing;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    String text;
+    switch (invite.status) {
+      case 'accepted':
+        text = isOutgoing
+            ? 'Đã được chấp nhận'
+            : 'Bạn đã chấp nhận lời mời này.';
+        break;
+      case 'rejected':
+        text = isOutgoing ? 'Đã bị từ chối' : 'Bạn đã từ chối lời mời này.';
+        break;
+      case 'cancelled':
+        text = isOutgoing ? 'Bạn đã huỷ lời mời này.' : 'Lời mời đã bị huỷ.';
+        break;
+      default:
+        text = isOutgoing ? 'Đã gửi • Chờ phản hồi' : 'Đang chờ phản hồi của bạn.';
+    }
+
+    return Text(
+      text,
+      style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+    );
   }
 }
 

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1126,27 +1126,79 @@ class _StatusLabel extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
+    Color fg;
+    Color bg;
+    IconData icon;
+    String title;
+    String subtitle;
 
-    String text;
     switch (invite.status) {
       case 'accepted':
-        text = isOutgoing
-            ? 'Đã được chấp nhận'
-            : 'Bạn đã chấp nhận lời mời này.';
+        fg = Colors.green.shade700;
+        bg = Colors.green.withOpacity(0.12);
+        icon = Icons.check_circle_rounded;
+        title = isOutgoing ? 'Đã được chấp nhận' : 'Bạn đã chấp nhận lời mời này';
+        subtitle = 'Đã khoá lịch hẹn, hãy liên hệ để xác nhận chi tiết.';
         break;
       case 'rejected':
-        text = isOutgoing ? 'Đã bị từ chối' : 'Bạn đã từ chối lời mời này.';
+        fg = Colors.red.shade600;
+        bg = Colors.red.withOpacity(0.1);
+        icon = Icons.cancel_rounded;
+        title = isOutgoing ? 'Đã bị từ chối' : 'Bạn đã từ chối lời mời này';
+        subtitle = 'Bạn có thể gửi lời mời khác hoặc chọn slot khác.';
         break;
       case 'cancelled':
-        text = isOutgoing ? 'Bạn đã huỷ lời mời này.' : 'Lời mời đã bị huỷ.';
+        fg = cs.onSurfaceVariant;
+        bg = cs.surfaceVariant.withOpacity(0.3);
+        icon = Icons.block_rounded;
+        title = isOutgoing ? 'Bạn đã huỷ lời mời này' : 'Lời mời đã bị huỷ';
+        subtitle = 'Nếu cần, hãy gửi lại lời mời mới với thông tin cập nhật.';
         break;
       default:
-        text = isOutgoing ? 'Đã gửi • Chờ phản hồi' : 'Đang chờ phản hồi của bạn.';
+        fg = cs.primary;
+        bg = cs.primary.withOpacity(0.08);
+        icon = Icons.hourglass_top_rounded;
+        title = isOutgoing ? 'Đã gửi • Chờ phản hồi' : 'Đang chờ phản hồi của bạn';
+        subtitle = isOutgoing
+            ? 'Người nhận sẽ xem và phản hồi sớm.'
+            : 'Chấp nhận để chốt lịch, hoặc từ chối nếu chưa phù hợp.';
     }
 
-    return Text(
-      text,
-      style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: fg.withOpacity(0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: fg, size: 22),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: tt.bodyMedium?.copyWith(
+                    color: fg,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  subtitle,
+                  style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/user/user_public_profile_page.dart
+++ b/lib/pages/user/user_public_profile_page.dart
@@ -1,10 +1,16 @@
+import 'package:badminton_booking_app/models/chat_contact.dart';
 import 'package:badminton_booking_app/models/friend_relation.dart';
 import 'package:badminton_booking_app/models/friend_search_result.dart';
 import 'package:badminton_booking_app/models/user_details.dart';
+import 'package:badminton_booking_app/pages/social/chat/chat_page.dart';
+import 'package:badminton_booking_app/services/chat_service.dart';
 import 'package:badminton_booking_app/services/friend_request_service.dart';
 import 'package:badminton_booking_app/services/user_service.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../social/chat/chat_conversation_manager.dart';
 
 class UserPublicProfilePage extends StatefulWidget {
   const UserPublicProfilePage({super.key, required this.result});
@@ -866,8 +872,59 @@ class _UserPublicProfilePageState extends State<UserPublicProfilePage> {
   }
 
   void _openChat() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Tính năng nhắn tin sẽ sớm ra mắt.')),
+    final contact = ChatContact(
+      id: widget.result.user.id,
+      userId: widget.result.user.id,
+      name: widget.result.displayName,
+      avatarText: widget.result.initials,
+      avatarUrl: _details?.avatarUrl,
+      statusMessage:
+          _details?.level ?? widget.result.user.email ?? widget.result.user.phone,
     );
+
+    final service = ChatService();
+    final navigator = Navigator.of(context);
+    final scaffold = ScaffoldMessenger.of(context);
+
+    () async {
+      try {
+        final targetUserId = contact.userId ?? contact.id;
+
+        if (targetUserId == null) {
+          throw Exception('Không xác định được người nhận tin nhắn.');
+        }
+
+        String? roomId = contact.chatId;
+        if (roomId == null &&
+            contact.userId != null &&
+            contact.id != null &&
+            contact.id != contact.userId) {
+          roomId = contact.id;
+        }
+
+        final ensuredRoom = roomId ?? await service.ensureRoomWith(targetUserId);
+
+        if (!mounted) return;
+
+        final targetContact = contact.copyWith(
+          id: ensuredRoom,
+          chatId: ensuredRoom,
+        );
+
+        navigator.push(
+          MaterialPageRoute(
+            builder: (_) => ChangeNotifierProvider(
+              create: (_) =>
+                  ChatConversationManager(chatId: ensuredRoom)..initialize(),
+              child: ChatPage(contact: targetContact),
+            ),
+          ),
+        );
+      } catch (error) {
+        scaffold.showSnackBar(
+          SnackBar(content: Text('$error')),
+        );
+      }
+    }();
   }
 }

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -57,7 +57,9 @@ class BookingService {
 
     final escapedUserId = _escapeFilterValue(userId);
     final filterBuffer = StringBuffer("user_id='$escapedUserId'");
-    filterBuffer.write(" && (status='confirmed' || status='confirm')");
+    filterBuffer.write(
+      " && (status='held' || status='awaiting_payment' || status='confirmed')",
+    );
 
     if (startTimeInclusive != null) {
       final normalizedStart = startTimeInclusive.toUtc().toIso8601String();

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -47,7 +47,8 @@ class ChatService {
     final result = await pb.collection(chatsCollection).getList(
           filter: "user_a = '$currentUserId' || user_b = '$currentUserId'",
           sort: '-last_message_at,-updated',
-          expand: 'user_a,user_b,last_sender',
+          expand:
+              'user_a,user_b,last_sender,user_a.user_details_via_user_id,user_b.user_details_via_user_id',
         );
 
     return result.items

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -265,7 +265,9 @@ class InvitationService {
         recruitmentIds: result.items.map((e) => e.id).toList(growable: false),
       );
 
-      return result.items
+      final today = DateTime.now();
+
+      final posts = result.items
           .map(
             (record) => RecruitmentPost.fromRecord(
               record: record,
@@ -274,7 +276,23 @@ class InvitationService {
               applicants: applicantsMap[record.id] ?? const [],
             ),
           )
+          .where((post) {
+            final eventTime = post.eventTime;
+            if (eventTime == null) return false;
+
+            final matchesToday = eventTime.year == today.year &&
+                eventTime.month == today.month &&
+                eventTime.day == today.day;
+
+            final hasCapacity = post.requiredPlayers <= 0
+                ? true
+                : post.joinedPlayers < post.requiredPlayers;
+
+            return matchesToday && post.isActive && hasCapacity;
+          })
           .toList(growable: false);
+
+      return posts;
     } on ClientException catch (error) {
       throw InvitationServiceException(_mapClientError(error));
     } catch (_) {

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1,0 +1,287 @@
+import 'package:badminton_booking_app/models/court.dart';
+import 'package:badminton_booking_app/models/invitation.dart';
+import 'package:badminton_booking_app/models/recruitment_post.dart';
+import 'package:badminton_booking_app/models/user_booking_view.dart';
+import 'package:badminton_booking_app/services/booking_service.dart';
+import 'package:badminton_booking_app/services/court_service.dart';
+import 'package:badminton_booking_app/services/recruitment_service.dart';
+import 'package:pocketbase/pocketbase.dart';
+
+import '../utils/pocketbase_utils.dart';
+import 'pocketbase_client.dart';
+
+class InvitationServiceException implements Exception {
+  InvitationServiceException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class InvitationComposerData {
+  InvitationComposerData({
+    required this.recruitments,
+    required this.bookings,
+    required this.courts,
+  });
+
+  final List<RecruitmentPost> recruitments;
+  final List<UserBookingView> bookings;
+  final List<Court> courts;
+}
+
+class InvitationService {
+  static const String collection = 'invitations';
+
+  final RecruitmentService _recruitmentService;
+  final BookingService _bookingService;
+  final CourtService _courtService;
+
+  InvitationService({
+    RecruitmentService? recruitmentService,
+    BookingService? bookingService,
+    CourtService? courtService,
+  })  : _recruitmentService = recruitmentService ?? RecruitmentService(),
+        _bookingService = bookingService ?? BookingService(),
+        _courtService = courtService ?? CourtService();
+
+  Future<InvitationComposerData> loadComposerData() async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = pb.authStore.record?.id;
+    if (currentUserId == null) {
+      throw InvitationServiceException('Bạn cần đăng nhập để gửi lời mời.');
+    }
+
+    final recruitments = await _listMyRecruitments(pb, currentUserId);
+    final bookings = await _bookingService.listUserBookings(
+      userId: currentUserId,
+      startTimeInclusive: DateTime.now(),
+      endTimeExclusive: DateTime.now().add(const Duration(days: 14)),
+    );
+    final courts = await _courtService.listCourts(perPage: 50);
+
+    return InvitationComposerData(
+      recruitments: recruitments,
+      bookings: bookings,
+      courts: courts,
+    );
+  }
+
+  Future<List<Invitation>> fetchIncoming() async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = pb.authStore.record?.id;
+    if (currentUserId == null) {
+      return const <Invitation>[];
+    }
+
+    try {
+      final result = await pb.collection(collection).getList(
+            filter: "to_user='${_escape(currentUserId)}'",
+            sort: '-created',
+            expand: 'from_user,recruitment,recruitment.court,booking,booking.court_id,court',
+          );
+
+      return result.items
+          .map((record) => Invitation.fromRecord(record, pb))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw InvitationServiceException(_mapClientError(error));
+    } catch (_) {
+      throw InvitationServiceException(
+          'Không thể tải danh sách lời mời. Vui lòng thử lại.');
+    }
+  }
+
+  Future<Invitation> sendRecruitmentInvite({
+    required String toUserId,
+    required String recruitmentId,
+    String? message,
+  }) async {
+    return _createInvitation(
+      toUserId: toUserId,
+      type: 'recruitment',
+      body: {
+        'recruitment': recruitmentId,
+        'message': message,
+      },
+    );
+  }
+
+  Future<Invitation> sendBookingInvite({
+    required String toUserId,
+    required UserBookingView booking,
+    String? message,
+  }) async {
+    return _createInvitation(
+      toUserId: toUserId,
+      type: 'booking',
+      body: {
+        'booking': booking.id,
+        'court': booking.courtId,
+        'start_time': booking.startTime?.toUtc().toIso8601String(),
+        'end_time': booking.endTime?.toUtc().toIso8601String(),
+        'message': message,
+      },
+    );
+  }
+
+  Future<Invitation> sendProposedInvite({
+    required String toUserId,
+    required DateTime startTime,
+    DateTime? endTime,
+    String? courtId,
+    String? message,
+  }) async {
+    return _createInvitation(
+      toUserId: toUserId,
+      type: 'proposed',
+      body: {
+        'court': courtId,
+        'start_time': startTime.toUtc().toIso8601String(),
+        if (endTime != null) 'end_time': endTime.toUtc().toIso8601String(),
+        'message': message,
+      },
+    );
+  }
+
+  Future<Invitation> respond({
+    required Invitation invitation,
+    required bool accept,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    try {
+      final record = await pb.collection(collection).update(
+        invitation.id,
+        body: {'status': accept ? 'accepted' : 'rejected'},
+      );
+
+      if (accept && invitation.recruitmentId != null) {
+        await _upsertRecruitmentApplicant(
+          recruitmentId: invitation.recruitmentId!,
+          userId: invitation.toUserId,
+          pb: pb,
+        );
+      }
+
+      return Invitation.fromRecord(record, pb);
+    } on ClientException catch (error) {
+      throw InvitationServiceException(_mapClientError(error));
+    } catch (_) {
+      throw InvitationServiceException('Không thể cập nhật lời mời.');
+    }
+  }
+
+  Future<Invitation> _createInvitation({
+    required String toUserId,
+    required String type,
+    required Map<String, dynamic> body,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final fromUserId = pb.authStore.record?.id;
+    if (fromUserId == null) {
+      throw InvitationServiceException('Bạn cần đăng nhập để gửi lời mời.');
+    }
+
+    try {
+      final record = await pb.collection(collection).create(body: {
+        'from_user': fromUserId,
+        'to_user': toUserId,
+        'type': type,
+        'status': 'pending',
+        ...body,
+      });
+      final hydrated = await pb.collection(collection).getOne(
+            record.id,
+            expand:
+                'from_user,recruitment,recruitment.court,booking,booking.court_id,court',
+          );
+      return Invitation.fromRecord(hydrated, pb);
+    } on ClientException catch (error) {
+      throw InvitationServiceException(_mapClientError(error));
+    } catch (_) {
+      throw InvitationServiceException('Không thể gửi lời mời.');
+    }
+  }
+
+  Future<void> _upsertRecruitmentApplicant({
+    required String recruitmentId,
+    required String userId,
+    required PocketBase pb,
+  }) async {
+    final filter =
+        "recruitment='${_escape(recruitmentId)}' && user='${_escape(userId)}'";
+
+    try {
+      RecordModel? existing;
+      try {
+        existing = await pb
+            .collection(RecruitmentService.recruitmentApplicantsCollection)
+            .getFirstListItem(filter);
+      } catch (_) {
+        existing = null;
+      }
+
+      if (existing == null) {
+        await pb.collection(RecruitmentService.recruitmentApplicantsCollection)
+            .create(body: {
+          'recruitment': recruitmentId,
+          'user': userId,
+          'status': 'accepted',
+        });
+      } else {
+        await pb.collection(RecruitmentService.recruitmentApplicantsCollection)
+            .update(existing.id, body: {
+          'status': 'accepted',
+        });
+      }
+    } on ClientException catch (error) {
+      throw InvitationServiceException(_mapClientError(error));
+    } catch (_) {
+      throw InvitationServiceException(
+          'Không thể thêm thành viên vào bài tuyển.');
+    }
+  }
+
+  Future<List<RecruitmentPost>> _listMyRecruitments(
+    PocketBase pb,
+    String userId,
+  ) async {
+    try {
+      final result = await pb.collection(RecruitmentService.recruitmentPostsCollection).getList(
+            page: 1,
+            perPage: 50,
+            filter: "author='${_escape(userId)}' && is_active=true",
+            expand: 'court',
+          );
+
+      final applicantsMap = await _recruitmentService.fetchApplicantsMap(
+        pocketBase: pb,
+        recruitmentIds: result.items.map((e) => e.id).toList(growable: false),
+      );
+
+      return result.items
+          .map(
+            (record) => RecruitmentPost.fromRecord(
+              record: record,
+              pocketBase: pb,
+              currentUserId: userId,
+              applicants: applicantsMap[record.id] ?? const [],
+            ),
+          )
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw InvitationServiceException(_mapClientError(error));
+    } catch (_) {
+      throw InvitationServiceException('Không thể tải bài tuyển của bạn.');
+    }
+  }
+}
+
+String _mapClientError(ClientException error) {
+  if (error.response['message'] is String) {
+    return error.response['message'] as String;
+  }
+  return 'Có lỗi xảy ra. Vui lòng thử lại.';
+}
+
+String _escape(String value) => value.replaceAll("'", "\\'");

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -76,13 +76,19 @@ class InvitationService {
 
     try {
       final result = await pb.collection(collection).getList(
-            filter: "to_user='${_escape(currentUserId)}'",
+            filter:
+                "to_user='${_escape(currentUserId)}' || from_user='${_escape(currentUserId)}'",
             sort: '-created',
-            expand: 'from_user,recruitment,recruitment.court,booking,booking.court_id,court',
+            expand:
+                'from_user,to_user,recruitment,recruitment.court,booking,booking.court_id,court',
           );
 
       return result.items
-          .map((record) => Invitation.fromRecord(record, pb))
+          .map((record) => Invitation.fromRecord(
+                record,
+                pb,
+                viewerId: currentUserId,
+              ))
           .toList(growable: false);
     } on ClientException catch (error) {
       throw InvitationServiceException(_mapClientError(error));
@@ -193,9 +199,9 @@ class InvitationService {
       final hydrated = await pb.collection(collection).getOne(
             record.id,
             expand:
-                'from_user,recruitment,recruitment.court,booking,booking.court_id,court',
+                'from_user,to_user,recruitment,recruitment.court,booking,booking.court_id,court',
           );
-      return Invitation.fromRecord(hydrated, pb);
+      return Invitation.fromRecord(hydrated, pb, viewerId: fromUserId);
     } on ClientException catch (error) {
       throw InvitationServiceException(_mapClientError(error));
     } catch (_) {

--- a/lib/services/recruitment_service.dart
+++ b/lib/services/recruitment_service.dart
@@ -37,7 +37,7 @@ class RecruitmentService {
                 expand: 'author,court',
               );
 
-      final applicantsMap = await _fetchApplicantsMap(
+      final applicantsMap = await fetchApplicantsMap(
         pocketBase: pocketBase,
         recruitmentIds: result.items.map((e) => e.id).toList(growable: false),
       );
@@ -97,7 +97,7 @@ class RecruitmentService {
           .collection(recruitmentPostsCollection)
           .getOne(recruitmentId, expand: 'author,court');
 
-      final applicantsMap = await _fetchApplicantsMap(
+      final applicantsMap = await fetchApplicantsMap(
         pocketBase: pocketBase,
         recruitmentIds: [recruitmentId],
       );
@@ -317,7 +317,7 @@ class RecruitmentService {
     }
   }
 
-  Future<Map<String, List<RecordModel>>> _fetchApplicantsMap({
+  Future<Map<String, List<RecordModel>>> fetchApplicantsMap({
     required PocketBase pocketBase,
     required List<String> recruitmentIds,
   }) async {


### PR DESCRIPTION
## Summary
- add invitation data model, service, and manager to send and respond to invitations tied to recruitment posts, bookings, or proposed slots
- update partner suggestions to open an invitation sheet that selects an active recruitment, existing booking, or proposed slot before sending
- refresh the Invited tab to list real invitations with status handling and acceptance/rejection actions

## Testing
- Not run (environment lacks Dart/Flutter tooling)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eb356d678832b9ddf815d2bc34c76)