### PR TITLE
Add filter controls to partner suggestion tab

### DIFF
--- a/lib/pages/social/partner_suggestion_manager.dart
+++ b/lib/pages/social/partner_suggestion_manager.dart
@@ -1,20 +1,43 @@
 import 'package:badminton_booking_app/models/partner_recommendation.dart';
+import 'package:badminton_booking_app/models/friend_relation.dart';
 import 'package:badminton_booking_app/services/recommender_service.dart';
+import 'package:badminton_booking_app/services/friend_request_service.dart';
 import 'package:flutter/foundation.dart';
 
 class PartnerSuggestionManager extends ChangeNotifier {
-  PartnerSuggestionManager({RecommenderService? service})
-      : _service = service ?? RecommenderService();
+  PartnerSuggestionManager({
+    RecommenderService? service,
+    FriendRequestService? friendRequestService,
+  })  : _service = service ?? RecommenderService(),
+        _friendRequestService = friendRequestService ?? FriendRequestService();
 
   final RecommenderService _service;
+  final FriendRequestService _friendRequestService;
 
   List<PartnerRecommendation> _suggestions = const <PartnerRecommendation>[];
+  List<PartnerRecommendation> _filteredSuggestions =
+      const <PartnerRecommendation>[];
   bool _isLoading = false;
   String? _error;
 
-  List<PartnerRecommendation> get suggestions => _suggestions;
+  String? _selectedMatchType;
+  String? _selectedIntensity;
+  bool _onlyHomeCourt = false;
+  double _minMatchScore = 0;
+  bool _hideExistingRelations = false;
+  String? _homeCourtId;
+  final Map<String, FriendRelationStatus> _relations =
+      <String, FriendRelationStatus>{};
+
+  List<PartnerRecommendation> get suggestions => _filteredSuggestions;
   bool get isLoading => _isLoading;
   String? get error => _error;
+  double get minMatchScore => _minMatchScore;
+  String? get selectedMatchType => _selectedMatchType;
+  String? get selectedIntensity => _selectedIntensity;
+  bool get onlyHomeCourt => _onlyHomeCourt;
+  bool get hideExistingRelations => _hideExistingRelations;
+  String? get homeCourtId => _homeCourtId;
 
   Future<void> loadSuggestions({bool force = false}) async {
     if (_isLoading) return;
@@ -22,16 +45,120 @@ class PartnerSuggestionManager extends ChangeNotifier {
     _error = null;
     if (force) {
       _suggestions = const <PartnerRecommendation>[];
+      _filteredSuggestions = const <PartnerRecommendation>[];
     }
     notifyListeners();
 
     try {
       _suggestions = await _service.fetchRecommendations();
+      await _maybeLoadRelations();
+      _applyFilters();
     } catch (err) {
       _error = err.toString();
+      _filteredSuggestions = const <PartnerRecommendation>[];
     } finally {
       _isLoading = false;
       notifyListeners();
     }
+  }
+
+  void setMatchType(String? matchType) {
+    if (_selectedMatchType == matchType) return;
+    _selectedMatchType = matchType;
+    _applyFilters();
+  }
+
+  void setIntensity(String? intensity) {
+    if (_selectedIntensity == intensity) return;
+    _selectedIntensity = intensity;
+    _applyFilters();
+  }
+
+  void setHomeCourtOnly(bool value) {
+    if (_onlyHomeCourt == value) return;
+    _onlyHomeCourt = value;
+    _applyFilters();
+  }
+
+  void setMinMatchScore(double value) {
+    if (_minMatchScore == value) return;
+    _minMatchScore = value;
+    _applyFilters();
+  }
+
+  Future<void> setHideExistingRelations(bool value) async {
+    if (_hideExistingRelations == value) return;
+    _hideExistingRelations = value;
+    if (value) {
+      await _maybeLoadRelations();
+    }
+    _applyFilters();
+  }
+
+  void setHomeCourtId(String? id) {
+    if (_homeCourtId == id) return;
+    _homeCourtId = id;
+    if (_onlyHomeCourt) {
+      _applyFilters();
+    }
+  }
+
+  Future<void> _maybeLoadRelations() async {
+    if (!_hideExistingRelations || _suggestions.isEmpty) return;
+
+    final idsToFetch = _suggestions
+        .map((rec) => rec.friend.user.id)
+        .where((id) => !_relations.containsKey(id))
+        .toList(growable: false);
+
+    if (idsToFetch.isEmpty) return;
+
+    try {
+      final results = await Future.wait(
+        idsToFetch.map(_friendRequestService.getRelationStatus),
+      );
+
+      for (int i = 0; i < idsToFetch.length; i++) {
+        _relations[idsToFetch[i]] = results[i];
+      }
+    } catch (_) {
+      // Nếu không lấy được trạng thái quan hệ, bỏ qua để tránh chặn UI
+    }
+  }
+
+  void _applyFilters() {
+    _filteredSuggestions = _suggestions.where((suggestion) {
+      final details = suggestion.friend.details;
+
+      if (_selectedMatchType != null &&
+          !(details?.matchTypes.contains(_selectedMatchType) ?? false)) {
+        return false;
+      }
+
+      if (_selectedIntensity != null &&
+          details?.intensity != _selectedIntensity) {
+        return false;
+      }
+
+      if (_onlyHomeCourt && _homeCourtId != null) {
+        if (details?.homeCourtId != _homeCourtId) return false;
+      }
+
+      if (suggestion.matchScore < _minMatchScore) {
+        return false;
+      }
+
+      if (_hideExistingRelations) {
+        final relation =
+            _relations[suggestion.friend.user.id] ?? const FriendRelationStatus.none();
+        if (relation.type != FriendRelationType.none) {
+          return false;
+        }
+      }
+
+      return true;
+    }).toList(growable: false);
+
+    notifyListeners();
   }
 }

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1434,7 +1434,8 @@ class _QuickFilterPanel extends StatelessWidget {
               FilterChip(
                 selected: manager.selectedMatchType == option.value,
                 label: Text(option.label),
-                onSelected: (_) => manager.setMatchType(option.value),
+                onSelected: (selected) =>
+                    manager.setMatchType(selected ? option.value : null),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(14),
                 ),
@@ -1457,7 +1458,8 @@ class _QuickFilterPanel extends StatelessWidget {
               FilterChip(
                 selected: manager.selectedIntensity == option.value,
                 label: Text(option.label),
-                onSelected: (_) => manager.setIntensity(option.value),
+                onSelected: (selected) =>
+                    manager.setIntensity(selected ? option.value : null),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(14),
                 ),

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1437,14 +1437,6 @@ class _QuickFilterPanel extends StatelessWidget {
                         style:
                             tt.titleMedium?.copyWith(fontWeight: FontWeight.w800),
                       ),
-                      const SizedBox(height: 2),
-                      Text(
-                        'Thu gọn gợi ý theo kèo và độ "máu"',
-                        style: tt.bodySmall?.copyWith(
-                          color: cs.onSurfaceVariant,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
                     ],
                   ),
                 ],

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -345,6 +345,8 @@ class _SocialPageState extends State<SocialPage> {
         animation: partnerManager,
         builder: (context, _) {
           final suggestions = partnerManager.suggestions;
+          final userManager = context.watch<UserManager>();
+          partnerManager.setHomeCourtId(userManager.myDetails?.homeCourtId);
 
           return CustomScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
@@ -390,6 +392,12 @@ class _SocialPageState extends State<SocialPage> {
                         ],
                       ),
                       const SizedBox(height: 14),
+                      _QuickFilterPanel(
+                        manager: partnerManager,
+                        onAdvancedTap: () =>
+                            _openPartnerFilterSheet(context, partnerManager),
+                      ),
+                      const SizedBox(height: 12),
                       DecoratedBox(
                         decoration: BoxDecoration(
                           color: cs.primaryContainer,
@@ -432,6 +440,13 @@ class _SocialPageState extends State<SocialPage> {
                     onRetry: () => partnerManager.loadSuggestions(force: true),
                   ),
                 )
+              else if (suggestions.isEmpty)
+                const SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Center(
+                    child: Text('Không có gợi ý phù hợp với bộ lọc hiện tại.'),
+                  ),
+                )
               else
                 SliverPadding(
                   padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -467,6 +482,91 @@ class _SocialPageState extends State<SocialPage> {
                 ),
               const SliverPadding(padding: EdgeInsets.only(bottom: 120)),
             ],
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openPartnerFilterSheet(
+    BuildContext context,
+    PartnerSuggestionManager manager,
+  ) async {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (_) => AnimatedBuilder(
+        animation: manager,
+        builder: (context, __) {
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      'Lọc nâng cao',
+                      style: tt.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                    const Spacer(),
+                    IconButton(
+                      onPressed: () => Navigator.of(context).maybePop(),
+                      icon: const Icon(Icons.close_rounded),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                SwitchListTile.adaptive(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Chỉ hiện người cùng sân nhà'),
+                  subtitle: Text(
+                    manager.homeCourtId == null
+                        ? 'Bạn chưa chọn sân nhà trong hồ sơ.'
+                        : 'Ưu tiên các partner có home court trùng với bạn.',
+                  ),
+                  value: manager.homeCourtId != null && manager.onlyHomeCourt,
+                  onChanged: manager.homeCourtId == null
+                      ? null
+                      : manager.setHomeCourtOnly,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Match score tối thiểu: ${manager.minMatchScore.round()}%',
+                  style:
+                      tt.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                Slider(
+                  min: 0,
+                  max: 100,
+                  divisions: 20,
+                  label: '${manager.minMatchScore.round()}%',
+                  value: manager.minMatchScore.clamp(0, 100),
+                  activeColor: cs.primary,
+                  onChanged: manager.setMinMatchScore,
+                ),
+                const SizedBox(height: 4),
+                CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Ẩn người đã gửi lời mời hoặc đã là bạn'),
+                  subtitle: const Text(
+                    'Loại bỏ các profile bạn đã gửi/nhận lời mời hoặc đã trở thành bạn bè.',
+                  ),
+                  value: manager.hideExistingRelations,
+                  onChanged: (value) {
+                    if (value == null) return;
+                    unawaited(manager.setHideExistingRelations(value));
+                  },
+                ),
+              ],
+            ),
           );
         },
       ),
@@ -1265,6 +1365,108 @@ class _ErrorBox extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _QuickFilterPanel extends StatelessWidget {
+  const _QuickFilterPanel({
+    required this.manager,
+    required this.onAdvancedTap,
+  });
+
+  final PartnerSuggestionManager manager;
+  final VoidCallback onAdvancedTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    const matchTypeOptions = [
+      (label: 'Tất cả', value: null as String?),
+      (label: 'Đánh đơn', value: 'singles'),
+      (label: 'Đánh đôi', value: 'doubles'),
+      (label: 'Đôi nam nữ', value: 'mixed'),
+    ];
+
+    const intensityOptions = [
+      (label: 'Chơi vui', value: 'casual'),
+      (label: 'Vừa phải', value: 'semi_competitive'),
+      (label: 'Đánh giải', value: 'competitive'),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Bộ lọc nhanh',
+              style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            OutlinedButton.icon(
+              onPressed: onAdvancedTap,
+              icon: const Icon(Icons.filter_alt_rounded),
+              label: const Text('Lọc nâng cao'),
+              style: OutlinedButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Loại kèo',
+          style: tt.labelLarge?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final option in matchTypeOptions)
+              FilterChip(
+                selected: manager.selectedMatchType == option.value,
+                label: Text(option.label),
+                onSelected: (_) => manager.setMatchType(option.value),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                selectedColor: cs.primaryContainer,
+                checkmarkColor: cs.onPrimaryContainer,
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Độ "máu"',
+          style: tt.labelLarge?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final option in intensityOptions)
+              FilterChip(
+                selected: manager.selectedIntensity == option.value,
+                label: Text(option.label),
+                onSelected: (_) => manager.setIntensity(option.value),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                selectedColor: cs.secondaryContainer,
+                checkmarkColor: cs.onSecondaryContainer,
+              ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -213,7 +213,7 @@ class _SocialPageState extends State<SocialPage> {
                   children: const [
                     Icon(Icons.mail_outline_rounded, size: 20),
                     SizedBox(width: 8),
-                    Text('Invited'),
+                    Text('Invitations'),
                   ],
                 ),
               ),
@@ -514,7 +514,8 @@ class _SocialPageState extends State<SocialPage> {
                   children: [
                     Text(
                       'Lọc nâng cao',
-                      style: tt.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+                      style:
+                          tt.titleLarge?.copyWith(fontWeight: FontWeight.w700),
                     ),
                     const Spacer(),
                     IconButton(
@@ -540,8 +541,7 @@ class _SocialPageState extends State<SocialPage> {
                 const SizedBox(height: 4),
                 Text(
                   'Match score tối thiểu: ${manager.minMatchScore.round()}%',
-                  style:
-                      tt.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                  style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                 ),
                 Slider(
                   min: 0,
@@ -1203,11 +1203,13 @@ class _InviteCard extends StatelessWidget {
     if (invite.startTime == null) return 'Thời gian đang đề xuất';
     final start = invite.startTime!;
     final end = invite.endTime;
-    final timeString = '${start.hour.toString().padLeft(2, '0')}:${start.minute.toString().padLeft(2, '0')}';
+    final timeString =
+        '${start.hour.toString().padLeft(2, '0')}:${start.minute.toString().padLeft(2, '0')}';
     if (end == null) {
       return '$timeString - ${_formatDate(start)}';
     }
-    final endStr = '${end.hour.toString().padLeft(2, '0')}:${end.minute.toString().padLeft(2, '0')}';
+    final endStr =
+        '${end.hour.toString().padLeft(2, '0')}:${end.minute.toString().padLeft(2, '0')}';
     return '$timeString - $endStr • ${_formatDate(start)}';
   }
 
@@ -1237,7 +1239,8 @@ class _StatusLabel extends StatelessWidget {
         fg = Colors.green.shade700;
         bg = Colors.green.withOpacity(0.12);
         icon = Icons.check_circle_rounded;
-        title = isOutgoing ? 'Đã được chấp nhận' : 'Bạn đã chấp nhận lời mời này';
+        title =
+            isOutgoing ? 'Đã được chấp nhận' : 'Bạn đã chấp nhận lời mời này';
         subtitle = 'Đã khoá lịch hẹn, hãy liên hệ để xác nhận chi tiết.';
         break;
       case 'rejected':
@@ -1258,7 +1261,8 @@ class _StatusLabel extends StatelessWidget {
         fg = cs.primary;
         bg = cs.primary.withOpacity(0.08);
         icon = Icons.hourglass_top_rounded;
-        title = isOutgoing ? 'Đã gửi • Chờ phản hồi' : 'Đang chờ phản hồi của bạn';
+        title =
+            isOutgoing ? 'Đã gửi • Chờ phản hồi' : 'Đang chờ phản hồi của bạn';
         subtitle = isOutgoing
             ? 'Người nhận sẽ xem và phản hồi sớm.'
             : 'Chấp nhận để chốt lịch, hoặc từ chối nếu chưa phù hợp.';
@@ -1425,8 +1429,8 @@ class _QuickFilterPanel extends StatelessWidget {
                       color: cs.primary.withOpacity(0.12),
                       shape: BoxShape.circle,
                     ),
-                    child: Icon(Icons.tune_rounded,
-                        color: cs.primary, size: 20),
+                    child:
+                        Icon(Icons.tune_rounded, color: cs.primary, size: 20),
                   ),
                   const SizedBox(width: 10),
                   Column(
@@ -1434,8 +1438,8 @@ class _QuickFilterPanel extends StatelessWidget {
                     children: [
                       Text(
                         'Bộ lọc nhanh',
-                        style:
-                            tt.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+                        style: tt.titleMedium
+                            ?.copyWith(fontWeight: FontWeight.w800),
                       ),
                     ],
                   ),
@@ -1575,8 +1579,7 @@ class _FilterPill extends StatelessWidget {
               if (selected) ...[
                 Icon(Icons.check_rounded, size: 18, color: color),
                 const SizedBox(width: 6),
-              ]
-              else if (icon != null) ...[
+              ] else if (icon != null) ...[
                 Icon(icon, size: 18, color: cs.onSurfaceVariant),
                 const SizedBox(width: 6),
               ],

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -1396,79 +1396,209 @@ class _QuickFilterPanel extends StatelessWidget {
       (label: 'Đánh giải', value: 'competitive'),
     ];
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(
-              'Bộ lọc nhanh',
-              style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.6)),
+        boxShadow: [
+          BoxShadow(
+            color: cs.shadow.withOpacity(0.08),
+            blurRadius: 24,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: cs.primary.withOpacity(0.12),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(Icons.tune_rounded,
+                        color: cs.primary, size: 20),
+                  ),
+                  const SizedBox(width: 10),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Bộ lọc nhanh',
+                        style:
+                            tt.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Thu gọn gợi ý theo kèo và độ "máu"',
+                        style: tt.bodySmall?.copyWith(
+                          color: cs.onSurfaceVariant,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              TextButton.icon(
+                onPressed: onAdvancedTap,
+                icon: const Icon(Icons.expand_more_rounded),
+                label: const Text('Lọc nâng cao'),
+                style: TextButton.styleFrom(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  foregroundColor: cs.primary,
+                  backgroundColor: cs.primary.withOpacity(0.08),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Text(
+            'Loại kèo',
+            style: tt.labelLarge?.copyWith(fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 10,
+            children: [
+              for (final option in matchTypeOptions)
+                _FilterPill(
+                  label: option.label,
+                  icon: option.value == null
+                      ? Icons.all_inclusive_rounded
+                      : option.value == 'singles'
+                          ? Icons.person_outline_rounded
+                          : option.value == 'doubles'
+                              ? Icons.groups_2_outlined
+                              : Icons.favorite_outline_rounded,
+                  selected: manager.selectedMatchType == option.value,
+                  onTap: () => manager.setMatchType(
+                    manager.selectedMatchType == option.value
+                        ? null
+                        : option.value,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Độ "máu"',
+            style: tt.labelLarge?.copyWith(fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 10,
+            children: [
+              for (final option in intensityOptions)
+                _FilterPill(
+                  label: option.label,
+                  icon: option.value == 'casual'
+                      ? Icons.sentiment_satisfied_alt_rounded
+                      : option.value == 'semi_competitive'
+                          ? Icons.bolt_rounded
+                          : Icons.emoji_events_outlined,
+                  selected: manager.selectedIntensity == option.value,
+                  onTap: () => manager.setIntensity(
+                    manager.selectedIntensity == option.value
+                        ? null
+                        : option.value,
+                  ),
+                  accentColor: cs.secondary,
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterPill extends StatelessWidget {
+  const _FilterPill({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.icon,
+    this.accentColor,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final IconData? icon;
+  final Color? accentColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    final color = accentColor ?? cs.primary;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: selected
+                ? color.withOpacity(0.14)
+                : cs.surfaceVariant.withOpacity(0.45),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: selected ? color : cs.outlineVariant,
+              width: 1.2,
             ),
-            OutlinedButton.icon(
-              onPressed: onAdvancedTap,
-              icon: const Icon(Icons.filter_alt_rounded),
-              label: const Text('Lọc nâng cao'),
-              style: OutlinedButton.styleFrom(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
+            boxShadow: selected
+                ? [
+                    BoxShadow(
+                      color: color.withOpacity(0.16),
+                      blurRadius: 14,
+                      offset: const Offset(0, 6),
+                    ),
+                  ]
+                : null,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (selected) ...[
+                Icon(Icons.check_rounded, size: 18, color: color),
+                const SizedBox(width: 6),
+              ]
+              else if (icon != null) ...[
+                Icon(icon, size: 18, color: cs.onSurfaceVariant),
+                const SizedBox(width: 6),
+              ],
+              Text(
+                label,
+                style: tt.labelLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: selected ? color : cs.onSurface,
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-        const SizedBox(height: 8),
-        Text(
-          'Loại kèo',
-          style: tt.labelLarge?.copyWith(fontWeight: FontWeight.w700),
-        ),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            for (final option in matchTypeOptions)
-              FilterChip(
-                selected: manager.selectedMatchType == option.value,
-                label: Text(option.label),
-                onSelected: (selected) =>
-                    manager.setMatchType(selected ? option.value : null),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(14),
-                ),
-                selectedColor: cs.primaryContainer,
-                checkmarkColor: cs.onPrimaryContainer,
-              ),
-          ],
-        ),
-        const SizedBox(height: 12),
-        Text(
-          'Độ "máu"',
-          style: tt.labelLarge?.copyWith(fontWeight: FontWeight.w700),
-        ),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            for (final option in intensityOptions)
-              FilterChip(
-                selected: manager.selectedIntensity == option.value,
-                label: Text(option.label),
-                onSelected: (selected) =>
-                    manager.setIntensity(selected ? option.value : null),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(14),
-                ),
-                selectedColor: cs.secondaryContainer,
-                checkmarkColor: cs.onSecondaryContainer,
-              ),
-          ],
-        ),
-      ],
+      ),
     );
   }
 }

--- a/recommender_system/app.py
+++ b/recommender_system/app.py
@@ -366,3 +366,138 @@ async def recommend_players_endpoint(user_id: str, limit: int = 10):
     # 3. Tính score & trả về top
     candidates = recommend_partners(me, others, limit=limit, weights=DEFAULT_WEIGHTS)
     return candidates
+
+
+# ---------------- FRIEND MODE CONFIG ---------------- #
+
+class FriendScoringWeights(BaseModel):
+    """
+    Cấu hình trọng số dành riêng cho gợi ý kết bạn.
+    Mục tiêu: tìm người có "gu chơi" và "sân nhà" giống nhau.
+    """
+
+    # Gợi ý kết bạn không cần trình độ quá sát
+    level: float = 20.0
+
+    # Hợp lối chơi khiến dễ làm bạn khi đánh chung
+    play_style: float = 25.0
+
+    # Intensity quan trọng vì những người cùng độ máu dễ hợp nhau
+    intensity: float = 30.0
+
+    # Rất quan trọng cho chức năng kết bạn: cùng sân → khả năng gặp nhau cao
+    home_court: float = 25.0
+
+    # Cho phép chênh level lớn hơn partner-mode
+    max_level_diff: int = 2   # vd: 1 vs 3 vẫn accept
+
+
+FRIEND_WEIGHTS = FriendScoringWeights()
+
+
+def compute_friend_score(
+    me: UserDetails,
+    other: UserDetails,
+    weights: FriendScoringWeights = FRIEND_WEIGHTS,
+) -> Tuple[float, Dict[str, Any]]:
+    """
+    Mode FRIEND:
+    - Không áp dụng giới tính / match_types
+    - Level chỉ loại nếu quá lệch (>2)
+    - Tập trung vào intensity, style và sân nhà
+    """
+
+    if me.user_id == other.user_id:
+        return 0.0, {"reason": "same_user"}
+
+    # 1. Level filter rất mềm
+    if abs(me.level_numeric - other.level_numeric) > weights.max_level_diff:
+        return 0.0, {"reason": "level_diff_too_high_for_friend"}
+
+    # 2. Scoring
+    scores = {}
+
+    # level
+    diff = abs(me.level_numeric - other.level_numeric)
+    if diff == 0:
+        scores["level"] = 1.0 * weights.level
+    elif diff == 1:
+        scores["level"] = 0.6 * weights.level
+    elif diff == 2:
+        scores["level"] = 0.2 * weights.level
+    else:
+        scores["level"] = 0.0
+
+    # play style
+    scores["style"] = _jaccard(me.play_style_tags, other.play_style_tags) * weights.play_style
+
+    # intensity
+    int_diff = abs(_intensity_value(me.intensity) - _intensity_value(other.intensity))
+    if int_diff == 0:
+        scores["intensity"] = 1.0 * weights.intensity
+    elif int_diff == 1:
+        scores["intensity"] = 0.5 * weights.intensity
+    else:
+        scores["intensity"] = 0.0
+
+    # home court
+    scores["home_court"] = (
+        weights.home_court if me.home_court and me.home_court == other.home_court else 0.0
+    )
+
+    total = sum(scores.values())
+    return total, scores
+
+
+def recommend_friends(
+    me: UserDetails,
+    others: List[UserDetails],
+    limit: int = 10,
+    weights: FriendScoringWeights = FRIEND_WEIGHTS,
+) -> List[MatchCandidate]:
+
+    candidates = []
+
+    for other in others:
+        score, details = compute_friend_score(me, other, weights=weights)
+        if score <= 0:
+            continue
+
+        candidates.append(
+            MatchCandidate(
+                user=other,
+                score=round(score, 2),
+                debug_info=details,
+            )
+        )
+
+    candidates.sort(key=lambda c: c.score, reverse=True)
+    return candidates[:limit]
+
+
+# ---------------- FASTAPI ENDPOINT: FRIENDS ---------------- #
+
+@app.get("/recommend/friends", response_model=List[MatchCandidate])
+async def recommend_friends_endpoint(user_id: str, limit: int = 10):
+    """
+    Gợi ý KẾT BẠN:
+    - Không xét giới tính
+    - Không xét match_types
+    - Level filter mềm
+    - Ưu tiên: intensity, playstyle, home_court
+    """
+
+    me_record = await get_user_details_by_user_id(user_id)
+    if not me_record:
+        raise HTTPException(status_code=404, detail="User details not found")
+
+    me = UserDetails.from_pb_record(me_record)
+
+    others_records = await get_all_other_user_details(user_id)
+    if not others_records:
+        return []
+
+    others = [UserDetails.from_pb_record(r) for r in others_records]
+
+    candidates = recommend_friends(me, others, limit=limit, weights=FRIEND_WEIGHTS)
+    return candidates


### PR DESCRIPTION
## Summary
- add quick filter chips for match type and intensity alongside a link to advanced filters in the partner suggestions tab
- extend partner suggestion filtering logic with match type, intensity, home court, minimum match score, and relation-based exclusions
- provide an advanced bottom sheet and empty-state messaging to make narrowing partner recommendations clearer

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302f2b6574832bb43c740442ecd462)