### PR TITLE
Improve court page UI and favorite courts support

### DIFF
--- a/lib/components/my_court.dart
+++ b/lib/components/my_court.dart
@@ -1,8 +1,10 @@
 import 'package:badminton_booking_app/models/court.dart';
-import 'package:badminton_booking_app/services/court_service.dart';
 import 'package:badminton_booking_app/pages/court/booking_page.dart';
 import 'package:badminton_booking_app/pages/court/court_detail.dart';
+import 'package:badminton_booking_app/pages/court/favorite_court_manager.dart';
+import 'package:badminton_booking_app/services/court_service.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class MyCourt extends StatefulWidget {
   const MyCourt({super.key, required this.court});
@@ -14,12 +16,11 @@ class MyCourt extends StatefulWidget {
 }
 
 class _MyCourtState extends State<MyCourt> {
-  bool _isFavorite = false;
+  Future<void> _toggleFavorite() async {
+    final favoriteManager = context.read<FavoriteCourtManager?>();
+    if (favoriteManager == null) return;
 
-  void _toggleFavorite() {
-    setState(() {
-      _isFavorite = !_isFavorite;
-    });
+    await favoriteManager.toggleFavorite(widget.court);
   }
 
   @override
@@ -27,6 +28,8 @@ class _MyCourtState extends State<MyCourt> {
     final screenWidth = MediaQuery.of(context).size.width;
     final colorSchema = Theme.of(context).colorScheme;
     final court = widget.court;
+    final isFavorite =
+        context.watch<FavoriteCourtManager?>()?.isFavorite(court.id) ?? false;
     final courtName = court.name.isNotEmpty ? court.name : 'Sân không tên';
     final location =
         court.location.isNotEmpty ? court.location : 'Địa chỉ chưa cập nhật';
@@ -78,10 +81,8 @@ class _MyCourtState extends State<MyCourt> {
                             borderRadius: BorderRadius.circular(50),
                           ),
                           child: Icon(
-                            _isFavorite
-                                ? Icons.favorite
-                                : Icons.favorite_border,
-                            color: _isFavorite ? Colors.red : Colors.black54,
+                            isFavorite ? Icons.favorite : Icons.favorite_border,
+                            color: isFavorite ? Colors.red : Colors.black54,
                             size: 28,
                           ),
                         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
+import 'package:badminton_booking_app/pages/court/favorite_court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
@@ -23,6 +24,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => AuthManager()),
         ChangeNotifierProvider(create: (_) => UserManager()),
         ChangeNotifierProvider(create: (_) => CourtManager()),
+        ChangeNotifierProvider(create: (_) => FavoriteCourtManager()),
         ChangeNotifierProvider(create: (_) => SocialManager()),
       ],
       child: const MyApp(),

--- a/lib/pages/court/court_detail.dart
+++ b/lib/pages/court/court_detail.dart
@@ -526,7 +526,8 @@ class _CourtDetailState extends State<CourtDetail>
           const SizedBox(height: 6),
           Text(
             timeLabel,
-            style: textTheme.bodySmall?.copyWith(color: cs.outline),
+            style:
+                textTheme.bodySmall?.copyWith(color: cs.onSurfaceVariant),
           ),
         ],
       ),

--- a/lib/pages/court/court_detail.dart
+++ b/lib/pages/court/court_detail.dart
@@ -1,3 +1,4 @@
+import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court.dart';
 import 'package:badminton_booking_app/models/court_detail.dart';
 import 'package:badminton_booking_app/pages/court/booking_page.dart';
@@ -6,6 +7,7 @@ import 'package:badminton_booking_app/pages/court/tabs/image_tab.dart';
 import 'package:badminton_booking_app/pages/court/tabs/review_tab.dart';
 import 'package:badminton_booking_app/pages/court/tabs/rule_tab.dart';
 import 'package:badminton_booking_app/pages/court/tabs/service_tab.dart';
+import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/services/court_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -31,12 +33,18 @@ class _CourtDetailState extends State<CourtDetail>
   bool _isLoading = false;
   String? _errorMessage;
   late final CourtService _courtService;
+  late final BookingService _bookingService;
+  bool _isAvailabilityLoading = false;
+  String? _availabilityError;
+  int? _availableCourtsNow;
+  DateTime? _availabilitySnapshotAt;
 
   @override
   void initState() {
     super.initState();
     _detailData = CourtDetailData(court: widget.court);
     _courtService = widget.courtService ?? _resolveCourtService();
+    _bookingService = BookingService();
     _loadDetail();
   }
 
@@ -69,6 +77,7 @@ class _CourtDetailState extends State<CourtDetail>
         _detailData = data;
         _isLoading = false;
       });
+      _refreshAvailability();
     } catch (error) {
       if (!mounted) return;
       setState(() {
@@ -215,9 +224,8 @@ class _CourtDetailState extends State<CourtDetail>
     final code = court.code.isNotEmpty ? court.code : 'Đang cập nhật';
     final description = court.description?.trim();
     final openingText = _buildOpeningHoursText(_detailData.openingHours);
-    final unitLabels = _detailData.units
+    final activeUnits = _detailData.units
         .where((unit) => unit.label.trim().isNotEmpty && unit.isActive)
-        .map((unit) => unit.label.trim())
         .toList(growable: false);
 
     final avatarImage = court.coverImageUrl != null &&
@@ -295,23 +303,12 @@ class _CourtDetailState extends State<CourtDetail>
                   Text(_formatCourtQuantity(court.courtQuantity)),
                 ],
               ),
-              if (unitLabels.isNotEmpty) ...[
-                const SizedBox(height: 12),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: unitLabels
-                      .map(
-                        (label) => Chip(
-                          label: Text(label),
-                          backgroundColor: cs.primary.withOpacity(0.1),
-                          side: BorderSide(color: cs.primary.withOpacity(0.4)),
-                          labelStyle: TextStyle(color: cs.primary),
-                        ),
-                      )
-                      .toList(growable: false),
-                ),
-              ],
+              const SizedBox(height: 12),
+              _buildAvailabilityStatus(
+                context,
+                cs,
+                activeUnits.length,
+              ),
               if (_isLoading) ...[
                 const SizedBox(height: 16),
                 const LinearProgressIndicator(minHeight: 3),
@@ -321,6 +318,70 @@ class _CourtDetailState extends State<CourtDetail>
         ),
       ),
     );
