### PR TITLE
Prevent notifying disposed social managers

### DIFF
--- a/lib/pages/auth/login_page.dart
+++ b/lib/pages/auth/login_page.dart
@@ -4,7 +4,6 @@ import 'package:badminton_booking_app/components/my_button.dart';
 import 'package:badminton_booking_app/components/my_text_field.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
 import 'package:badminton_booking_app/pages/auth/sign_up_page.dart';
-import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/utils/dialog_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -47,12 +46,6 @@ class _LoginPageState extends State<LoginPage> {
             email,
             password,
           );
-
-      if (!mounted) return;
-      Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(builder: (_) => const NavBarPage()),
-        (_) => false,
-      );
     } catch (e, st) {
       log('login error: $e', stackTrace: st);
       if (!mounted) return;

--- a/lib/pages/auth/sign_up_page.dart
+++ b/lib/pages/auth/sign_up_page.dart
@@ -5,7 +5,6 @@ import 'package:badminton_booking_app/components/my_button.dart';
 import 'package:badminton_booking_app/components/my_text_field.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
 import 'package:badminton_booking_app/pages/auth/login_page.dart';
-import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/utils/dialog_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:intl_phone_field/intl_phone_field.dart';
@@ -66,10 +65,7 @@ class _SignUpPageState extends State<SignUpPage> {
           );
 
       if (!mounted) return;
-      Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(builder: (_) => const NavBarPage()),
-        (_) => false,
-      );
+      Navigator.of(context).popUntil((route) => route.isFirst);
     } catch (e, st) {
       log('signup error: $e', stackTrace: st);
       if (!mounted) return;

--- a/lib/pages/social/invitation/invitation_manager.dart
+++ b/lib/pages/social/invitation/invitation_manager.dart
@@ -11,6 +11,7 @@ class InvitationManager extends ChangeNotifier {
       : _service = service ?? InvitationService();
 
   final InvitationService _service;
+  bool _isDisposed = false;
 
   List<Invitation> _invitations = const <Invitation>[];
   bool _isLoading = false;
@@ -24,7 +25,7 @@ class InvitationManager extends ChangeNotifier {
     if (_isLoading) return;
     _isLoading = true;
     _error = null;
-    notifyListeners();
+    _notifyListeners();
 
     try {
       _invitations = await _service.fetchIncoming();
@@ -32,7 +33,7 @@ class InvitationManager extends ChangeNotifier {
       _error = err.toString();
     } finally {
       _isLoading = false;
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -45,7 +46,7 @@ class InvitationManager extends ChangeNotifier {
     } catch (err) {
       _error = err.toString();
     } finally {
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -102,4 +103,15 @@ class InvitationManager extends ChangeNotifier {
   List<Court> mapCourts(List<Court> courts) => courts;
   List<RecruitmentPost> mapRecruitments(List<RecruitmentPost> posts) => posts;
   List<UserBookingView> mapBookings(List<UserBookingView> bookings) => bookings;
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+
+  void _notifyListeners() {
+    if (_isDisposed) return;
+    notifyListeners();
+  }
 }

--- a/lib/pages/social/partner_suggestion_manager.dart
+++ b/lib/pages/social/partner_suggestion_manager.dart
@@ -13,6 +13,7 @@ class PartnerSuggestionManager extends ChangeNotifier {
 
   final RecommenderService _service;
   final FriendRequestService _friendRequestService;
+  bool _isDisposed = false;
 
   List<PartnerRecommendation> _suggestions = const <PartnerRecommendation>[];
   List<PartnerRecommendation> _filteredSuggestions =
@@ -47,7 +48,7 @@ class PartnerSuggestionManager extends ChangeNotifier {
       _suggestions = const <PartnerRecommendation>[];
       _filteredSuggestions = const <PartnerRecommendation>[];
     }
-    notifyListeners();
+    _notifyListeners();
 
     try {
       _suggestions = await _service.fetchRecommendations();
@@ -58,7 +59,7 @@ class PartnerSuggestionManager extends ChangeNotifier {
       _filteredSuggestions = const <PartnerRecommendation>[];
     } finally {
       _isLoading = false;
-      notifyListeners();
+      _notifyListeners();
     }
   }
 
@@ -159,6 +160,17 @@ class PartnerSuggestionManager extends ChangeNotifier {
       return true;
     }).toList(growable: false);
 
+    _notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+
+  void _notifyListeners() {
+    if (_isDisposed) return;
     notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- avoid calling listeners after InvitationManager and PartnerSuggestionManager are disposed
- add disposal guards to prevent async callbacks from firing when the page is gone
