### PR TITLE
Add dynamic friend suggestions with incremental loading

### DIFF
--- a/lib/pages/social/chat/add_friend_page.dart
+++ b/lib/pages/social/chat/add_friend_page.dart
@@ -7,30 +7,21 @@ import 'package:badminton_booking_app/pages/user/user_public_profile_page.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class AddFriendPage extends StatelessWidget {
+class AddFriendPage extends StatefulWidget {
   const AddFriendPage({super.key});
 
-  static const List<ChatContact> _suggestedFriends = [
-    ChatContact(
-      id: 'suggest-1',
-      name: 'Linh Trần',
-      avatarText: 'LT',
-      statusMessage: 'Bạn chung: Bảo Minh, Ngọc Anh',
-      isOnline: true,
-    ),
-    ChatContact(
-      id: 'suggest-2',
-      name: 'Phúc Nguyễn',
-      avatarText: 'PN',
-      statusMessage: 'Tham gia các nhóm giao lưu Quận 7',
-    ),
-    ChatContact(
-      id: 'suggest-3',
-      name: 'Thuỷ Tiên',
-      avatarText: 'TT',
-      statusMessage: 'Đánh đơn nữ trình trung bình khá',
-    ),
-  ];
+  @override
+  State<AddFriendPage> createState() => _AddFriendPageState();
+}
+
+class _AddFriendPageState extends State<AddFriendPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<FriendManager>().loadFriendSuggestions();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,18 +57,7 @@ class AddFriendPage extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            ..._suggestedFriends.map(
-              (contact) => Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: ContactListTile.suggestion(
-                  contact: contact,
-                  onTap: () {},
-                  onChatPressed: () {},
-                ),
-              ),
-            ),
-            const SizedBox(height: 12),
-            _buildCommunityCard(context),
+            _buildSuggestions(context, friendManager, theme),
           ],
         ),
       ),
@@ -181,6 +161,79 @@ class AddFriendPage extends StatelessWidget {
             ),
           ),
         ),
+      ],
+    );
+  }
+
+  Widget _buildSuggestions(
+    BuildContext context,
+    FriendManager friendManager,
+    ThemeData theme,
+  ) {
+    if (friendManager.isLoadingSuggestions) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (friendManager.suggestionsError != null) {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            child: Text(
+              friendManager.suggestionsError!,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+          TextButton(
+            onPressed: () => friendManager.loadFriendSuggestions(),
+            child: const Text('Thử lại'),
+          ),
+        ],
+      );
+    }
+
+    if (friendManager.friendSuggestions.isEmpty) {
+      return Text(
+        'Hiện chưa có gợi ý kết bạn.',
+        style: theme.textTheme.bodyMedium,
+      );
+    }
+
+    final visibleSuggestions = friendManager.friendSuggestions
+        .take(friendManager.visibleSuggestions)
+        .toList();
+
+    return Column(
+      children: [
+        ...visibleSuggestions.map(
+          (result) => Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: ContactListTile.suggestion(
+              contact: ChatContact(
+                id: result.user.id,
+                name: result.displayName,
+                avatarText: result.initials,
+                statusMessage:
+                    result.subtitle.isEmpty ? null : result.subtitle,
+              ),
+              trailing: _buildTrailingActions(
+                context,
+                friendManager,
+                result,
+              ),
+              onTap: () => _openProfile(context, result),
+            ),
+          ),
+        ),
+        if (friendManager.visibleSuggestions <
+            friendManager.friendSuggestions.length)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton(
+              onPressed: friendManager.showMoreSuggestions,
+              child: const Text('Xem thêm'),
+            ),
+          ),
       ],
     );
   }
@@ -402,54 +455,5 @@ class AddFriendPage extends StatelessWidget {
         );
       }
     }