+  }
+
+  Future<void> _refreshAvailability() async {
+    final activeUnits = _detailData.units.where((unit) => unit.isActive).toList();
+
+    setState(() {
+      _isAvailabilityLoading = true;
+      _availabilityError = null;
+    });
+
+    if (activeUnits.isEmpty) {
+      setState(() {
+        _isAvailabilityLoading = false;
+        _availabilityError = 'Chưa có dữ liệu về số sân đang hoạt động.';
+      });
+      return;
+    }
+
+    try {
+      final now = DateTime.now();
+      final bookings = await _bookingService.listBookings(
+        courtId: widget.court.id,
+        date: now,
+      );
+
+      final nowUtc = now.toUtc();
+      final blockingUnits = <String>{};
+      for (final booking in bookings) {
+        final overlapsNow =
+            booking.startTime.isBefore(nowUtc) && booking.endTime.isAfter(nowUtc);
+        final isBlockingStatus = booking.status == BookingStatus.confirmed ||
+            booking.status == BookingStatus.awaitingPayment ||
+            booking.isActiveLock;
+
+        if (overlapsNow && isBlockingStatus) {
+          blockingUnits.add(booking.courtUnitId);
+        }
+      }
+
+      final totalActive = activeUnits.length;
+      final available = (totalActive - blockingUnits.length).clamp(0, totalActive);
+
+      if (!mounted) return;
+      setState(() {
+        _availableCourtsNow = available;
+        _availabilitySnapshotAt = DateTime.now();
+        _isAvailabilityLoading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _availabilityError = _describeAvailabilityError(error);
+        _isAvailabilityLoading = false;
+      });
+    }
+  }
+
+  String _describeAvailabilityError(Object error) {
+    if (error is BookingServiceException) {
+      return error.message;
+    }
+    final message = error.toString();
+    if (message.isNotEmpty) return message;
+    return 'Không thể kiểm tra tình trạng sân. Vui lòng thử lại.';
   }
 
   Widget _buildErrorBanner(BuildContext context, ColorScheme cs) {
@@ -361,6 +422,143 @@ class _CourtDetailState extends State<CourtDetail>
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildAvailabilityStatus(
+    BuildContext context,
+    ColorScheme cs,
+    int totalActive,
+  ) {
+    final textTheme = Theme.of(context).textTheme;
+
+    if (_isAvailabilityLoading) {
+      return _buildAvailabilityTile(
+        cs: cs,
+        icon: Icons.hourglass_top,
+        iconColor: cs.primary,
+        content: Text(
+          'Đang kiểm tra số sân trống...',
+          style: textTheme.bodyMedium,
+        ),
+        trailing: const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+
+    if (_availabilityError != null) {
+      return _buildAvailabilityTile(
+        cs: cs,
+        icon: Icons.error_outline,
+        iconColor: cs.error,
+        content: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Không thể kiểm tra tình trạng sân',
+              style: textTheme.bodyMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _availabilityError!,
+              style: textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton(
+                onPressed: _refreshAvailability,
+                child: const Text('Thử lại'),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (totalActive == 0) {
+      return _buildAvailabilityTile(
+        cs: cs,
+        icon: Icons.help_outline,
+        iconColor: cs.secondary,
+        content: Text(
+          'Chưa có dữ liệu số sân hoạt động để hiển thị tình trạng trống.',
+          style: textTheme.bodyMedium,
+        ),
+      );
+    }
+
+    final available = (_availableCourtsNow ?? totalActive).clamp(0, totalActive);
+    final snapshot = _availabilitySnapshotAt?.toLocal();
+    final timeLabel = snapshot != null
+        ? 'Cập nhật lúc ${TimeOfDay.fromDateTime(snapshot).format(context)}'
+        : 'Chưa có thời gian cập nhật';
+    final hasOpenSlots = available > 0;
+
+    final headline = hasOpenSlots
+        ? 'Còn $available/$totalActive sân trống ngay bây giờ'
+        : 'Hiện không còn sân trống ở thời điểm này';
+
+    return _buildAvailabilityTile(
+      cs: cs,
+      icon: hasOpenSlots ? Icons.event_available : Icons.event_busy,
+      iconColor: hasOpenSlots ? cs.primary : cs.error,
+      content: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            headline,
+            style:
+                textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            hasOpenSlots
+                ? 'Bạn có thể chọn ngay một sân trống để đặt lịch.'
+                : 'Vui lòng thử chọn thời gian khác hoặc quay lại sau.',
+            style: textTheme.bodySmall,
+          ),
+          const SizedBox(height: 6),
+          Text(
+            timeLabel,
+            style: textTheme.bodySmall?.copyWith(color: cs.outline),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAvailabilityTile({
+    required ColorScheme cs,
+    required IconData icon,
+    required Color iconColor,
+    required Widget content,
+    Widget? trailing,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: cs.surfaceVariant.withOpacity(0.4),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: iconColor),
+          const SizedBox(width: 10),
+          Expanded(child: content),
+          if (trailing != null) ...[
+            const SizedBox(width: 12),
+            trailing,
+          ],
+        ],
       ),
     );
   }

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -1094,20 +1094,22 @@ class _CourtPageState extends State<CourtPage> {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Row(
-                children: [
-                  Icon(icon, size: 18),
-                  const SizedBox(width: 8),
-                  Flexible(
-                    child: Text(
-                      label,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(fontWeight: FontWeight.w700),
+              Expanded(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(icon, size: 18),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        label,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontWeight: FontWeight.w700),
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
               const Icon(Icons.edit_calendar, size: 18),
             ],

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -27,44 +27,32 @@ class _CourtPageState extends State<CourtPage> {
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              Theme.of(context).colorScheme.primary.withOpacity(0.05),
-              Theme.of(context).colorScheme.surface,
-            ],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-          ),
-        ),
-        child: SafeArea(
-          child: RefreshIndicator(
-            onRefresh: () async {
-              await Future.wait([
-                context.read<CourtManager>().refresh(),
-                context.read<FavoriteCourtManager>().refresh(),
-              ]);
-            },
-            child: Builder(
-              builder: (context) {
-                if (courtManager.isLoading) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-                if (courtManager.errorMessage != null) {
-                  return _buildErrorState(context, courtManager.errorMessage!);
-                }
-                if (courtManager.courts.isEmpty) {
-                  return _buildEmptyState(context);
-                }
+      body: SafeArea(
+        child: RefreshIndicator(
+          onRefresh: () async {
+            await Future.wait([
+              context.read<CourtManager>().refresh(),
+              context.read<FavoriteCourtManager>().refresh(),
+            ]);
+          },
+          child: Builder(
+            builder: (context) {
+              if (courtManager.isLoading) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (courtManager.errorMessage != null) {
+                return _buildErrorState(context, courtManager.errorMessage!);
+              }
+              if (courtManager.courts.isEmpty) {
+                return _buildEmptyState(context);
+              }
 
-                return _buildContent(
-                  context,
-                  courtManager.courts,
-                  context.watch<FavoriteCourtManager>(),
-                );
-              },
-            ),
+              return _buildContent(
+                context,
+                courtManager.courts,
+                context.watch<FavoriteCourtManager>(),
+              );
+            },
           ),
         ),
       ),
@@ -234,8 +222,6 @@ class _CourtPageState extends State<CourtPage> {
     final filters = [
       ('Mới nhất', Icons.auto_awesome),
       ('Gần tôi', Icons.location_on_outlined),
-      ('Giá tốt', Icons.local_offer_outlined),
-      ('Phù hợp', Icons.emoji_events_outlined),
     ];
     final colorScheme = Theme.of(context).colorScheme;
 

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -181,11 +181,17 @@ class _CourtPageState extends State<CourtPage> {
         final minHeight = constraints.hasBoundedHeight
             ? constraints.maxHeight
             : MediaQuery.of(context).size.height;
+        final minWidth = constraints.hasBoundedWidth
+            ? constraints.maxWidth
+            : MediaQuery.of(context).size.width;
         return SingleChildScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
           child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: minHeight),
-            child: child,
+            constraints: BoxConstraints(minHeight: minHeight, minWidth: minWidth),
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: child,
+            ),
           ),
         );
       },

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -1,53 +1,90 @@
 import 'package:badminton_booking_app/components/my_court.dart';
 import 'package:badminton_booking_app/models/court.dart';
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
+import 'package:badminton_booking_app/pages/court/favorite_court_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class CourtPage extends StatelessWidget {
+class CourtPage extends StatefulWidget {
   CourtPage({super.key});
+
+  @override
+  State<CourtPage> createState() => _CourtPageState();
+}
+
+class _CourtPageState extends State<CourtPage> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      context.read<FavoriteCourtManager>().initialize();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final courtManager = context.watch<CourtManager>();
 
-    Widget body;
-
-    if (courtManager.isLoading) {
-      body = const Center(child: CircularProgressIndicator());
-    } else if (courtManager.errorMessage != null) {
-      body = _buildErrorState(context, courtManager.errorMessage!);
-    } else if (courtManager.courts.isEmpty) {
-      body = _buildEmptyState(context);
-    } else {
-      body = _buildContent(context, courtManager.courts);
-    }
-
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          'C O U R T',
-          style: TextStyle(
-            fontSize: 22,
-            fontWeight: FontWeight.bold,
-            color: Theme.of(context).colorScheme.onPrimary,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Theme.of(context).colorScheme.primary.withOpacity(0.05),
+              Theme.of(context).colorScheme.surface,
+            ],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
           ),
         ),
-        centerTitle: true,
+        child: SafeArea(
+          child: RefreshIndicator(
+            onRefresh: () async {
+              await Future.wait([
+                context.read<CourtManager>().refresh(),
+                context.read<FavoriteCourtManager>().refresh(),
+              ]);
+            },
+            child: Builder(
+              builder: (context) {
+                if (courtManager.isLoading) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                if (courtManager.errorMessage != null) {
+                  return _buildErrorState(context, courtManager.errorMessage!);
+                }
+                if (courtManager.courts.isEmpty) {
+                  return _buildEmptyState(context);
+                }
+
+                return _buildContent(
+                  context,
+                  courtManager.courts,
+                  context.watch<FavoriteCourtManager>(),
+                );
+              },
+            ),
+          ),
+        ),
       ),
-      backgroundColor: Theme.of(context).colorScheme.surface,
-      body: body,
     );
   }
 
-  Widget _buildContent(BuildContext context, List<Court> courts) {
+  Widget _buildContent(
+    BuildContext context,
+    List<Court> courts,
+    FavoriteCourtManager favoriteManager,
+  ) {
     final recommended = courts.take(5).toList();
     final remainingAfterRecommended = courts.skip(recommended.length).toList();
     final nearby = remainingAfterRecommended.take(5).toList();
     final popular = remainingAfterRecommended.skip(nearby.length).toList();
 
     final sections = <Widget>[
-      const SizedBox(height: 10),
+      _buildHeroHeader(context, courts.length, favoriteManager),
+      _buildFilterChips(context),
+      const SizedBox(height: 16),
       _buildCourtSection(context, 'Có Thể Bạn Sẽ Thích', recommended),
     ];
 
@@ -62,9 +99,183 @@ class CourtPage extends StatelessWidget {
     sections.add(const SizedBox(height: 100));
 
     return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: sections,
+      physics: const AlwaysScrollableScrollPhysics(),
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: sections,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeroHeader(
+    BuildContext context,
+    int courtCount,
+    FavoriteCourtManager favoriteManager,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 6),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              colorScheme.primary.withOpacity(0.9),
+              colorScheme.primary.withOpacity(0.7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(22),
+          boxShadow: [
+            BoxShadow(
+              color: colorScheme.primary.withOpacity(0.25),
+              blurRadius: 18,
+              offset: const Offset(0, 8),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'COURT',
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      letterSpacing: 2,
+                      color: colorScheme.onPrimary.withOpacity(0.9),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Khám phá & đặt sân ngay',
+                    style: TextStyle(
+                      color: colorScheme.onPrimary,
+                      fontSize: 22,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      _buildStatPill(
+                        context,
+                        icon: Icons.sports_tennis,
+                        label: '$courtCount sân khả dụng',
+                      ),
+                      const SizedBox(width: 8),
+                      _buildStatPill(
+                        context,
+                        icon: Icons.favorite,
+                        label:
+                            '${favoriteManager.favoriteCourtIds.length} yêu thích',
+                      ),
+                    ],
+                  )
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Container(
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.16),
+                borderRadius: BorderRadius.circular(16),
+              ),
+              padding: const EdgeInsets.all(12),
+              child: const Icon(
+                Icons.flash_on,
+                size: 30,
+                color: Colors.white,
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatPill(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: colorScheme.onPrimary.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(30),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: colorScheme.onPrimary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              color: colorScheme.onPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterChips(BuildContext context) {
+    final filters = [
+      ('Mới nhất', Icons.auto_awesome),
+      ('Gần tôi', Icons.location_on_outlined),
+      ('Giá tốt', Icons.local_offer_outlined),
+      ('Phù hợp', Icons.emoji_events_outlined),
+    ];
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return SizedBox(
+      height: 42,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        itemBuilder: (_, index) {
+          final (label, icon) = filters[index];
+          return Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              color: colorScheme.surface,
+              borderRadius: BorderRadius.circular(24),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.05),
+                  blurRadius: 12,
+                  offset: const Offset(0, 6),
+                ),
+              ],
+            ),
+            child: Row(
+              children: [
+                Icon(icon, size: 18, color: colorScheme.primary),
+                const SizedBox(width: 8),
+                Text(
+                  label,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                  ),
+                )
+              ],
+            ),
+          );
+        },
+        separatorBuilder: (_, __) => const SizedBox(width: 10),
+        itemCount: filters.length,
       ),
     );
   }

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -712,7 +712,8 @@ class _CourtPageState extends State<CourtPage> {
               booking.endTime.isAfter(startUtc);
         }).toList();
 
