### PR TITLE
Enhance home page with live data

### DIFF
--- a/lib/models/court.dart
+++ b/lib/models/court.dart
@@ -10,6 +10,10 @@ class Court {
   final String phone;
   final String location;
   final String? description;
+  final double? rating;
+  final double? distanceKm;
+  final int? pricePerHour;
+  final String? nextSlotLabel;
   final int courtQuantity;
   final bool isActive;
   final String ownerId;
@@ -17,6 +21,7 @@ class Court {
   final String? coverImageUrl;
   final DateTime? createdAt;
   final DateTime? updatedAt;
+  final int bookingCount;
 
   Court({
     required this.id,
@@ -27,11 +32,16 @@ class Court {
     required this.courtQuantity,
     required this.isActive,
     required this.ownerId,
+    this.rating,
+    this.distanceKm,
+    this.pricePerHour,
+    this.nextSlotLabel,
     this.description,
     this.coverImage,
     this.coverImageUrl,
     this.createdAt,
     this.updatedAt,
+    this.bookingCount = 0,
   }) : assert(
           phone.isEmpty || _vnPhoneReg.hasMatch(phone),
           'phone không đúng định dạng VN (0xxxxxxxxx hoặc +84xxxxxxxxx)',
@@ -51,6 +61,10 @@ class Court {
       name: json['name'] as String? ?? '',
       code: json['code'] as String? ?? '',
       phone: normalized,
+      rating: _parseDouble(json['rating']),
+      distanceKm: _parseDouble(json['distance_km']),
+      pricePerHour: _parseInt(json['price_per_hour']),
+      nextSlotLabel: json['next_slot_label'] as String?,
       location: json['location'] as String? ?? '',
       description: json['description'] as String?,
       courtQuantity: _parseInt(json['court_quantity']),
@@ -60,6 +74,7 @@ class Court {
       coverImageUrl: coverImageUrl,
       createdAt: _parseDate(json['created']),
       updatedAt: _parseDate(json['updated']),
+      bookingCount: _parseInt(json['booking_count']),
     );
   }
 
@@ -76,11 +91,16 @@ class Court {
         'code': code,
         'phone': phone, // đã chuẩn hoá
         'location': location,
+        'rating': rating,
+        'distance_km': distanceKm,
+        'price_per_hour': pricePerHour,
+        'next_slot_label': nextSlotLabel,
         'description': description,
         'court_quantity': courtQuantity,
         'is_active': isActive,
         'owner_id': ownerId,
         'cover_image': coverImage,
+        'booking_count': bookingCount,
         'created': createdAt?.toIso8601String(),
         'updated': updatedAt?.toIso8601String(),
       };
@@ -129,6 +149,10 @@ class Court {
     String? code,
     String? phone,
     String? location,
+    double? rating,
+    double? distanceKm,
+    int? pricePerHour,
+    String? nextSlotLabel,
     String? description,
     int? courtQuantity,
     bool? isActive,
@@ -137,6 +161,7 @@ class Court {
     String? coverImageUrl,
     DateTime? createdAt,
     DateTime? updatedAt,
+    int? bookingCount,
   }) {
     final nextPhone = phone ?? this.phone;
     assert(
@@ -149,6 +174,10 @@ class Court {
       code: code ?? this.code,
       phone: _normalizePhone(nextPhone),
       location: location ?? this.location,
+      rating: rating ?? this.rating,
+      distanceKm: distanceKm ?? this.distanceKm,
+      pricePerHour: pricePerHour ?? this.pricePerHour,
+      nextSlotLabel: nextSlotLabel ?? this.nextSlotLabel,
       description: description ?? this.description,
       courtQuantity: courtQuantity ?? this.courtQuantity,
       isActive: isActive ?? this.isActive,
@@ -157,6 +186,7 @@ class Court {
       coverImageUrl: coverImageUrl ?? this.coverImageUrl,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      bookingCount: bookingCount ?? this.bookingCount,
     );
   }
 
@@ -185,6 +215,13 @@ class Court {
     if (value is num) return value.toInt();
     if (value is String) return int.tryParse(value) ?? 0;
     return 0;
+  }
+
+  static double? _parseDouble(dynamic value) {
+    if (value is double) return value;
+    if (value is num) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+    return null;
   }
 
   static bool _parseBool(dynamic value) {

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -68,6 +68,10 @@ class _CourtPageState extends State<CourtPage> {
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
+      appBar: AppBar(
+        title: const Text('Danh sách sân'),
+        centerTitle: true,
+      ),
       body: SafeArea(
         child: RefreshIndicator(
           onRefresh: () async {

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -25,14 +25,16 @@ class TimeOfDayRange {
 }
 
 class CourtPage extends StatefulWidget {
-  CourtPage({super.key});
+  const CourtPage({super.key, this.initialFilter = CourtFilter.newest});
+
+  final CourtFilter initialFilter;
 
   @override
   State<CourtPage> createState() => _CourtPageState();
 }
 
 class _CourtPageState extends State<CourtPage> {
-  var _selectedFilter = CourtFilter.newest;
+  late CourtFilter _selectedFilter;
   var _minCourtQuantity = 0.0;
   int? _quantityQuickUpperBound;
   bool _openNowOnly = false;
@@ -54,6 +56,7 @@ class _CourtPageState extends State<CourtPage> {
   @override
   void initState() {
     super.initState();
+    _selectedFilter = widget.initialFilter;
     Future.microtask(() {
       context.read<FavoriteCourtManager>().initialize();
     });

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -1,10 +1,10 @@
 import 'package:badminton_booking_app/components/my_carousel.dart';
-import 'package:badminton_booking_app/components/my_court.dart';
 import 'package:badminton_booking_app/components/my_text_field.dart';
 import 'package:badminton_booking_app/models/court.dart';
 import 'package:badminton_booking_app/models/user_booking_view.dart';
 import 'package:badminton_booking_app/pages/court/booking_page.dart';
 import 'package:badminton_booking_app/pages/court/court_page.dart';
+import 'package:badminton_booking_app/pages/court/court_detail.dart';
 import 'package:badminton_booking_app/pages/home/search_page.dart';
 import 'package:badminton_booking_app/pages/user/user_booking_history_page.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
@@ -13,6 +13,7 @@ import 'package:badminton_booking_app/services/court_service.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:badminton_booking_app/utils/currency.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -172,7 +173,12 @@ class _HomePageState extends State<HomePage> {
 
             // ===== Section: Gần bạn =====
             _SectionHeaderSliver(
-                title: 'Gần bạn', actionText: 'Xem tất cả', onTap: _reloadCourts),
+              title: 'Gần bạn',
+              actionText: 'Xem tất cả',
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const CourtPage()),
+              ),
+            ),
             ..._buildCourtsSliver(),
 
             SliverToBoxAdapter(
@@ -198,10 +204,13 @@ class _HomePageState extends State<HomePage> {
     });
 
     try {
-      final courts = await _courtService.listCourts(perPage: 8);
+      final courts = await _courtService.listCourts(perPage: 24);
+      final sorted = List<Court>.of(courts)
+        ..sort((a, b) => b.bookingCount.compareTo(a.bookingCount));
+      final topCourts = sorted.take(3).toList(growable: false);
       if (!mounted) return;
       setState(() {
-        _courts = courts;
+        _courts = topCourts;
       });
     } catch (error) {
       if (!mounted) return;
@@ -337,7 +346,7 @@ class _HomePageState extends State<HomePage> {
         itemCount: _courts.length,
         itemBuilder: (_, i) => Padding(
           padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
-          child: MyCourt(court: _courts[i]),
+          child: _CourtCard(court: _courts[i]),
         ),
       ),
     ];
@@ -567,6 +576,133 @@ class _SectionHeaderSliver extends StatelessWidget {
                   ],
                 ),
               ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CourtCard extends StatelessWidget {
+  final Court court;
+  const _CourtCard({required this.court});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final hasCoverImage =
+        court.coverImageUrl != null && court.coverImageUrl!.isNotEmpty;
+    final imageProvider = hasCoverImage
+        ? NetworkImage(court.coverImageUrl!) as ImageProvider
+        : const AssetImage('assets/images/badminton_logo.jpg');
+
+    final ratingLabel =
+        court.rating != null && court.rating! > 0 ? court.rating!.toStringAsFixed(1) : null;
+    final distanceLabel = court.distanceKm != null && court.distanceKm! > 0
+        ? '${court.distanceKm!.toStringAsFixed(1)}km'
+        : null;
+    final primaryMeta = [ratingLabel, distanceLabel]
+        .whereType<String>()
+        .where((value) => value.isNotEmpty)
+        .join(' • ');
+    final nextSlot = court.nextSlotLabel?.trim();
+    final nextSlotLabel =
+        nextSlot != null && nextSlot.isNotEmpty ? nextSlot : 'Khung giờ đang cập nhật';
+    final price = court.pricePerHour != null && court.pricePerHour! > 0
+        ? formatVND(court.pricePerHour!)
+        : 'Giá đang cập nhật';
+
+    return Material(
+      color: cs.surface,
+      borderRadius: BorderRadius.circular(12),
+      elevation: 1,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => CourtDetail(court: court),
+            ),
+          );
+        },
+        child: Row(
+          children: [
+            ClipRRect(
+              borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(12), bottomLeft: Radius.circular(12)),
+              child: SizedBox(
+                width: 110,
+                height: 88,
+                child: Image(
+                  image: imageProvider,
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.only(right: 12, top: 10, bottom: 10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(court.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontWeight: FontWeight.w700)),
+                    const SizedBox(height: 2),
+                    Row(
+                      children: [
+                        const Icon(Icons.star, size: 16, color: Colors.amber),
+                        const SizedBox(width: 4),
+                        Text(
+                          primaryMeta.isNotEmpty ? primaryMeta : 'Chưa có đánh giá',
+                        ),
+                        const Spacer(),
+                        Text(price,
+                            style: TextStyle(
+                                color: cs.primary, fontWeight: FontWeight.w800)),
+                        const Text('/giờ', style: TextStyle(fontSize: 12)),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Icon(Icons.schedule,
+                            size: 16, color: cs.onSurface.withOpacity(0.7)),
+                        const SizedBox(width: 4),
+                        Expanded(
+                          child: Text(
+                            nextSlotLabel,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(color: cs.onSurface.withOpacity(0.7)),
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (court.bookingCount > 0) ...[
+                      const SizedBox(height: 6),
+                      Row(
+                        children: [
+                          Icon(Icons.trending_up,
+                              size: 16, color: cs.primary.withOpacity(0.85)),
+                          const SizedBox(width: 6),
+                          Text(
+                            '${court.bookingCount} lượt đặt',
+                            style: TextStyle(
+                              color: cs.onSurface.withOpacity(0.75),
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      )
+                    ],
+                  ],
+                ),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -1,8 +1,18 @@
 import 'package:badminton_booking_app/components/my_carousel.dart';
+import 'package:badminton_booking_app/components/my_court.dart';
 import 'package:badminton_booking_app/components/my_text_field.dart';
+import 'package:badminton_booking_app/models/court.dart';
+import 'package:badminton_booking_app/models/user_booking_view.dart';
+import 'package:badminton_booking_app/pages/court/booking_page.dart';
+import 'package:badminton_booking_app/pages/court/court_page.dart';
 import 'package:badminton_booking_app/pages/home/search_page.dart';
-import 'package:badminton_booking_app/utils/currency.dart';
+import 'package:badminton_booking_app/pages/user/user_booking_history_page.dart';
+import 'package:badminton_booking_app/pages/user/user_manager.dart';
+import 'package:badminton_booking_app/services/booking_service.dart';
+import 'package:badminton_booking_app/services/court_service.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -12,6 +22,8 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   final TextEditingController searchController = TextEditingController();
+  final CourtService _courtService = CourtService();
+  final BookingService _bookingService = BookingService();
   final _banner = [
     'assets/images/court_cover.jpg',
     'https://picsum.photos/seed/promo1/1200/600',
@@ -21,6 +33,23 @@ class _HomePageState extends State<HomePage> {
     'https://picsum.photos/seed/promo5/1200/600',
   ];
   int _bannerIndex = 0;
+  bool _isCourtsLoading = false;
+  String? _courtError;
+  List<Court> _courts = const [];
+
+  bool _isUpcomingLoading = false;
+  String? _upcomingError;
+  UserBookingView? _upcomingBooking;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      if (!mounted) return;
+      _reloadCourts();
+      _loadUpcomingBooking();
+    });
+  }
 
   @override
   void dispose() {
@@ -37,106 +66,281 @@ class _HomePageState extends State<HomePage> {
         title: const Text('Courtify'),
         centerTitle: true,
       ),
-      body: CustomScrollView(
-        slivers: [
-          // ===== Search + Location + Quick filters =====
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _GreetingHeader(
-                    onNotificationTap: () =>
-                        _toast(context, 'Thông báo sẽ sớm có mặt!'),
-                  ),
-                  const SizedBox(height: 18),
-                  MyTextfield(
-                    hintText: "Search for courts...",
-                    controller: searchController,
-                    prefixIcon: const Icon(Icons.search_rounded),
-                    suffixIcon: IconButton(
-                      onPressed: () => _toast(
-                          context, 'Bộ lọc nâng cao đang được hoàn thiện'),
-                      icon: const Icon(Icons.tune_rounded),
+      body: RefreshIndicator(
+        onRefresh: _refreshHome,
+        child: CustomScrollView(
+          slivers: [
+            // ===== Search + Location + Quick filters =====
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _GreetingHeader(
+                      onNotificationTap: () =>
+                          _toast(context, 'Thông báo sẽ sớm có mặt!'),
                     ),
-                    isReadOnly: true,
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => SearchPage()),
-                      );
-                    },
-                  ),
-                ],
+                    const SizedBox(height: 18),
+                    MyTextfield(
+                      hintText: "Search for courts...",
+                      controller: searchController,
+                      prefixIcon: const Icon(Icons.search_rounded),
+                      suffixIcon: IconButton(
+                        onPressed: () => _toast(
+                            context, 'Bộ lọc nâng cao đang được hoàn thiện'),
+                        icon: const Icon(Icons.tune_rounded),
+                      ),
+                      isReadOnly: true,
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (context) => SearchPage()),
+                        );
+                      },
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
 
-          // ===== Quick actions =====
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
-              child: Row(
-                children: [
-                  _QuickAction(
-                    icon: Icons.sports_tennis,
-                    label: 'Đặt sân',
-                    onTap: () => _toast(context, 'Đi tới màn đặt sân (demo)'),
-                  ),
-                  const SizedBox(width: 12),
-                  _QuickAction(
-                    icon: Icons.history,
-                    label: 'Lịch sử',
-                    onTap: () => _toast(context, 'Mở Lịch sử đặt sân'),
-                  ),
-                  const SizedBox(width: 12),
-                  _QuickAction(
-                    icon: Icons.favorite_border,
-                    label: 'Yêu thích',
-                    onTap: () => _toast(context, 'Mở danh sách yêu thích'),
-                  ),
-                ],
+            // ===== Quick actions =====
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+                child: Row(
+                  children: [
+                    _QuickAction(
+                      icon: Icons.sports_tennis,
+                      label: 'Đặt sân',
+                      onTap: () => Navigator.of(context).push(
+                        MaterialPageRoute(builder: (_) => const SearchPage()),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    _QuickAction(
+                      icon: Icons.history,
+                      label: 'Lịch sử',
+                      onTap: () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                            builder: (_) => const UserBookingHistoryPage()),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    _QuickAction(
+                      icon: Icons.favorite_border,
+                      label: 'Yêu thích',
+                      onTap: () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => CourtPage(
+                            initialFilter: CourtFilter.favorites,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
 
-          // ===== Promo carousel =====
-          SliverToBoxAdapter(
-            child: MyCarousel(
-              images: _banner,
-              onIndexChanged: (i) => setState(() => _bannerIndex = i),
-            ),
-          ),
-
-          // ===== Upcoming booking (demo) =====
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-              child: _UpcomingCard(
-                hasBooking: true, // đổi false để thấy CTA rỗng
-                onTap: () => _toast(context, 'Mở chi tiết lịch sắp tới'),
+            // ===== Promo carousel =====
+            SliverToBoxAdapter(
+              child: MyCarousel(
+                images: _banner,
+                onIndexChanged: (i) => setState(() => _bannerIndex = i),
               ),
             ),
-          ),
 
-          // ===== Section: Gần bạn =====
-          _SectionHeaderSliver(
-              title: 'Gần bạn', actionText: 'Xem tất cả', onTap: () {}),
-          SliverList.builder(
-            itemBuilder: (_, i) => Padding(
-              padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
-              child: _CourtCard(court: kHomeCourts[i]),
+            // ===== Upcoming booking =====
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: _UpcomingCard(
+                  booking: _upcomingBooking,
+                  isLoading: _isUpcomingLoading,
+                  error: _upcomingError,
+                  onTap: _upcomingBooking == null
+                      ? null
+                      : () => _openBookingDetail(_upcomingBooking!),
+                  onCreateTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const SearchPage()),
+                  ),
+                  onRetry: _loadUpcomingBooking,
+                ),
+              ),
             ),
-            itemCount: kHomeCourts.length,
-          ),
 
-          SliverToBoxAdapter(
-              child:
-                  SizedBox(height: MediaQuery.of(context).padding.bottom + 16)),
-        ],
+            // ===== Section: Gần bạn =====
+            _SectionHeaderSliver(
+                title: 'Gần bạn', actionText: 'Xem tất cả', onTap: _reloadCourts),
+            ..._buildCourtsSliver(),
+
+            SliverToBoxAdapter(
+                child: SizedBox(
+                    height: MediaQuery.of(context).padding.bottom + 16)),
+          ],
+        ),
       ),
     );
+  }
+
+  Future<void> _refreshHome() async {
+    await Future.wait([
+      _reloadCourts(),
+      _loadUpcomingBooking(),
+    ]);
+  }
+
+  Future<void> _reloadCourts() async {
+    setState(() {
+      _isCourtsLoading = true;
+      _courtError = null;
+    });
+
+    try {
+      final courts = await _courtService.listCourts(perPage: 8);
+      if (!mounted) return;
+      setState(() {
+        _courts = courts;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _courtError = error.toString();
+      });
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isCourtsLoading = false;
+      });
+    }
+  }
+
+  Future<void> _loadUpcomingBooking() async {
+    final userManager = context.read<UserManager>();
+    final userId = await userManager.getCurrentUserId();
+
+    setState(() {
+      _isUpcomingLoading = true;
+      _upcomingError = null;
+      _upcomingBooking = null;
+    });
+
+    if (userId == null) {
+      setState(() {
+        _upcomingError = 'Bạn cần đăng nhập để xem lịch đặt sân sắp tới.';
+        _isUpcomingLoading = false;
+      });
+      return;
+    }
+
+    try {
+      final now = DateTime.now();
+      final bookings = await _bookingService.listUserBookings(
+        userId: userId,
+        startTimeInclusive: now,
+      );
+
+      final upcoming = bookings
+          .where((b) => b.endTime.isAfter(now))
+          .toList(growable: false)
+        ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+      if (!mounted) return;
+      setState(() {
+        _upcomingBooking = upcoming.isNotEmpty ? upcoming.first : null;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _upcomingError = error.toString();
+      });
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isUpcomingLoading = false;
+      });
+    }
+  }
+
+  Future<void> _openBookingDetail(UserBookingView booking) async {
+    try {
+      final detail = await _courtService.getCourtDetail(booking.courtId);
+      if (!mounted) return;
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => BookingPage(detailData: detail),
+        ),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      _toast(context, error.toString());
+    }
+  }
+
+  List<Widget> _buildCourtsSliver() {
+    if (_isCourtsLoading) {
+      return [
+        const SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 12),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+        )
+      ];
+    }
+
+    if (_courtError != null) {
+      return [
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Column(
+              children: [
+                const Icon(Icons.error_outline, color: Colors.redAccent),
+                const SizedBox(height: 8),
+                Text(
+                  _courtError!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 8),
+                FilledButton.icon(
+                  onPressed: _reloadCourts,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Thử lại'),
+                ),
+              ],
+            ),
+          ),
+        )
+      ];
+    }
+
+    if (_courts.isEmpty) {
+      return [
+        const SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Text(
+              'Chưa có sân nào gần bạn. Hãy thử tìm kiếm để đặt sân nhé!',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+          ),
+        )
+      ];
+    }
+
+    return [
+      SliverList.builder(
+        itemCount: _courts.length,
+        itemBuilder: (_, i) => Padding(
+          padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
+          child: MyCourt(court: _courts[i]),
+        ),
+      ),
+    ];
   }
 
   void _toast(BuildContext context, String msg) {
@@ -370,169 +574,164 @@ class _SectionHeaderSliver extends StatelessWidget {
   }
 }
 
-class _CourtCard extends StatelessWidget {
-  final HomeCourt court;
-  const _CourtCard({required this.court});
+class _UpcomingCard extends StatelessWidget {
+  final UserBookingView? booking;
+  final bool isLoading;
+  final String? error;
+  final VoidCallback? onTap;
+  final VoidCallback? onCreateTap;
+  final VoidCallback? onRetry;
+  const _UpcomingCard({
+    required this.booking,
+    required this.isLoading,
+    this.error,
+    this.onTap,
+    this.onCreateTap,
+    this.onRetry,
+  });
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isAsset = !court.image.startsWith('http');
 
-    return Material(
-      color: cs.surface,
-      borderRadius: BorderRadius.circular(12),
-      elevation: 1,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: () {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Mở chi tiết: ${court.name}')),
-          );
-        },
+    if (isLoading) {
+      return Container(
+        padding: const EdgeInsets.all(18),
+        decoration: BoxDecoration(
+          color: cs.surfaceVariant.withOpacity(0.5),
+          borderRadius: BorderRadius.circular(18),
+        ),
         child: Row(
-          children: [
-            ClipRRect(
-              borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(12),
-                  bottomLeft: Radius.circular(12)),
-              child: SizedBox(
-                width: 110,
-                height: 88,
-                child: isAsset
-                    ? Image.asset(court.image, fit: BoxFit.cover)
-                    : Image.network(court.image, fit: BoxFit.cover),
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.only(right: 12, top: 10, bottom: 10),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(court.name,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(fontWeight: FontWeight.w700)),
-                    const SizedBox(height: 2),
-                    Row(
-                      children: [
-                        const Icon(Icons.star, size: 16, color: Colors.amber),
-                        const SizedBox(width: 4),
-                        Text(
-                            '${court.rating.toStringAsFixed(1)} • ${court.distanceKm.toStringAsFixed(1)}km'),
-                        const Spacer(),
-                        Text(formatVND(court.pricePerHour),
-                            style: TextStyle(
-                                color: cs.primary,
-                                fontWeight: FontWeight.w800)),
-                        const Text('/giờ', style: TextStyle(fontSize: 12)),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Row(
-                      children: [
-                        Icon(Icons.schedule,
-                            size: 16, color: cs.onSurface.withOpacity(0.7)),
-                        const SizedBox(width: 4),
-                        Text(court.nextSlotLabel,
-                            style: TextStyle(
-                                color: cs.onSurface.withOpacity(0.7))),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ),
+          children: const [
+            CircularProgressIndicator(),
+            SizedBox(width: 12),
+            Text('Đang kiểm tra lịch sắp tới...'),
           ],
         ),
-      ),
-    );
-  }
-}
+      );
+    }
 
-/// ===================== Mock data & helpers =====================
-class HomeCourt {
-  final String name;
-  final String image; // asset or url
-  final double rating;
-  final double distanceKm;
-  final int pricePerHour;
-  final String nextSlotLabel;
-  HomeCourt({
-    required this.name,
-    required this.image,
-    required this.rating,
-    required this.distanceKm,
-    required this.pricePerHour,
-    required this.nextSlotLabel,
-  });
-}
+    if (error != null) {
+      return Container(
+        padding: const EdgeInsets.all(18),
+        decoration: BoxDecoration(
+          color: cs.errorContainer.withOpacity(0.7),
+          borderRadius: BorderRadius.circular(18),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.error_outline, color: cs.onErrorContainer),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    error!,
+                    style: TextStyle(
+                      color: cs.onErrorContainer,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 10),
+              FilledButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Thử lại'),
+              ),
+            ],
+          ],
+        ),
+      );
+    }
 
-final kHomeCourts = <HomeCourt>[
-  HomeCourt(
-    name: 'Minh Nghĩa Badminton',
-    image: 'assets/images/court_cover.jpg',
-    rating: 4.7,
-    distanceKm: 1.2,
-    pricePerHour: 60000,
-    nextSlotLabel: 'Còn 18:00–19:00 hôm nay',
-  ),
-  HomeCourt(
-    name: 'NTĐ Quận Ninh Kiều',
-    image: 'https://picsum.photos/seed/court21/1200/800',
-    rating: 4.5,
-    distanceKm: 2.6,
-    pricePerHour: 70000,
-    nextSlotLabel: '19:00–20:00 hôm nay',
-  ),
-  HomeCourt(
-    name: 'Sân Cầu Lông Xuân Khánh',
-    image: 'https://picsum.photos/seed/court22/1200/800',
-    rating: 4.2,
-    distanceKm: 3.1,
-    pricePerHour: 55000,
-    nextSlotLabel: '17:00–18:00 ngày mai',
-  ),
-];
+    if (booking == null) {
+      return InkWell(
+        onTap: onCreateTap,
+        borderRadius: BorderRadius.circular(18),
+        child: Ink(
+          decoration: BoxDecoration(
+            color: cs.surfaceVariant.withOpacity(0.65),
+            borderRadius: BorderRadius.circular(18),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(18),
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: cs.primary.withOpacity(0.14),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Icon(
+                    Icons.event_busy,
+                    color: cs.primary,
+                    size: 24,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: const [
+                      Text(
+                        'Chưa có lịch chơi',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 15,
+                        ),
+                      ),
+                      SizedBox(height: 6),
+                      Text(
+                        'Đặt sân ngay để không bỏ lỡ khung giờ đẹp.',
+                        style: TextStyle(height: 1.3),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                const Icon(Icons.chevron_right),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
 
-class _UpcomingCard extends StatelessWidget {
-  final bool hasBooking;
-  final VoidCallback onTap;
-  const _UpcomingCard({required this.hasBooking, required this.onTap});
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final highlight = hasBooking;
-    final textColor = highlight ? cs.onPrimary : cs.onSurface;
-    final subtitleColor = highlight
-        ? cs.onPrimary.withOpacity(0.8)
-        : cs.onSurface.withOpacity(0.7);
+    final highlight = true;
+    final textColor = cs.onPrimary;
+    final subtitleColor = cs.onPrimary.withOpacity(0.8);
+    final dateFormat = DateFormat('HH:mm, dd/MM');
+    final location = booking!.courtLocation ?? 'Địa điểm đang cập nhật';
+    final unitLabel = booking!.courtUnitLabel;
+    final timeRange =
+        '${dateFormat.format(booking!.startTime.toLocal())} – ${dateFormat.format(booking!.endTime.toLocal())}';
 
     return InkWell(
-      onTap: hasBooking ? onTap : null,
+      onTap: onTap,
       borderRadius: BorderRadius.circular(18),
       child: Ink(
         decoration: BoxDecoration(
-          gradient: highlight
-              ? LinearGradient(
-                  colors: [
-                    cs.primary,
-                    cs.primary.withOpacity(0.7),
-                  ],
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                )
-              : null,
-          color: highlight ? null : cs.surfaceVariant.withOpacity(0.65),
+          gradient: LinearGradient(
+            colors: [
+              cs.primary,
+              cs.primary.withOpacity(0.7),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
           borderRadius: BorderRadius.circular(18),
           boxShadow: [
-            if (highlight)
-              BoxShadow(
-                color: cs.primary.withOpacity(0.18),
-                blurRadius: 24,
-                offset: const Offset(0, 12),
-              ),
+            BoxShadow(
+              color: cs.primary.withOpacity(0.18),
+              blurRadius: 24,
+              offset: const Offset(0, 12),
+            ),
           ],
         ),
         child: Padding(
@@ -542,14 +741,12 @@ class _UpcomingCard extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: highlight
-                      ? cs.onPrimary.withOpacity(0.18)
-                      : cs.primary.withOpacity(0.14),
+                  color: cs.onPrimary.withOpacity(0.18),
                   borderRadius: BorderRadius.circular(16),
                 ),
                 child: Icon(
-                  highlight ? Icons.event_available : Icons.event_busy,
-                  color: highlight ? cs.onPrimary : cs.primary,
+                  Icons.event_available,
+                  color: cs.onPrimary,
                   size: 24,
                 ),
               ),
@@ -560,7 +757,7 @@ class _UpcomingCard extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      highlight ? 'Lịch chơi sắp tới' : 'Chưa có lịch chơi',
+                      booking!.courtName ?? 'Lịch chơi sắp tới',
                       style: TextStyle(
                         color: textColor,
                         fontWeight: FontWeight.w700,
@@ -569,9 +766,9 @@ class _UpcomingCard extends StatelessWidget {
                     ),
                     const SizedBox(height: 6),
                     Text(
-                      highlight
-                          ? 'Bạn có lịch Minh Nghĩa Badminton • 19:00–21:00 hôm nay'
-                          : 'Đặt sân ngay để không bỏ lỡ khung giờ đẹp.',
+                      unitLabel == null || unitLabel.isEmpty
+                          ? '$location • $timeRange'
+                          : '$location • $unitLabel • $timeRange',
                       style: TextStyle(
                         color: subtitleColor,
                         height: 1.3,

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -656,13 +656,25 @@ class _CourtCard extends StatelessWidget {
                       children: [
                         const Icon(Icons.star, size: 16, color: Colors.amber),
                         const SizedBox(width: 4),
-                        Text(
-                          primaryMeta.isNotEmpty ? primaryMeta : 'Chưa có đánh giá',
+                        Expanded(
+                          child: Text(
+                            primaryMeta.isNotEmpty
+                                ? primaryMeta
+                                : 'Chưa có đánh giá',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
                         ),
-                        const Spacer(),
-                        Text(price,
-                            style: TextStyle(
-                                color: cs.primary, fontWeight: FontWeight.w800)),
+                        const SizedBox(width: 8),
+                        Text(
+                          price,
+                          style: TextStyle(
+                            color: cs.primary,
+                            fontWeight: FontWeight.w800,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                         const Text('/giờ', style: TextStyle(fontSize: 12)),
                       ],
                     ),

--- a/lib/pages/nav_bar_page.dart
+++ b/lib/pages/nav_bar_page.dart
@@ -32,7 +32,7 @@ class _NavBarPageState extends State<NavBarPage> {
       _loadAndCheckOnboarding();
     });
 
-    _pages = [
+    _pages = const [
       HomePage(),
       SocialPage(),
       CourtPage(),


### PR DESCRIPTION
## Summary
- fetch courts and upcoming bookings for the home page with loading, empty, and error states
- wire quick actions to real navigation targets and open upcoming booking details
- allow the court page to start on favorites and update navigation page initialization

## Testing
- not run (environment does not have Flutter/Dart tooling available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f459c804832a9189ce135e054466)