-  }
-
-  Widget _buildCommunityCard(BuildContext context) {
-    final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(24),
-        gradient: LinearGradient(
-          colors: [cs.primary, cs.primary.withOpacity(0.8)],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: cs.primary.withOpacity(0.25),
-            blurRadius: 18,
-            offset: const Offset(0, 10),
-          ),
-        ],
-      ),
-      padding: const EdgeInsets.all(20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Kết nối nhiều hơn',
-            style: theme.textTheme.titleLarge?.copyWith(
-              color: cs.onPrimary,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Tham gia các nhóm cầu lông địa phương để tìm thêm nhiều người bạn cùng sở thích.',
-            style: theme.textTheme.bodyMedium?.copyWith(color: cs.onPrimary),
-          ),
-          const SizedBox(height: 16),
-          FilledButton.tonal(
-            style: FilledButton.styleFrom(
-              backgroundColor: cs.onPrimary.withOpacity(0.15),
-              foregroundColor: cs.onPrimary,
-            ),
-            onPressed: () {},
-            child: const Text('Khám phá nhóm mới'),
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/lib/pages/social/chat/friend_manager.dart
+++ b/lib/pages/social/chat/friend_manager.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:badminton_booking_app/models/friend_relation.dart';
 import 'package:badminton_booking_app/models/friend_search_result.dart';
 import 'package:badminton_booking_app/services/friend_request_service.dart';
 import 'package:badminton_booking_app/services/pocketbase_client.dart';
+import 'package:badminton_booking_app/services/recommender_service.dart';
 import 'package:badminton_booking_app/services/user_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:pocketbase/pocketbase.dart';
@@ -11,17 +13,24 @@ import 'package:pocketbase/pocketbase.dart';
 class FriendManager extends ChangeNotifier {
   FriendManager()
       : _userDetailsService = UserDetailsService(),
-        _friendRequestService = FriendRequestService();
+        _friendRequestService = FriendRequestService(),
+        _recommenderService = RecommenderService();
 
   Timer? _searchDebounce;
 
   final UserDetailsService _userDetailsService;
   final FriendRequestService _friendRequestService;
+  final RecommenderService _recommenderService;
 
   List<FriendSearchResult> _searchResults = const <FriendSearchResult>[];
   bool _isSearching = false;
   String _currentQuery = '';
   String? _error;
+
+  List<FriendSearchResult> _friendSuggestions = const <FriendSearchResult>[];
+  bool _isLoadingSuggestions = false;
+  String? _suggestionsError;
+  int _visibleSuggestions = 0;
 
   final Map<String, FriendRelationStatus> _relations = {};
   final Map<String, bool> _actionLoading = {};
@@ -41,6 +50,10 @@ class FriendManager extends ChangeNotifier {
   bool isFriend(String userId) =>
       _relations[userId]?.type == FriendRelationType.friends;
   bool isActionInProgress(String userId) => _actionLoading[userId] == true;
+  List<FriendSearchResult> get friendSuggestions => _friendSuggestions;
+  bool get isLoadingSuggestions => _isLoadingSuggestions;
+  String? get suggestionsError => _suggestionsError;
+  int get visibleSuggestions => _visibleSuggestions;
 
   FriendRelationStatus relationFor(String userId) =>
       _relations[userId] ?? const FriendRelationStatus.none();
@@ -197,7 +210,11 @@ class FriendManager extends ChangeNotifier {
         return;
       }
       _searchResults = results;
-      _loadRelationsForResults(results, term);
+      _loadRelationsForResults(
+        results,
+        term: term,
+        clearExisting: true,
+      );
     } catch (_) {
       if (_currentQuery.trim() != term) return;
       _error = 'Không thể tìm kiếm. Vui lòng thử lại.';
@@ -210,9 +227,10 @@ class FriendManager extends ChangeNotifier {
   }
 
   void _loadRelationsForResults(
-    List<FriendSearchResult> results,
-    String term,
-  ) {
+    List<FriendSearchResult> results, {
+    String? term,
+    bool clearExisting = false,
+  }) {
     unawaited(() async {
       try {
         final entries = await Future.wait(
@@ -223,16 +241,48 @@ class FriendManager extends ChangeNotifier {
           }),
         );
 
-        if (_currentQuery.trim() != term.trim()) return;
+        if (term != null && _currentQuery.trim() != term.trim()) return;
 
-        _relations
-          ..clear()
-          ..addEntries(entries);
+        if (clearExisting) {
+          _relations.clear();
+        }
+        _relations.addEntries(entries);
         notifyListeners();
       } catch (_) {
         // ignore background errors
       }
     }());
+  }
+
+  Future<void> loadFriendSuggestions({int limit = 20}) async {
+    _isLoadingSuggestions = true;
+    _suggestionsError = null;
+    notifyListeners();
+
+    try {
+      final results = await _recommenderService.fetchFriendSuggestions(
+        limit: limit,
+      );
+      _friendSuggestions = results;
+      _visibleSuggestions =
+          results.isEmpty ? 0 : math.min(5, _friendSuggestions.length);
+      _loadRelationsForResults(results);
+    } catch (_) {
+      _suggestionsError = 'Không thể tải gợi ý kết bạn. Vui lòng thử lại.';
+    } finally {
+      _isLoadingSuggestions = false;
+      notifyListeners();
+    }
+  }
+
+  void showMoreSuggestions() {
+    if (_visibleSuggestions >= _friendSuggestions.length) return;
+
+    _visibleSuggestions = math.min(
+      _visibleSuggestions + 5,
+      _friendSuggestions.length,
+    );
+    notifyListeners();
   }
 
   Future<void> sendFriendRequest(FriendSearchResult target) async {

--- a/lib/pages/user/user_public_profile_page.dart
+++ b/lib/pages/user/user_public_profile_page.dart
@@ -72,6 +72,18 @@ class _UserPublicProfilePageState extends State<UserPublicProfilePage> {
     try {
       final details = await _service.getByUserId(widget.result.user.id);
       if (!mounted) return;
+
+      if (details == null) {
+        setState(() {
+          _details = null;
+          _homeCourtName = null;
+          _isHomeCourtLoading = false;
+          _error = 'Không thể tải hồ sơ người dùng. Vui lòng thử lại sau.';
+          _isLoading = false;
+        });
+        return;
+      }
+
       setState(() {
         _details = details;
         _isLoading = false;

--- a/lib/pages/user/user_public_profile_page.dart
+++ b/lib/pages/user/user_public_profile_page.dart
@@ -51,13 +51,14 @@ class _UserPublicProfilePageState extends State<UserPublicProfilePage> {
     _service = UserDetailsService();
     _friendRequestService = FriendRequestService();
     _courtService = CourtService();
-    _details = widget.result.details;
-    _isLoading = _details == null;
-    if (_details == null) {
+    final initialDetails = widget.result.details;
+    _details = initialDetails;
+    _isLoading = initialDetails == null;
+    if (initialDetails == null) {
       _fetchDetails();
     } else {
       _isLoading = false;
-      _loadHomeCourtName(_details!.homeCourtId);
+      _loadHomeCourtName(initialDetails.homeCourtId);
     }
     _loadRelation();
   }

--- a/lib/pages/user/user_public_profile_page.dart
+++ b/lib/pages/user/user_public_profile_page.dart
@@ -4,6 +4,7 @@ import 'package:badminton_booking_app/models/friend_search_result.dart';
 import 'package:badminton_booking_app/models/user_details.dart';
 import 'package:badminton_booking_app/pages/social/chat/chat_page.dart';
 import 'package:badminton_booking_app/services/chat_service.dart';
+import 'package:badminton_booking_app/services/court_service.dart';
 import 'package:badminton_booking_app/services/friend_request_service.dart';
 import 'package:badminton_booking_app/services/user_service.dart';
 import 'package:flutter/material.dart';
@@ -32,6 +33,7 @@ class _UserPublicProfilePageState extends State<UserPublicProfilePage> {
 
   late final UserDetailsService _service;
   late final FriendRequestService _friendRequestService;
+  late final CourtService _courtService;
   UserDetails? _details;
   bool _isLoading = true;
   String? _error;
@@ -40,18 +42,22 @@ class _UserPublicProfilePageState extends State<UserPublicProfilePage> {
   bool _isActionLoading = false;
   String? _relationError;
   String? _currentUserId;
+  bool _isHomeCourtLoading = false;
+  String? _homeCourtName;
 
   @override
   void initState() {
     super.initState();
     _service = UserDetailsService();
     _friendRequestService = FriendRequestService();
+    _courtService = CourtService();
     _details = widget.result.details;
     _isLoading = _details == null;
     if (_details == null) {
       _fetchDetails();
     } else {
       _isLoading = false;
+      _loadHomeCourtName(_details!.homeCourtId);
     }
     _loadRelation();
   }
@@ -69,6 +75,7 @@ class _UserPublicProfilePageState extends State<UserPublicProfilePage> {
         _details = details;
         _isLoading = false;
       });
+      _loadHomeCourtName(details.homeCourtId);
     } catch (_) {
       if (!mounted) return;
       setState(() {
@@ -109,6 +116,40 @@ class _UserPublicProfilePageState extends State<UserPublicProfilePage> {
 
   Future<void> _refreshAll() async {
     await Future.wait([_fetchDetails(), _loadRelation()]);
+  }
+
+  Future<void> _loadHomeCourtName(String? homeCourtId) async {
+    final id = homeCourtId?.trim();
+    if (id == null || id.isEmpty) {
+      setState(() {
+        _homeCourtName = null;
+        _isHomeCourtLoading = false;
+      });
+      return;
+    }
+
+    setState(() {
+      _isHomeCourtLoading = true;
+      _homeCourtName = null;
+    });
+
+    try {
+      final court = await _courtService.getCourt(id);
+      if (!mounted) return;
+      setState(() {
+        _homeCourtName = court.name.trim().isNotEmpty ? court.name : null;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _homeCourtName = null;
+      });
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isHomeCourtLoading = false;
+      });
+    }
   }
 
   @override
@@ -436,7 +477,10 @@ class _UserPublicProfilePageState extends State<UserPublicProfilePage> {
             _infoTile(
               Icons.house_outlined,
               'Sân yêu thích',
-              details.homeCourtId ?? 'Chưa cập nhật',
+              _homeCourtName ??
+                  (_isHomeCourtLoading
+                      ? 'Đang tải...'
+                      : (details.homeCourtId ?? 'Chưa cập nhật')),
             ),
           ],
         ),

--- a/lib/services/recommender_service.dart
+++ b/lib/services/recommender_service.dart
@@ -48,6 +48,34 @@ class RecommenderService {
     return results;
   }
 
+  Future<List<FriendSearchResult>> fetchFriendSuggestions({int limit = 20}) async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = pb.authStore.record?.id;
+    if (currentUserId == null) {
+      throw Exception('Bạn chưa đăng nhập.');
+    }
+
+    final uri = Uri.parse('$_baseUrl/recommend/friends').replace(
+      queryParameters: {
+        'user_id': currentUserId,
+        'limit': '$limit',
+      },
+    );
+
+    final response = await _client.get(uri);
+    if (response.statusCode != 200) {
+      throw Exception('Không thể tải gợi ý kết bạn. Vui lòng thử lại.');
+    }
+
+    final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+
+    final results = await Future.wait(
+      data.map((raw) => _mapFriendCandidate(raw as Map<String, dynamic>, pb)),
+    );
+
+    return results;
+  }
+
   Future<PartnerRecommendation> _mapCandidate(
     Map<String, dynamic> json,
     PocketBase pb,
@@ -64,5 +92,19 @@ class RecommenderService {
       friend: FriendSearchResult(user: user, details: details),
       matchScore: rawScore,
     );
+  }
+
+  Future<FriendSearchResult> _mapFriendCandidate(
+    Map<String, dynamic> json,
+    PocketBase pb,
+  ) async {
+    final userJson = json['user'] as Map<String, dynamic>? ?? <String, dynamic>{};
+    final userId = (userJson['user_id'] ?? '') as String;
+
+    final details = await _userDetailsService.getByUserIdWithClient(pb, userId);
+    final userRecord = await pb.collection('users').getOne(userId);
+    final user = User.fromJson(userRecord.toJson());
+
+    return FriendSearchResult(user: user, details: details);
   }
 }

--- a/recommender_system/app.py
+++ b/recommender_system/app.py
@@ -3,10 +3,12 @@ from typing import List, Optional, Any, Dict, Tuple
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-# DÙNG IMPORT THẬT TỪ POCKETBASE CLIENT CỦA BẠN
-from pocketbase_client import (
+# DÙNG IMPORT THẬT TỪ POCKETBASE CLIENT/SERVICE CỦA BẠN
+from pocketbase_service import (
     get_user_details_by_user_id,
     get_all_other_user_details,
+    create_recommendation_log,
+    create_match_feedback,
 )
 
 
@@ -76,6 +78,17 @@ class MatchCandidate(BaseModel):
     score: float
     # Để debug: lưu được cả số điểm từng tiêu chí hoặc reason bị loại
     debug_info: Optional[Dict[str, Any]] = None
+
+
+class MatchFeedbackRequest(BaseModel):
+    """
+    Payload nhận feedback sau khi chơi.
+    """
+    from_user_id: str           # ai đang đánh giá
+    to_user_id: str             # đang đánh giá ai
+    booking_id: Optional[str] = None  # trận / booking cụ thể (có thể None)
+    feedback: str               # "good" | "ok" | "bad"
+    comment: Optional[str] = None
 
 
 # ---------- SCORING CONFIG ----------
@@ -332,6 +345,45 @@ def recommend_partners(
     return candidates[:limit]
 
 
+# ---------- LOGGING HELPERS ----------
+
+
+async def log_recommendations(
+    *,
+    from_user_id: str,
+    candidates: List[MatchCandidate],
+    mode: str,  # "partner" | "friend"
+) -> None:
+    """
+    Ghi log cho mỗi candidate vào collection recommendation_logs.
+
+    - from_user_id: user đang được gợi ý danh sách
+    - candidates  : danh sách gợi ý (MatchCandidate)
+    - mode        : "partner" hoặc "friend" (để sau này dễ phân tích)
+    """
+    for index, c in enumerate(candidates, start=1):
+        try:
+            # copy debug_info (có thể là None)
+            features: Dict[str, Any] = dict(c.debug_info or {})
+            features["mode"] = mode
+
+            await create_recommendation_log(
+                from_user_id=from_user_id,
+                to_user_id=c.user.user_id,
+                rule_score=c.score,
+                rank_in_list=index,
+                features=features,
+                invited=False,
+                accepted=False,
+            )
+        except Exception as e:
+            # Không làm vỡ response chỉ vì log lỗi
+            print(
+                f"[RECO_LOG][ERROR] cannot log recommendation "
+                f"{from_user_id} -> {c.user.user_id}: {e}"
+            )
+
+
 # ---------- FASTAPI APP ----------
 
 
@@ -341,6 +393,30 @@ app = FastAPI(title="Badminton Recommendation Service")
 @app.get("/health")
 async def health_check():
     return {"status": "ok"}
+
+
+@app.post("/feedback/match")
+async def submit_match_feedback(payload: MatchFeedbackRequest):
+    """
+    Nhận feedback sau khi chơi:
+    - from_user_id: người cho feedback
+    - to_user_id  : người được đánh giá
+    - booking_id  : trận/booking liên quan (có thể None)
+    - feedback    : "good" | "ok" | "bad"
+    - comment     : ghi chú thêm
+    """
+    try:
+        record = await create_match_feedback(
+            from_user_id=payload.from_user_id,
+            to_user_id=payload.to_user_id,
+            booking_id=payload.booking_id,
+            feedback=payload.feedback,
+            comment=payload.comment,
+        )
+        return {"status": "ok", "id": record.get("id")}
+    except Exception as e:
+        print("[MATCH_FEEDBACK][ERROR] cannot create match_feedback record:", e)
+        raise HTTPException(status_code=500, detail="Cannot save feedback")
 
 
 @app.get("/recommend/players", response_model=List[MatchCandidate])
@@ -365,10 +441,19 @@ async def recommend_players_endpoint(user_id: str, limit: int = 10):
 
     # 3. Tính score & trả về top
     candidates = recommend_partners(me, others, limit=limit, weights=DEFAULT_WEIGHTS)
+
+    # 4. Ghi log recommendation (mode = "partner")
+    await log_recommendations(
+        from_user_id=user_id,
+        candidates=candidates,
+        mode="partner",
+    )
+
     return candidates
 
 
 # ---------------- FRIEND MODE CONFIG ---------------- #
+
 
 class FriendScoringWeights(BaseModel):
     """
@@ -415,7 +500,7 @@ def compute_friend_score(
         return 0.0, {"reason": "level_diff_too_high_for_friend"}
 
     # 2. Scoring
-    scores = {}
+    scores: Dict[str, float] = {}
 
     # level
     diff = abs(me.level_numeric - other.level_numeric)
@@ -456,7 +541,7 @@ def recommend_friends(
     weights: FriendScoringWeights = FRIEND_WEIGHTS,
 ) -> List[MatchCandidate]:
 
-    candidates = []
+    candidates: List[MatchCandidate] = []
 
     for other in others:
         score, details = compute_friend_score(me, other, weights=weights)
@@ -476,6 +561,7 @@ def recommend_friends(
 
 
 # ---------------- FASTAPI ENDPOINT: FRIENDS ---------------- #
+
 
 @app.get("/recommend/friends", response_model=List[MatchCandidate])
 async def recommend_friends_endpoint(user_id: str, limit: int = 10):
@@ -500,4 +586,12 @@ async def recommend_friends_endpoint(user_id: str, limit: int = 10):
     others = [UserDetails.from_pb_record(r) for r in others_records]
 
     candidates = recommend_friends(me, others, limit=limit, weights=FRIEND_WEIGHTS)
+
+    # Ghi log recommendation (mode = "friend")
+    await log_recommendations(
+        from_user_id=user_id,
+        candidates=candidates,
+        mode="friend",
+    )
+
     return candidates

--- a/recommender_system/pocketbase_client.py
+++ b/recommender_system/pocketbase_client.py
@@ -1,5 +1,6 @@
+# pocketbase_client.py
 import os
-from typing import List, Optional, Any
+from typing import Any, Dict, Optional
 
 import httpx
 from dotenv import load_dotenv
@@ -10,79 +11,68 @@ POCKETBASE_URL = os.getenv("POCKETBASE_URL", "http://127.0.0.1:8090")
 PB_USER_EMAIL = os.getenv("PB_USER_EMAIL")
 PB_USER_PASSWORD = os.getenv("PB_USER_PASSWORD")
 
-if not PB_USER_EMAIL or not PB_USER_PASSWORD:
-    raise RuntimeError("PB_USER_EMAIL or PB_USER_PASSWORD is not set in .env")
-
-# Tạo 1 AsyncClient dùng chung
 client = httpx.AsyncClient(base_url=POCKETBASE_URL, timeout=10.0)
-
 _auth_token: Optional[str] = None
 
 
 async def ensure_user_login() -> None:
-    """
-    Đăng nhập bằng user thường (auth collection `users`), lấy token để dùng cho các request sau.
-    Gọi nhiều lần cũng không sao: nếu đã có token thì return luôn.
-    """
     global _auth_token
     if _auth_token is not None:
         return
 
     resp = await client.post(
         "/api/collections/users/auth-with-password",
-        json={
-            "identity": PB_USER_EMAIL,
-            "password": PB_USER_PASSWORD,
-        },
+        json={"identity": PB_USER_EMAIL, "password": PB_USER_PASSWORD},
     )
     resp.raise_for_status()
-    data = resp.json()
-    _auth_token = data["token"]
-    # Nếu bạn thích dùng cookie thì có thể dùng resp.cookies, nhưng token là đủ.
+    _auth_token = resp.json()["token"]
 
 
-def _auth_headers() -> dict[str, str]:
-    if _auth_token is None:
-        return {}
-    return {"Authorization": f"Bearer {_auth_token}"}
+def _auth_headers() -> Dict[str, str]:
+    return {"Authorization": f"Bearer {_auth_token}"} if _auth_token else {}
 
 
-async def get_user_details_by_user_id(user_id: str) -> Optional[dict]:
-    """
-    Lấy 1 record user_details theo user_id (id của _pb_users_auth_).
-    """
+async def create_record(collection: str, data: Dict[str, Any]) -> Dict[str, Any]:
     await ensure_user_login()
-
-    resp = await client.get(
-        "/api/collections/user_details/records",
-        params={
-            "filter": f"user_id = '{user_id}'",
-            "perPage": 1,
-        },
+    resp = await client.post(
+        f"/api/collections/{collection}/records",
+        json=data,
         headers=_auth_headers(),
     )
     resp.raise_for_status()
-    data = resp.json()
-    items = data.get("items", [])
-    if not items:
-        return None
-    return items[0]
+    return resp.json()
 
 
-async def get_all_other_user_details(current_user_id: str, per_page: int = 200) -> List[dict]:
-    """
-    Lấy danh sách user_details của tất cả người dùng khác current_user_id.
-    """
+async def update_record(collection: str, record_id: str, data: Dict[str, Any]) -> Dict[str, Any]:
     await ensure_user_login()
-
-    resp = await client.get(
-        "/api/collections/user_details/records",
-        params={
-            "filter": f"user_id != '{current_user_id}'",
-            "perPage": per_page,
-        },
+    resp = await client.patch(
+        f"/api/collections/{collection}/records/{record_id}",
+        json=data,
         headers=_auth_headers(),
     )
     resp.raise_for_status()
-    data = resp.json()
-    return data.get("items", [])
+    return resp.json()
+
+
+async def get_list(
+    collection: str,
+    page: int = 1,
+    per_page: int = 30,
+    *,
+    filter_expr: Optional[str] = None,
+    sort: Optional[str] = None,
+) -> Dict[str, Any]:
+    await ensure_user_login()
+    params: Dict[str, Any] = {"page": page, "perPage": per_page}
+    if filter_expr:
+        params["filter"] = filter_expr
+    if sort:
+        params["sort"] = sort
+
+    resp = await client.get(
+        f"/api/collections/{collection}/records",
+        params=params,
+        headers=_auth_headers(),
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/recommender_system/pocketbase_service.py
+++ b/recommender_system/pocketbase_service.py
@@ -1,0 +1,100 @@
+# pocketbase_service.py
+from typing import Any, Dict, List, Optional
+
+from   pocketbase_client import create_record, update_record, get_list
+
+
+# ---------- USER_DETAILS ----------
+
+async def get_user_details_by_user_id(user_id: str) -> Optional[dict]:
+    data = await get_list(
+        "user_details",
+        page=1,
+        per_page=1,
+        filter_expr=f"user_id = '{user_id}'",
+    )
+    items = data.get("items", [])
+    return items[0] if items else None
+
+
+async def get_all_other_user_details(current_user_id: str, per_page: int = 200) -> List[dict]:
+    data = await get_list(
+        "user_details",
+        page=1,
+        per_page=per_page,
+        filter_expr=f"user_id != '{current_user_id}'",
+    )
+    return data.get("items", [])
+
+
+# ---------- RECOMMENDATION_LOGS ----------
+
+async def create_recommendation_log(
+    *,
+    from_user_id: str,
+    to_user_id: str,
+    rule_score: float,
+    rank_in_list: int,
+    features: Optional[Dict[str, Any]] = None,
+    invited: bool = False,
+    accepted: bool = False,
+) -> Dict[str, Any]:
+    payload = {
+        "from_user": from_user_id,
+        "to_user": to_user_id,
+        "rule_score": rule_score,
+        "rank_in_list": rank_in_list,
+        "features": features or {},
+        "invited": invited,
+        "accepted": accepted,
+    }
+    return await create_record("recommendation_logs", payload)
+
+
+async def _get_latest_recommendation_log(from_user_id: str, to_user_id: str) -> Optional[Dict[str, Any]]:
+    data = await get_list(
+        "recommendation_logs",
+        page=1,
+        per_page=1,
+        filter_expr=f'from_user = "{from_user_id}" && to_user = "{to_user_id}"',
+        sort="-created",
+    )
+    items = data.get("items", [])
+    return items[0] if items else None
+
+
+async def mark_recommendation_invited(from_user_id: str, to_user_id: str) -> None:
+    rec = await _get_latest_recommendation_log(from_user_id, to_user_id)
+    if not rec:
+        return
+    await update_record("recommendation_logs", rec["id"], {"invited": True})
+
+
+async def mark_recommendation_accepted(from_user_id: str, to_user_id: str) -> None:
+    rec = await _get_latest_recommendation_log(from_user_id, to_user_id)
+    if not rec:
+        return
+    await update_record("recommendation_logs", rec["id"], {"accepted": True})
+
+
+# ---------- MATCH_FEEDBACK ----------
+
+async def create_match_feedback(
+    *,
+    from_user_id: str,
+    to_user_id: str,
+    booking_id: Optional[str],
+    feedback: str,
+    comment: Optional[str] = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "from_user": from_user_id,
+        "to_user": to_user_id,
+        "feedback": feedback,
+    }
+    if booking_id:
+        payload["booking_id"] = booking_id
+    if comment:
+        payload["comment"] = comment
+
+    return await create_record("match_feedback", payload)


### PR DESCRIPTION
## Summary
- fetch friend suggestions from the recommender API and show them on the add friend page
- support incremental "see more" loading in batches of five and remove the old static card content
- reuse friend relation actions with newly loaded suggestions

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303c32ec48832b9429f14880ac978b)