-        final utilization = units == 0 ? 0 : overlapping.length / units;
+        final double utilization =
+            units == 0 ? 0.0 : overlapping.length / units;
         nextSnapshots[court.id] = _CourtAvailabilitySnapshot(
           activeUnits: units,
           overlappingBookings: overlapping.length,

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -137,7 +137,7 @@ class _CourtPageState extends State<CourtPage> {
     final sections = <Widget>[
       _buildHeroHeader(context, filteredCourts.length, favoriteManager),
       _buildFilterChips(context, favoriteManager),
-      _buildAdvancedFilters(context),
+      _buildAdvancedFilterLauncher(context),
       if (_needsOpeningHoursData || _needsAvailabilityData)
         _buildFilterStatus(context),
       const SizedBox(height: 16),
@@ -440,7 +440,81 @@ class _CourtPageState extends State<CourtPage> {
     );
   }
 
-  Widget _buildAdvancedFilters(BuildContext context) {
+  Widget _buildAdvancedFilterLauncher(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Bộ lọc nâng cao',
+            style: Theme.of(context)
+                .textTheme
+                .titleMedium
+                ?.copyWith(fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            icon: Icon(Icons.tune, color: colorScheme.primary),
+            style: OutlinedButton.styleFrom(
+              alignment: Alignment.centerLeft,
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              backgroundColor: colorScheme.surfaceVariant,
+              side: BorderSide(color: colorScheme.outlineVariant),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+            ),
+            label: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: const [
+                Text(
+                  'Mở bộ lọc',
+                  style: TextStyle(fontWeight: FontWeight.w800),
+                ),
+                SizedBox(height: 2),
+                Text(
+                  'Số sân, giờ mở cửa, slot trống',
+                  style: TextStyle(fontSize: 12),
+                )
+              ],
+            ),
+            onPressed: () => _openAdvancedFiltersBottomSheet(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openAdvancedFiltersBottomSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: DraggableScrollableSheet(
+            expand: false,
+            initialChildSize: 0.85,
+            minChildSize: 0.45,
+            maxChildSize: 0.95,
+            builder: (context, scrollController) {
+              return SingleChildScrollView(
+                controller: scrollController,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                child: _buildAdvancedFiltersContent(context),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildAdvancedFiltersContent(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Padding(

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -178,10 +178,13 @@ class _CourtPageState extends State<CourtPage> {
   Widget _wrapScrollable(Widget child) {
     return LayoutBuilder(
       builder: (context, constraints) {
+        final minHeight = constraints.hasBoundedHeight
+            ? constraints.maxHeight
+            : MediaQuery.of(context).size.height;
         return SingleChildScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
           child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            constraints: BoxConstraints(minHeight: minHeight),
             child: child,
           ),
         );

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -14,6 +14,16 @@ enum _AvailabilityFilter { openSlot, nearlyFull }
 
 enum _OpeningDayPart { morning, afternoon, evening }
 
+class TimeOfDayRange {
+  final TimeOfDay start;
+  final TimeOfDay end;
+
+  const TimeOfDayRange({
+    required this.start,
+    required this.end,
+  });
+}
+
 class CourtPage extends StatefulWidget {
   CourtPage({super.key});
 

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -164,9 +164,8 @@ class _CourtPageState extends State<CourtPage> {
 
     sections.add(const SizedBox(height: 100));
 
-    return SingleChildScrollView(
-      physics: const AlwaysScrollableScrollPhysics(),
-      child: Padding(
+    return _wrapScrollable(
+      Padding(
         padding: const EdgeInsets.only(bottom: 16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -80,13 +80,17 @@ class _CourtPageState extends State<CourtPage> {
           child: Builder(
             builder: (context) {
               if (courtManager.isLoading) {
-                return const Center(child: CircularProgressIndicator());
+                return _wrapScrollable(
+                  const Center(child: CircularProgressIndicator()),
+                );
               }
               if (courtManager.errorMessage != null) {
-                return _buildErrorState(context, courtManager.errorMessage!);
+                return _wrapScrollable(
+                  _buildErrorState(context, courtManager.errorMessage!),
+                );
               }
               if (courtManager.courts.isEmpty) {
-                return _buildEmptyState(context);
+                return _wrapScrollable(_buildEmptyState(context));
               }
 
               return _buildContent(
@@ -107,17 +111,19 @@ class _CourtPageState extends State<CourtPage> {
     FavoriteCourtManager favoriteManager,
   ) {
     if (_selectedFilter == CourtFilter.favorites && favoriteManager.isLoading) {
-      return Column(
-        children: [
-          _buildHeroHeader(
-            context,
-            favoriteManager.favoriteCourtIds.length,
-            favoriteManager,
-          ),
-          _buildFilterChips(context, favoriteManager),
-          const SizedBox(height: 32),
-          const Center(child: CircularProgressIndicator()),
-        ],
+      return _wrapScrollable(
+        Column(
+          children: [
+            _buildHeroHeader(
+              context,
+              favoriteManager.favoriteCourtIds.length,
+              favoriteManager,
+            ),
+            _buildFilterChips(context, favoriteManager),
+            const SizedBox(height: 32),
+            const Center(child: CircularProgressIndicator()),
+          ],
+        ),
       );
     }
 
@@ -167,6 +173,20 @@ class _CourtPageState extends State<CourtPage> {
           children: sections,
         ),
       ),
+    );
+  }
+
+  Widget _wrapScrollable(Widget child) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: child,
+          ),
+        );
+      },
     );
   }
 

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -5,7 +5,7 @@ import 'package:badminton_booking_app/pages/court/favorite_court_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-enum CourtFilter { newest, nearby, favorites }
+enum CourtFilter { newest, favorites }
 
 class CourtPage extends StatefulWidget {
   CourtPage({super.key});
@@ -255,7 +255,6 @@ class _CourtPageState extends State<CourtPage> {
   ) {
     final filters = [
       (CourtFilter.newest, 'Mới nhất', Icons.auto_awesome),
-      (CourtFilter.nearby, 'Gần tôi', Icons.location_on_outlined),
       (CourtFilter.favorites, 'Yêu thích', Icons.favorite),
     ];
     final colorScheme = Theme.of(context).colorScheme;
@@ -497,8 +496,6 @@ class _CourtPageState extends State<CourtPage> {
           return bDate.compareTo(aDate);
         });
         return sorted;
-      case CourtFilter.nearby:
-        return courts;
     }
   }
 }

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -5,6 +5,8 @@ import 'package:badminton_booking_app/pages/court/favorite_court_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+enum CourtFilter { newest, nearby, favorites }
+
 class CourtPage extends StatefulWidget {
   CourtPage({super.key});
 
@@ -13,6 +15,8 @@ class CourtPage extends StatefulWidget {
 }
 
 class _CourtPageState extends State<CourtPage> {
+  var _selectedFilter = CourtFilter.newest;
+
   @override
   void initState() {
     super.initState();
@@ -64,14 +68,31 @@ class _CourtPageState extends State<CourtPage> {
     List<Court> courts,
     FavoriteCourtManager favoriteManager,
   ) {
-    final recommended = courts.take(5).toList();
-    final remainingAfterRecommended = courts.skip(recommended.length).toList();
+    if (_selectedFilter == CourtFilter.favorites && favoriteManager.isLoading) {
+      return Column(
+        children: [
+          _buildHeroHeader(
+            context,
+            favoriteManager.favoriteCourtIds.length,
+            favoriteManager,
+          ),
+          _buildFilterChips(context, favoriteManager),
+          const SizedBox(height: 32),
+          const Center(child: CircularProgressIndicator()),
+        ],
+      );
+    }
+
+    final filteredCourts = _applyFilter(courts, favoriteManager);
+    final recommended = filteredCourts.take(5).toList();
+    final remainingAfterRecommended =
+        filteredCourts.skip(recommended.length).toList();
     final nearby = remainingAfterRecommended.take(5).toList();
     final popular = remainingAfterRecommended.skip(nearby.length).toList();
 
     final sections = <Widget>[
-      _buildHeroHeader(context, courts.length, favoriteManager),
-      _buildFilterChips(context),
+      _buildHeroHeader(context, filteredCourts.length, favoriteManager),
+      _buildFilterChips(context, favoriteManager),
       const SizedBox(height: 16),
       _buildCourtSection(context, 'Có Thể Bạn Sẽ Thích', recommended),
     ];
@@ -82,6 +103,16 @@ class _CourtPageState extends State<CourtPage> {
 
     if (popular.isNotEmpty) {
       sections.add(_buildCourtSection(context, 'Sân Phổ Biến', popular));
+    }
+
+    if (_selectedFilter == CourtFilter.favorites && filteredCourts.isEmpty) {
+      sections
+        ..clear()
+        ..addAll([
+          _buildHeroHeader(context, filteredCourts.length, favoriteManager),
+          _buildFilterChips(context, favoriteManager),
+          _buildEmptyFavoriteState(context),
+        ]);
     }
 
     sections.add(const SizedBox(height: 100));
@@ -218,10 +249,14 @@ class _CourtPageState extends State<CourtPage> {
     );
   }
 
-  Widget _buildFilterChips(BuildContext context) {
+  Widget _buildFilterChips(
+    BuildContext context,
+    FavoriteCourtManager favoriteManager,
+  ) {
     final filters = [
-      ('Mới nhất', Icons.auto_awesome),
-      ('Gần tôi', Icons.location_on_outlined),
+      (CourtFilter.newest, 'Mới nhất', Icons.auto_awesome),
+      (CourtFilter.nearby, 'Gần tôi', Icons.location_on_outlined),
+      (CourtFilter.favorites, 'Yêu thích', Icons.favorite),
     ];
     final colorScheme = Theme.of(context).colorScheme;
 
@@ -231,11 +266,13 @@ class _CourtPageState extends State<CourtPage> {
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.symmetric(horizontal: 16),
         itemBuilder: (_, index) {
-          final (label, icon) = filters[index];
+          final (filter, label, icon) = filters[index];
+          final isSelected = _selectedFilter == filter;
           return Container(
             padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
             decoration: BoxDecoration(
-              color: colorScheme.surface,
+              color:
+                  isSelected ? colorScheme.primaryContainer : colorScheme.surface,
               borderRadius: BorderRadius.circular(24),
               boxShadow: [
                 BoxShadow(
@@ -245,18 +282,42 @@ class _CourtPageState extends State<CourtPage> {
                 ),
               ],
             ),
-            child: Row(
-              children: [
-                Icon(icon, size: 18, color: colorScheme.primary),
-                const SizedBox(width: 8),
-                Text(
-                  label,
-                  style: const TextStyle(
-                    fontWeight: FontWeight.w700,
-                    fontSize: 14,
+            child: InkWell(
+              onTap: () {
+                setState(() {
+                  _selectedFilter = filter;
+                });
+              },
+              borderRadius: BorderRadius.circular(24),
+              child: Row(
+                children: [
+                  Icon(
+                    icon,
+                    size: 18,
+                    color: isSelected
+                        ? colorScheme.onPrimaryContainer
+                        : colorScheme.primary,
                   ),
-                )
-              ],
+                  const SizedBox(width: 8),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 14,
+                      color: isSelected
+                          ? colorScheme.onPrimaryContainer
+                          : null,
+                    ),
+                  ),
+                  if (filter == CourtFilter.favorites) ...[
+                    const SizedBox(width: 6),
+                    _buildFavoriteBadge(
+                      colorScheme,
+                      favoriteManager.favoriteCourtIds.length,
+                    ),
+                  ]
+                ],
+              ),
             ),
           );
         },
@@ -369,5 +430,75 @@ class _CourtPageState extends State<CourtPage> {
         ),
       ),
     );
+  }
+
+  Widget _buildEmptyFavoriteState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.favorite_border,
+              size: 48,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Chưa có sân yêu thích',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Hãy thêm sân bạn thích để xem nhanh tại đây!',
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFavoriteBadge(ColorScheme colorScheme, int count) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: colorScheme.primary,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        '$count',
+        style: TextStyle(
+          color: colorScheme.onPrimary,
+          fontWeight: FontWeight.w800,
+          fontSize: 12,
+        ),
+      ),
+    );
+  }
+
+  List<Court> _applyFilter(
+    List<Court> courts,
+    FavoriteCourtManager favoriteManager,
+  ) {
+    switch (_selectedFilter) {
+      case CourtFilter.favorites:
+        final favoriteIds = favoriteManager.favoriteCourtIds;
+        return courts
+            .where((court) => favoriteIds.contains(court.id))
+            .toList(growable: false);
+      case CourtFilter.newest:
+        final sorted = [...courts];
+        sorted.sort((a, b) {
+          final aDate = a.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+          final bDate = b.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+          return bDate.compareTo(aDate);
+        });
+        return sorted;
+      case CourtFilter.nearby:
+        return courts;
+    }
   }
 }

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -1,11 +1,18 @@
 import 'package:badminton_booking_app/components/my_court.dart';
+import 'package:badminton_booking_app/models/booking.dart';
 import 'package:badminton_booking_app/models/court.dart';
+import 'package:badminton_booking_app/models/court_detail.dart';
 import 'package:badminton_booking_app/pages/court/court_manager.dart';
 import 'package:badminton_booking_app/pages/court/favorite_court_manager.dart';
+import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 enum CourtFilter { newest, favorites }
+
+enum _AvailabilityFilter { openSlot, nearlyFull }
+
+enum _OpeningDayPart { morning, afternoon, evening }
 
 class CourtPage extends StatefulWidget {
   CourtPage({super.key});
@@ -16,6 +23,23 @@ class CourtPage extends StatefulWidget {
 
 class _CourtPageState extends State<CourtPage> {
   var _selectedFilter = CourtFilter.newest;
+  var _minCourtQuantity = 0.0;
+  int? _quantityQuickUpperBound;
+  bool _openNowOnly = false;
+  _OpeningDayPart? _dayPartFilter;
+  TimeOfDayRange? _desiredPlayRange;
+
+  DateTime? _selectedDate;
+  TimeOfDayRange? _selectedSlotRange;
+  _AvailabilityFilter? _availabilityFilter;
+
+  final Map<String, _CourtFilterMeta> _courtMetadata = {};
+  bool _isMetadataLoading = false;
+  String? _metadataError;
+
+  final Map<String, _CourtAvailabilitySnapshot> _availabilityByCourt = {};
+  bool _isAvailabilityLoading = false;
+  String? _availabilityError;
 
   @override
   void initState() {
@@ -38,6 +62,10 @@ class _CourtPageState extends State<CourtPage> {
               context.read<CourtManager>().refresh(),
               context.read<FavoriteCourtManager>().refresh(),
             ]);
+            setState(() {
+              _courtMetadata.clear();
+              _availabilityByCourt.clear();
+            });
           },
           child: Builder(
             builder: (context) {
@@ -93,6 +121,9 @@ class _CourtPageState extends State<CourtPage> {
     final sections = <Widget>[
       _buildHeroHeader(context, filteredCourts.length, favoriteManager),
       _buildFilterChips(context, favoriteManager),
+      _buildAdvancedFilters(context),
+      if (_needsOpeningHoursData || _needsAvailabilityData)
+        _buildFilterStatus(context),
       const SizedBox(height: 16),
       _buildCourtSection(context, 'Có Thể Bạn Sẽ Thích', recommended),
     ];
@@ -371,6 +402,123 @@ class _CourtPageState extends State<CourtPage> {
     );
   }
 
+  Widget _buildAdvancedFilters(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.filter_alt, size: 18, color: colorScheme.primary),
+              const SizedBox(width: 8),
+              Text(
+                'Bộ lọc nâng cao',
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(fontWeight: FontWeight.w800),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildQuantityFilterChip('1–3 sân', () {
+                _handleFilterChanged(() {
+                  _minCourtQuantity = 1;
+                  _quantityQuickUpperBound = 3;
+                });
+              },
+                  isSelected:
+                      _minCourtQuantity == 1 && _quantityQuickUpperBound == 3),
+              _buildQuantityFilterChip('4–6 sân', () {
+                _handleFilterChanged(() {
+                  _minCourtQuantity = 4;
+                  _quantityQuickUpperBound = 6;
+                });
+              },
+                  isSelected:
+                      _minCourtQuantity == 4 && _quantityQuickUpperBound == 6),
+              _buildQuantityFilterChip('≥ 7 sân', () {
+                _handleFilterChanged(() {
+                  _minCourtQuantity = 7;
+                  _quantityQuickUpperBound = null;
+                });
+              },
+                  isSelected:
+                      _minCourtQuantity == 7 && _quantityQuickUpperBound == null),
+              _buildToggleChip(
+                context,
+                label: 'Đang mở cửa',
+                icon: Icons.access_time,
+                value: _openNowOnly,
+                onChanged: (value) => _handleFilterChanged(() {
+                  _openNowOnly = value;
+                }),
+              ),
+              _buildToggleChip(
+                context,
+                label: 'Sáng',
+                icon: Icons.wb_sunny_outlined,
+                value: _dayPartFilter == _OpeningDayPart.morning,
+                onChanged: (value) => _handleFilterChanged(() {
+                  _dayPartFilter = value ? _OpeningDayPart.morning : null;
+                }),
+              ),
+              _buildToggleChip(
+                context,
+                label: 'Chiều',
+                icon: Icons.wb_twilight,
+                value: _dayPartFilter == _OpeningDayPart.afternoon,
+                onChanged: (value) => _handleFilterChanged(() {
+                  _dayPartFilter = value ? _OpeningDayPart.afternoon : null;
+                }),
+              ),
+              _buildToggleChip(
+                context,
+                label: 'Tối',
+                icon: Icons.nightlight_outlined,
+                value: _dayPartFilter == _OpeningDayPart.evening,
+                onChanged: (value) => _handleFilterChanged(() {
+                  _dayPartFilter = value ? _OpeningDayPart.evening : null;
+                }),
+              ),
+              _buildToggleChip(
+                context,
+                label: 'Còn trống',
+                icon: Icons.event_available,
+                value: _availabilityFilter == _AvailabilityFilter.openSlot,
+                onChanged: (value) => _handleFilterChanged(() {
+                  _availabilityFilter =
+                      value ? _AvailabilityFilter.openSlot : null;
+                }),
+              ),
+              _buildToggleChip(
+                context,
+                label: 'Gần full',
+                icon: Icons.speed,
+                value: _availabilityFilter == _AvailabilityFilter.nearlyFull,
+                onChanged: (value) => _handleFilterChanged(() {
+                  _availabilityFilter =
+                      value ? _AvailabilityFilter.nearlyFull : null;
+                }),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _buildSliderCard(context),
+          const SizedBox(height: 8),
+          _buildTimePickers(context),
+        ],
+      ),
+    );
+  }
+
   Widget _buildErrorState(BuildContext context, String errorMessage) {
     return Center(
       child: Padding(
@@ -478,24 +626,565 @@ class _CourtPageState extends State<CourtPage> {
     );
   }
 
+  bool get _needsOpeningHoursData =>
+      _openNowOnly || _dayPartFilter != null || _desiredPlayRange != null;
+
+  bool get _needsAvailabilityData =>
+      _availabilityFilter != null &&
+      _selectedDate != null &&
+      _selectedSlotRange != null;
+
+  void _kickOffMetadataLoad(List<Court> courts) async {
+    if (!_needsOpeningHoursData && !_needsAvailabilityData) return;
+    final missing = courts
+        .where((court) => !_courtMetadata.containsKey(court.id))
+        .toList();
+    if (missing.isEmpty) return;
+
+    setState(() {
+      _isMetadataLoading = true;
+      _metadataError = null;
+    });
+
+    try {
+      final service = context.read<CourtManager>().courtService;
+      for (final court in missing) {
+        final detail = await service.getCourtDetail(court.id);
+        _courtMetadata[court.id] = _CourtFilterMeta(
+          openingHours: detail.openingHours,
+          units: detail.units,
+        );
+      }
+    } catch (error) {
+      setState(() {
+        _metadataError = error.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isMetadataLoading = false;
+        });
+      }
+    }
+  }
+
+  void _refreshAvailabilityIfNeeded(List<Court> courts) async {
+    if (!_needsAvailabilityData) return;
+    setState(() {
+      _isAvailabilityLoading = true;
+      _availabilityError = null;
+    });
+
+    final bookingService = BookingService();
+    final targetDate = _selectedDate!;
+    final targetRange = _selectedSlotRange!;
+    final nextSnapshots = <String, _CourtAvailabilitySnapshot>{};
+
+    try {
+      for (final court in courts) {
+        final units = _courtMetadata[court.id]?.activeUnits ?? court.courtQuantity;
+        if (units <= 0) continue;
+
+        final bookings = await bookingService.listBookings(
+          courtId: court.id,
+          date: targetDate,
+        );
+
+        final startUtc = _combine(targetDate, targetRange.start).toUtc();
+        final endUtc = _combine(targetDate, targetRange.end).toUtc();
+
+        final overlapping = bookings.where((booking) {
+          if (booking.status == BookingStatus.cancelled ||
+              booking.status == BookingStatus.expired) {
+            return false;
+          }
+          return booking.startTime.isBefore(endUtc) &&
+              booking.endTime.isAfter(startUtc);
+        }).toList();
+
+        final utilization = units == 0 ? 0 : overlapping.length / units;
+        nextSnapshots[court.id] = _CourtAvailabilitySnapshot(
+          activeUnits: units,
+          overlappingBookings: overlapping.length,
+          utilization: utilization,
+        );
+      }
+
+      if (mounted) {
+        setState(() {
+          _availabilityByCourt
+            ..clear()
+            ..addAll(nextSnapshots);
+        });
+      }
+    } catch (error) {
+      setState(() {
+        _availabilityError = error.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isAvailabilityLoading = false;
+        });
+      }
+    }
+  }
+
+  DateTime _combine(DateTime date, TimeOfDay time) {
+    return DateTime(date.year, date.month, date.day, time.hour, time.minute);
+  }
+
+  bool _matchesQuantityFilter(Court court) {
+    final quantity = court.courtQuantity;
+    if (quantity < _minCourtQuantity) return false;
+    if (_quantityQuickUpperBound != null &&
+        quantity > _quantityQuickUpperBound!) {
+      return false;
+    }
+    return true;
+  }
+
+  bool _matchesOpeningFilter(String courtId) {
+    if (!_needsOpeningHoursData) return true;
+    final meta = _courtMetadata[courtId];
+    if (meta == null || meta.openingHours.isEmpty) {
+      return _isMetadataLoading ? true : !_openNowOnly;
+    }
+
+    final now = TimeOfDay.fromDateTime(DateTime.now());
+    final desiredRange = _desiredPlayRange;
+
+    for (final opening in meta.openingHours) {
+      final openTime = _parseTime(opening.openTime);
+      final closeTime = _parseTime(opening.closeTime);
+      if (openTime == null || closeTime == null) continue;
+
+      if (_openNowOnly && !_isWithinRange(openTime, closeTime, now, now)) {
+        continue;
+      }
+
+      if (_dayPartFilter != null &&
+          !_matchesDayPart(openTime, closeTime, _dayPartFilter!)) {
+        continue;
+      }
+
+      if (desiredRange != null &&
+          !_isWithinRange(openTime, closeTime, desiredRange.start, desiredRange.end)) {
+        continue;
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  bool _matchesAvailabilityFilter(String courtId) {
+    if (!_needsAvailabilityData) return true;
+    final snapshot = _availabilityByCourt[courtId];
+    if (snapshot == null) {
+      if (_isAvailabilityLoading) return true;
+      return false;
+    }
+
+    switch (_availabilityFilter) {
+      case _AvailabilityFilter.openSlot:
+        return snapshot.overlappingBookings < snapshot.activeUnits;
+      case _AvailabilityFilter.nearlyFull:
+        return snapshot.utilization >= 0.7 && snapshot.utilization <= 0.9;
+      case null:
+        return true;
+    }
+  }
+
+  bool _matchesDayPart(int openMinutes, int closeMinutes, _OpeningDayPart part) {
+    const morningStart = 5 * 60;
+    const morningEnd = 12 * 60;
+    const afternoonStart = morningEnd;
+    const afternoonEnd = 17 * 60;
+    const eveningEnd = 23 * 60;
+    switch (part) {
+      case _OpeningDayPart.morning:
+        return openMinutes <= morningStart && closeMinutes >= morningEnd;
+      case _OpeningDayPart.afternoon:
+        return openMinutes <= afternoonStart && closeMinutes >= afternoonEnd;
+      case _OpeningDayPart.evening:
+        return openMinutes <= afternoonEnd && closeMinutes >= eveningEnd;
+    }
+  }
+
+  bool _isWithinRange(
+    int openMinutes,
+    int closeMinutes,
+    TimeOfDay start,
+    TimeOfDay end,
+  ) {
+    final startMinutes = start.hour * 60 + start.minute;
+    final endMinutes = end.hour * 60 + end.minute;
+    return openMinutes <= startMinutes && closeMinutes >= endMinutes;
+  }
+
+  int? _parseTime(String value) {
+    final parts = value.split(':');
+    if (parts.length != 2) return null;
+    final hour = int.tryParse(parts[0]);
+    final minute = int.tryParse(parts[1]);
+    if (hour == null || minute == null) return null;
+    return hour * 60 + minute;
+  }
+
+  String get _slotRangeLabel {
+    if (_selectedSlotRange == null) return 'Chọn giờ';
+    return '${_selectedSlotRange!.start.format(context)} – ${_selectedSlotRange!.end.format(context)}';
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}';
+  }
+
+  Future<TimeOfDayRange?> _pickTimeRange(
+    BuildContext context,
+    TimeOfDayRange? initial,
+  ) async {
+    final now = TimeOfDay.now();
+    final first = await showTimePicker(
+      context: context,
+      initialTime: initial?.start ?? now,
+    );
+    if (first == null) return null;
+    final second = await showTimePicker(
+      context: context,
+      initialTime: initial?.end ?? first.replacing(hour: (first.hour + 2) % 24),
+    );
+    if (second == null) return null;
+    return TimeOfDayRange(start: first, end: second);
+  }
+
+  void _handleFilterChanged(VoidCallback updater) {
+    setState(updater);
+    final courts = context.read<CourtManager>().courts;
+    _kickOffMetadataLoad(courts);
+    _refreshAvailabilityIfNeeded(courts);
+  }
+
+  Widget _buildQuantityFilterChip(
+    String label,
+    VoidCallback onPressed, {
+    required bool isSelected,
+  }) {
+    return ChoiceChip(
+      label: Text(label),
+      selected: isSelected,
+      onSelected: (_) => onPressed(),
+      selectedColor: Theme.of(context).colorScheme.primaryContainer,
+      labelStyle: TextStyle(
+        fontWeight: FontWeight.w700,
+        color: isSelected
+            ? Theme.of(context).colorScheme.onPrimaryContainer
+            : null,
+      ),
+    );
+  }
+
+  Widget _buildToggleChip(
+    BuildContext context, {
+    required String label,
+    required IconData icon,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return FilterChip(
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: value ? colorScheme.onPrimary : null),
+          const SizedBox(width: 6),
+          Text(label),
+        ],
+      ),
+      selected: value,
+      onSelected: onChanged,
+      backgroundColor: colorScheme.surfaceVariant,
+      selectedColor: colorScheme.primary,
+      checkmarkColor: colorScheme.onPrimary,
+      labelStyle: TextStyle(
+        color: value ? colorScheme.onPrimary : null,
+        fontWeight: FontWeight.w700,
+      ),
+    );
+  }
+
+  Widget _buildSliderCard(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.stacked_line_chart, size: 18),
+                  const SizedBox(width: 6),
+                  const Text(
+                    'Số sân tối thiểu',
+                    style: TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                ],
+              ),
+              Text(
+                _minCourtQuantity.floor().toString(),
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+          Slider(
+            value: _minCourtQuantity.clamp(0, 12),
+            min: 0,
+            max: 12,
+            divisions: 12,
+            label: _minCourtQuantity.toStringAsFixed(0),
+            onChanged: (value) {
+              _handleFilterChanged(() {
+                _minCourtQuantity = value;
+                _quantityQuickUpperBound = null;
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimePickers(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Khung giờ bạn muốn chơi',
+            style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w800)),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: _buildFilledButton(
+                context,
+                icon: Icons.calendar_today,
+                label: _selectedDate == null
+                    ? 'Chọn ngày'
+                    : _formatDate(_selectedDate!),
+                onTap: () async {
+                  final now = DateTime.now();
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: _selectedDate ?? now,
+                    firstDate: now,
+                    lastDate: now.add(const Duration(days: 90)),
+                  );
+                  if (picked != null) {
+                    _handleFilterChanged(() {
+                      _selectedDate = picked;
+                    });
+                  }
+                },
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _buildFilledButton(
+                context,
+                icon: Icons.schedule,
+                label: _slotRangeLabel,
+                onTap: () async {
+                  final range = await _pickTimeRange(context, _selectedSlotRange);
+                  if (range != null) {
+                    _handleFilterChanged(() {
+                      _selectedSlotRange = range;
+                      _desiredPlayRange ??= range;
+                    });
+                  }
+                },
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Text('Giờ mở cửa mong muốn',
+            style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w800)),
+        const SizedBox(height: 8),
+        _buildFilledButton(
+          context,
+          icon: Icons.timelapse,
+          label: _desiredPlayRange == null
+              ? 'Chọn khung giờ'
+              : '${_desiredPlayRange!.start.format(context)} – ${_desiredPlayRange!.end.format(context)}',
+          onTap: () async {
+            final range = await _pickTimeRange(context, _desiredPlayRange);
+            if (range != null) {
+              _handleFilterChanged(() {
+                _desiredPlayRange = range;
+              });
+            }
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFilledButton(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      color: colorScheme.surfaceVariant,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  Icon(icon, size: 18),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      label,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                ],
+              ),
+              const Icon(Icons.edit_calendar, size: 18),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilterStatus(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isLoading =
+        (_needsOpeningHoursData && _isMetadataLoading) || _isAvailabilityLoading;
+    final error = _metadataError ?? _availabilityError;
+
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            isLoading ? Icons.downloading : Icons.info_outline,
+            color: isLoading ? colorScheme.primary : colorScheme.onSurface,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  isLoading
+                      ? 'Đang tải dữ liệu mở cửa & slot trống...'
+                      : 'Bộ lọc thời gian & slot đã sẵn sàng',
+                  style: const TextStyle(fontWeight: FontWeight.w800),
+                ),
+                if (error != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    error,
+                    style: TextStyle(color: colorScheme.error),
+                  ),
+                ]
+              ],
+            ),
+          ),
+          if (isLoading) const SizedBox(width: 8),
+          if (isLoading) const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2)),
+          if (error != null)
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: () {
+                final courts = context.read<CourtManager>().courts;
+                _kickOffMetadataLoad(courts);
+                _refreshAvailabilityIfNeeded(courts);
+              },
+            ),
+        ],
+      ),
+    );
+  }
+
   List<Court> _applyFilter(
     List<Court> courts,
     FavoriteCourtManager favoriteManager,
   ) {
+    List<Court> base;
     switch (_selectedFilter) {
       case CourtFilter.favorites:
         final favoriteIds = favoriteManager.favoriteCourtIds;
-        return courts
+        base = courts
             .where((court) => favoriteIds.contains(court.id))
             .toList(growable: false);
+        break;
       case CourtFilter.newest:
-        final sorted = [...courts];
-        sorted.sort((a, b) {
+        base = [...courts];
+        base.sort((a, b) {
           final aDate = a.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0);
           final bDate = b.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0);
           return bDate.compareTo(aDate);
         });
-        return sorted;
+        break;
     }
+
+    return base
+        .where(_matchesQuantityFilter)
+        .where((court) => _matchesOpeningFilter(court.id))
+        .where((court) => _matchesAvailabilityFilter(court.id))
+        .toList(growable: false);
   }
+}
+
+class _CourtFilterMeta {
+  _CourtFilterMeta({
+    this.openingHours = const [],
+    this.units = const [],
+  });
+
+  final List<CourtOpeningHour> openingHours;
+  final List<CourtUnit> units;
+
+  int get activeUnits => units.where((unit) => unit.isActive).length;
+}
+
+class _CourtAvailabilitySnapshot {
+  _CourtAvailabilitySnapshot({
+    required this.activeUnits,
+    required this.overlappingBookings,
+    required this.utilization,
+  });
+
+  final int activeUnits;
+  final int overlappingBookings;
+  final double utilization;
 }

--- a/lib/pages/court/favorite_court_manager.dart
+++ b/lib/pages/court/favorite_court_manager.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/foundation.dart';
+
+import '../../models/court.dart';
+import '../../services/favorite_court_service.dart';
+import '../../services/user_service.dart';
+
+class FavoriteCourtManager with ChangeNotifier {
+  FavoriteCourtManager({
+    FavoriteCourtService? favoriteCourtService,
+    UserDetailsService? userDetailsService,
+  })  : _favoriteService = favoriteCourtService ?? FavoriteCourtService(),
+        _userDetailsService = userDetailsService ?? UserDetailsService();
+
+  final FavoriteCourtService _favoriteService;
+  final UserDetailsService _userDetailsService;
+
+  bool _isLoading = false;
+  Set<String> _favoriteCourtIds = <String>{};
+  String? _userId;
+
+  bool get isLoading => _isLoading;
+  Set<String> get favoriteCourtIds => Set.unmodifiable(_favoriteCourtIds);
+
+  bool isFavorite(String courtId) => _favoriteCourtIds.contains(courtId);
+
+  Future<void> initialize() async {
+    if (_userId != null || _isLoading) return;
+
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      _userId = await _userDetailsService.getCurrentUserId();
+      if (_userId == null) {
+        _favoriteCourtIds = <String>{};
+        return;
+      }
+
+      _favoriteCourtIds = await _favoriteService.getFavoriteCourtIds(_userId!);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refresh() async {
+    _userId = await _userDetailsService.getCurrentUserId();
+    if (_userId == null) {
+      _favoriteCourtIds = <String>{};
+      notifyListeners();
+      return;
+    }
+
+    _favoriteCourtIds = await _favoriteService.getFavoriteCourtIds(_userId!);
+    notifyListeners();
+  }
+
+  Future<void> toggleFavorite(Court court) async {
+    final userId = _userId ?? await _userDetailsService.getCurrentUserId();
+    if (userId == null) return;
+
+    final isCurrentlyFavorite = _favoriteCourtIds.contains(court.id);
+    _favoriteCourtIds = Set<String>.from(_favoriteCourtIds)
+      ..toggle(court.id, isCurrentlyFavorite);
+    notifyListeners();
+
+    try {
+      if (isCurrentlyFavorite) {
+        await _favoriteService.removeFavorite(userId, court.id);
+      } else {
+        await _favoriteService.addFavorite(userId, court);
+      }
+    } catch (_) {
+      // revert on failure
+      _favoriteCourtIds = Set<String>.from(_favoriteCourtIds)
+        ..toggle(court.id, !isCurrentlyFavorite);
+      notifyListeners();
+      rethrow;
+    }
+  }
+}
+
+extension on Set<String> {
+  void toggle(String courtId, bool isFavorite) {
+    if (isFavorite) {
+      remove(courtId);
+    } else {
+      add(courtId);
+    }
+  }
+}

--- a/lib/services/favorite_court_service.dart
+++ b/lib/services/favorite_court_service.dart
@@ -1,0 +1,46 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/court.dart';
+import 'pocketbase_client.dart';
+
+class FavoriteCourtService {
+  static const collection = 'user_favorites';
+
+  Future<Set<String>> getFavoriteCourtIds(String userId) async {
+    final pb = await getPocketbaseInstance();
+    final result = await pb.collection(collection).getList(
+          filter: "user_id='$userId'",
+          perPage: 200,
+        );
+
+    return result.items
+        .map((item) => item.data['court_id']?.toString())
+        .whereType<String>()
+        .toSet();
+  }
+
+  Future<void> addFavorite(String userId, Court court) async {
+    final pb = await getPocketbaseInstance();
+    try {
+      await pb.collection(collection).create(body: {
+        'user_id': userId,
+        'court_id': court.id,
+      });
+    } on ClientException catch (error) {
+      // Ignore conflict when the favorite already exists
+      if ((error.response['code'] as int?) != 400) rethrow;
+    }
+  }
+
+  Future<void> removeFavorite(String userId, String courtId) async {
+    final pb = await getPocketbaseInstance();
+    try {
+      final first = await pb
+          .collection(collection)
+          .getFirstListItem("user_id='$userId' && court_id='$courtId'");
+      await pb.collection(collection).delete(first.id);
+    } on ClientException catch (error) {
+      if ((error.response['code'] as int?) != 404) rethrow;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refresh the court page with a modern hero header, gradients, and discovery chips while keeping existing court cards
- add a favorite court manager/service backed by the `user_favorites` collection and wire it into the court listing
- initialize and refresh favorite data alongside courts so heart toggles stay in sync

## Testing
- Not run (Flutter/Dart tooling unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367d3e9334832ba7d0a8fe72838e9a)