### PR TITLE
Enhance home carousel with CTA slides

### DIFF
--- a/lib/components/my_carousel.dart
+++ b/lib/components/my_carousel.dart
@@ -155,9 +155,8 @@ class _MyCarouselState extends State<MyCarousel> {
                                         horizontal: 14,
                                         vertical: 10,
                                       ),
-                                      backgroundColor:
-                                          Colors.white.withOpacity(0.95),
-                                      foregroundColor: Colors.black87,
+                                      backgroundColor: cs.primary,
+                                      foregroundColor: Colors.white,
                                       shape: RoundedRectangleBorder(
                                         borderRadius: BorderRadius.circular(12),
                                       ),

--- a/lib/components/my_carousel.dart
+++ b/lib/components/my_carousel.dart
@@ -2,8 +2,24 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
+class CarouselSlide {
+  final String image;
+  final String title;
+  final String? description;
+  final String? ctaLabel;
+  final VoidCallback? onTap;
+
+  const CarouselSlide({
+    required this.image,
+    required this.title,
+    this.description,
+    this.ctaLabel,
+    this.onTap,
+  });
+}
+
 class MyCarousel extends StatefulWidget {
-  final List<String> images;
+  final List<CarouselSlide> slides;
   final ValueChanged<int>? onIndexChanged;
   final Duration interval; // thời gian chờ giữa các lần chuyển
   final Duration duration; // thời gian chạy animation
@@ -11,7 +27,7 @@ class MyCarousel extends StatefulWidget {
 
   const MyCarousel({
     super.key,
-    required this.images,
+    required this.slides,
     this.onIndexChanged,
     this.interval = const Duration(seconds: 4),
     this.duration = const Duration(milliseconds: 450),
@@ -37,10 +53,10 @@ class _MyCarouselState extends State<MyCarousel> {
 
   void _startAutoPlay() {
     _timer?.cancel();
-    if (widget.images.isEmpty) return;
+    if (widget.slides.isEmpty) return;
     _timer = Timer.periodic(widget.interval, (_) {
       if (!mounted || _isUserDragging) return;
-      final next = (_idx + 1) % widget.images.length;
+      final next = (_idx + 1) % widget.slides.length;
       _pc.animateToPage(next, duration: widget.duration, curve: widget.curve);
     });
   }
@@ -74,13 +90,14 @@ class _MyCarouselState extends State<MyCarousel> {
               },
               child: PageView.builder(
                 controller: _pc,
-                itemCount: widget.images.length,
+                itemCount: widget.slides.length,
                 onPageChanged: (i) {
                   setState(() => _idx = i);
                   widget.onIndexChanged?.call(i);
                 },
                 itemBuilder: (_, i) {
-                  final src = widget.images[i];
+                  final slide = widget.slides[i];
+                  final src = slide.image;
                   final isAsset = !src.startsWith('http');
                   return ClipRRect(
                     borderRadius: BorderRadius.circular(14),
@@ -90,16 +107,81 @@ class _MyCarouselState extends State<MyCarousel> {
                         isAsset
                             ? Image.asset(src, fit: BoxFit.cover)
                             : Image.network(src, fit: BoxFit.cover),
-                        Container(color: Colors.black.withOpacity(0.2)),
-                        const Align(
+                        Container(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [
+                                Colors.black.withOpacity(0.55),
+                                Colors.black.withOpacity(0.15),
+                              ],
+                              begin: Alignment.bottomCenter,
+                              end: Alignment.topCenter,
+                            ),
+                          ),
+                        ),
+                        Align(
                           alignment: Alignment.bottomLeft,
-                          child: Padding(
-                            padding: EdgeInsets.all(12),
-                            child: Text(
-                              'Ưu đãi thành viên • tuần này',
-                              style: TextStyle(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w700),
+                          child: Container(
+                            width: double.infinity,
+                            padding: const EdgeInsets.all(12),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  slide.title,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w800,
+                                    fontSize: 18,
+                                  ),
+                                ),
+                                if (slide.description != null) ...[
+                                  const SizedBox(height: 6),
+                                  Text(
+                                    slide.description!,
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 13,
+                                    ),
+                                  ),
+                                ],
+                                if (slide.ctaLabel != null &&
+                                    slide.onTap != null) ...[
+                                  const SizedBox(height: 10),
+                                  FilledButton(
+                                    style: FilledButton.styleFrom(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 14,
+                                        vertical: 10,
+                                      ),
+                                      backgroundColor:
+                                          Colors.white.withOpacity(0.95),
+                                      foregroundColor: Colors.black87,
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(12),
+                                      ),
+                                    ),
+                                    onPressed: slide.onTap,
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Text(
+                                          slide.ctaLabel!,
+                                          style: const TextStyle(
+                                            fontWeight: FontWeight.w700,
+                                          ),
+                                        ),
+                                        const SizedBox(width: 6),
+                                        const Icon(
+                                          Icons.arrow_forward_rounded,
+                                          size: 18,
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ],
                             ),
                           ),
                         ),
@@ -113,7 +195,7 @@ class _MyCarouselState extends State<MyCarousel> {
           const SizedBox(height: 8),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
-            children: List.generate(widget.images.length, (i) {
+            children: List.generate(widget.slides.length, (i) {
               final active = i == _idx;
               return AnimatedContainer(
                 duration: const Duration(milliseconds: 200),

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -6,6 +6,7 @@ import 'package:badminton_booking_app/pages/court/booking_page.dart';
 import 'package:badminton_booking_app/pages/court/court_page.dart';
 import 'package:badminton_booking_app/pages/court/court_detail.dart';
 import 'package:badminton_booking_app/pages/home/search_page.dart';
+import 'package:badminton_booking_app/pages/social/social_page.dart';
 import 'package:badminton_booking_app/pages/user/user_booking_history_page.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:badminton_booking_app/services/booking_service.dart';
@@ -25,14 +26,7 @@ class _HomePageState extends State<HomePage> {
   final TextEditingController searchController = TextEditingController();
   final CourtService _courtService = CourtService();
   final BookingService _bookingService = BookingService();
-  final _banner = [
-    'assets/images/court_cover.jpg',
-    'https://picsum.photos/seed/promo1/1200/600',
-    'https://picsum.photos/seed/promo2/1200/600',
-    'https://picsum.photos/seed/promo3/1200/600',
-    'https://picsum.photos/seed/promo4/1200/600',
-    'https://picsum.photos/seed/promo5/1200/600',
-  ];
+  late final List<CarouselSlide> _bannerSlides;
   int _bannerIndex = 0;
   bool _isCourtsLoading = false;
   String? _courtError;
@@ -45,6 +39,29 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
+    _bannerSlides = [
+      CarouselSlide(
+        image: 'assets/images/court_cover_2.jpg',
+        title: 'Ưu đãi giờ vàng / gói thành viên',
+        description: 'Chọn nhanh sân trống giờ đẹp hoặc săn giá tốt cho hội nhóm.',
+        ctaLabel: 'Đặt sân ngay',
+        onTap: _openSearchPage,
+      ),
+      CarouselSlide(
+        image: 'assets/images/court_cover_5.jpg',
+        title: 'Sự kiện • giải nội bộ',
+        description: 'Tham gia giải giao lưu, tuyển thành viên hay lập kèo trong CLB.',
+        ctaLabel: 'Xem sự kiện',
+        onTap: () => _openSocialTab(1),
+      ),
+      CarouselSlide(
+        image: 'assets/images/court_cover_3.jpg',
+        title: 'Tìm bạn đánh đôi',
+        description: 'Kết nối partner hợp lối chơi, set kèo đôi ngay trong cộng đồng.',
+        ctaLabel: 'Mở tab Social',
+        onTap: () => _openSocialTab(2),
+      ),
+    ];
     Future.microtask(() {
       if (!mounted) return;
       _reloadCourts();
@@ -147,7 +164,7 @@ class _HomePageState extends State<HomePage> {
             // ===== Promo carousel =====
             SliverToBoxAdapter(
               child: MyCarousel(
-                images: _banner,
+                slides: _bannerSlides,
                 onIndexChanged: (i) => setState(() => _bannerIndex = i),
               ),
             ),
@@ -187,6 +204,19 @@ class _HomePageState extends State<HomePage> {
           ],
         ),
       ),
+    );
+  }
+
+  void _openSearchPage() {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const SearchPage()),
+    );
+  }
+
+  void _openSocialTab(int tabIndex) {
+    final int safeIndex = tabIndex.clamp(0, 3).toInt();
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => SocialPage(initialTab: safeIndex)),
     );
   }
 

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -6,6 +6,7 @@ import 'package:badminton_booking_app/pages/court/booking_page.dart';
 import 'package:badminton_booking_app/pages/court/court_page.dart';
 import 'package:badminton_booking_app/pages/court/court_detail.dart';
 import 'package:badminton_booking_app/pages/home/search_page.dart';
+import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/pages/social/social_page.dart';
 import 'package:badminton_booking_app/pages/user/user_booking_history_page.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
@@ -215,6 +216,14 @@ class _HomePageState extends State<HomePage> {
 
   void _openSocialTab(int tabIndex) {
     final int safeIndex = tabIndex.clamp(0, 3).toInt();
+
+    // Nếu đang ở trong NavBarPage thì chuyển tab thay vì push để tránh chồng UI
+    final navState = context.findAncestorStateOfType<NavBarPageState>();
+    if (navState != null) {
+      navState.openSocialTab(safeIndex);
+      return;
+    }
+
     Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => SocialPage(initialTab: safeIndex)),
     );

--- a/lib/pages/nav_bar_page.dart
+++ b/lib/pages/nav_bar_page.dart
@@ -15,12 +15,13 @@ class NavBarPage extends StatefulWidget {
   const NavBarPage({super.key});
 
   @override
-  State<NavBarPage> createState() => _NavBarPageState();
+  State<NavBarPage> createState() => NavBarPageState();
 }
 
-class _NavBarPageState extends State<NavBarPage> {
+class NavBarPageState extends State<NavBarPage> {
   int _index = 0;
   bool _checkingOnboarding = false;
+  final GlobalKey<SocialPageState> _socialPageKey = GlobalKey<SocialPageState>();
 
   late final List<Widget> _pages;
 
@@ -32,11 +33,11 @@ class _NavBarPageState extends State<NavBarPage> {
       _loadAndCheckOnboarding();
     });
 
-    _pages = const [
-      HomePage(),
-      SocialPage(),
-      CourtPage(),
-      ProfilePage(),
+    _pages = [
+      const HomePage(),
+      SocialPage(key: _socialPageKey),
+      const CourtPage(),
+      const ProfilePage(),
     ];
   }
 
@@ -64,6 +65,17 @@ class _NavBarPageState extends State<NavBarPage> {
         ],
       ),
     );
+  }
+
+  void setIndex(int newIndex) {
+    if (newIndex == _index) return;
+    setState(() => _index = newIndex.clamp(0, _pages.length - 1));
+  }
+
+  void openSocialTab(int tabIndex) {
+    final int safeIndex = tabIndex.clamp(0, 3).toInt();
+    _socialPageKey.currentState?.jumpToTab(safeIndex);
+    setState(() => _index = 1);
   }
 
   Future<void> _loadAndCheckOnboarding() async {

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -29,7 +29,12 @@ import '../../models/friend_search_result.dart';
 import '../../models/user_details.dart';
 
 class SocialPage extends StatefulWidget {
-  const SocialPage({super.key});
+  final int initialTab;
+
+  const SocialPage({
+    super.key,
+    this.initialTab = 0,
+  });
 
   @override
   State<SocialPage> createState() => _SocialPageState();
@@ -347,6 +352,7 @@ class _SocialPageState extends State<SocialPage> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
+    final int initialTab = widget.initialTab.clamp(0, 3).toInt();
 
     final manager = context.watch<SocialManager>();
 
@@ -355,6 +361,7 @@ class _SocialPageState extends State<SocialPage> {
 
     return DefaultTabController(
       length: 4,
+      initialIndex: initialTab,
       child: Scaffold(
         backgroundColor: cs.surfaceVariant.withOpacity(0.1),
         appBar: AppBar(

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -37,13 +37,14 @@ class SocialPage extends StatefulWidget {
   });
 
   @override
-  State<SocialPage> createState() => _SocialPageState();
+  State<SocialPage> createState() => SocialPageState();
 }
 
-class _SocialPageState extends State<SocialPage> {
+class SocialPageState extends State<SocialPage> {
   late final PartnerSuggestionManager _partnerManager;
   late final InvitationManager _invitationManager;
   final Set<String> _pendingRequests = <String>{};
+  TabController? _tabController;
 
   @override
   void initState() {
@@ -348,6 +349,13 @@ class _SocialPageState extends State<SocialPage> {
     );
   }
 
+  void jumpToTab(int index) {
+    final controller = _tabController;
+    if (controller == null) return;
+    if (index < 0 || index >= controller.length) return;
+    controller.animateTo(index);
+  }
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -362,151 +370,158 @@ class _SocialPageState extends State<SocialPage> {
     return DefaultTabController(
       length: 4,
       initialIndex: initialTab,
-      child: Scaffold(
-        backgroundColor: cs.surfaceVariant.withOpacity(0.1),
-        appBar: AppBar(
-          title: const Text(
-            'Cộng đồng cầu lông',
-            style: TextStyle(
-                fontSize: 22, fontWeight: FontWeight.w700, letterSpacing: -0.5),
-          ),
-          actions: [
-            IconButton(
-              icon: const Icon(Icons.add_circle_outline_rounded, size: 26),
-              tooltip: 'Đăng bài',
-              onPressed: () => _openCreatePost(context),
-              style: IconButton.styleFrom(
-                foregroundColor: cs.onPrimary,
-                backgroundColor: cs.primary.withOpacity(0.15),
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12)),
+      child: Builder(
+        builder: (context) {
+          _tabController = DefaultTabController.of(context);
+
+          return Scaffold(
+            backgroundColor: cs.surfaceVariant.withOpacity(0.1),
+            appBar: AppBar(
+              title: const Text(
+                'Cộng đồng cầu lông',
+                style: TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.5),
               ),
-            ),
-            const SizedBox(width: 8),
-            IconButton(
-              icon: const Icon(Icons.group_rounded, size: 28),
-              tooltip: 'Tin nhắn',
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => MultiProvider(
-                      providers: [
-                        ChangeNotifierProvider(
-                          create: (_) => FriendRequestManager()..initialize(),
+              actions: [
+                IconButton(
+                  icon: const Icon(Icons.add_circle_outline_rounded, size: 26),
+                  tooltip: 'Đăng bài',
+                  onPressed: () => _openCreatePost(context),
+                  style: IconButton.styleFrom(
+                    foregroundColor: cs.onPrimary,
+                    backgroundColor: cs.primary.withOpacity(0.15),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12)),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton(
+                  icon: const Icon(Icons.group_rounded, size: 28),
+                  tooltip: 'Tin nhắn',
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => MultiProvider(
+                          providers: [
+                            ChangeNotifierProvider(
+                              create: (_) => FriendRequestManager()..initialize(),
+                            ),
+                            ChangeNotifierProvider(
+                              create: (_) => FriendListManager()..initialize(),
+                            ),
+                            ChangeNotifierProvider(
+                              create: (_) => ChatListManager()..initialize(),
+                            ),
+                          ],
+                          child: const ChatHomePage(),
                         ),
-                        ChangeNotifierProvider(
-                          create: (_) => FriendListManager()..initialize(),
-                        ),
-                        ChangeNotifierProvider(
-                          create: (_) => ChatListManager()..initialize(),
-                        ),
+                      ),
+                    );
+                  },
+                  style: IconButton.styleFrom(
+                    foregroundColor: cs.onPrimary,
+                    backgroundColor: cs.primary.withOpacity(0.15),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12)),
+                  ),
+                ),
+                const SizedBox(width: 12),
+              ],
+              bottom: TabBar(
+                isScrollable: true,
+                padding: const EdgeInsets.only(left: 8),
+                labelPadding: const EdgeInsets.only(right: 24),
+                tabs: [
+                  Tab(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: const [
+                        Icon(Icons.people_alt_rounded, size: 20),
+                        SizedBox(width: 8),
+                        Text('Community'),
                       ],
-                      child: const ChatHomePage(),
                     ),
                   ),
-                );
-              },
-              style: IconButton.styleFrom(
-                foregroundColor: cs.onPrimary,
-                backgroundColor: cs.primary.withOpacity(0.15),
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12)),
+                  Tab(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: const [
+                        Icon(Icons.person_search_rounded, size: 20),
+                        SizedBox(width: 8),
+                        Text('Recruitment'),
+                      ],
+                    ),
+                  ),
+                  Tab(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: const [
+                        Icon(Icons.handshake_rounded, size: 20),
+                        SizedBox(width: 8),
+                        Text('Partner'),
+                      ],
+                    ),
+                  ),
+                  Tab(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: const [
+                        Icon(Icons.mail_outline_rounded, size: 20),
+                        SizedBox(width: 8),
+                        Text('Invitations'),
+                      ],
+                    ),
+                  ),
+                ],
+                // các phần còn lại giữ nguyên
+                labelStyle: tt.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  fontSize: 16,
+                ),
+                unselectedLabelStyle: tt.titleMedium?.copyWith(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+                labelColor: cs.onPrimary,
+                unselectedLabelColor: cs.onPrimary.withOpacity(0.75),
+                indicator: BoxDecoration(
+                  borderRadius:
+                      const BorderRadius.vertical(top: Radius.circular(12)),
+                  color: cs.primary.withOpacity(0.3),
+                ),
+                indicatorSize: TabBarIndicatorSize.tab,
+                indicatorColor: Colors.transparent,
+                dividerColor: cs.onPrimary.withOpacity(0.15),
+                overlayColor:
+                    WidgetStateProperty.all(cs.primary.withOpacity(0.1)),
               ),
-            ),
-            const SizedBox(width: 12),
-          ],
-          bottom: TabBar(
-            isScrollable: true,
-            padding: const EdgeInsets.only(
-                left: 8), // hơi cách mép trái 1 chút cho đẹp
-            labelPadding: const EdgeInsets.only(
-                right: 24), // chỉ chừa khoảng cách bên phải mỗi tab
-            tabs: [
-              Tab(
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: const [
-                    Icon(Icons.people_alt_rounded, size: 20),
-                    SizedBox(width: 8),
-                    Text('Community'),
-                  ],
+              flexibleSpace: Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [cs.primary, cs.primary.withOpacity(0.85)],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
                 ),
               ),
-              Tab(
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: const [
-                    Icon(Icons.person_search_rounded, size: 20),
-                    SizedBox(width: 8),
-                    Text('Recruitment'),
-                  ],
-                ),
-              ),
-              Tab(
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: const [
-                    Icon(Icons.handshake_rounded, size: 20),
-                    SizedBox(width: 8),
-                    Text('Partner'),
-                  ],
-                ),
-              ),
-              Tab(
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: const [
-                    Icon(Icons.mail_outline_rounded, size: 20),
-                    SizedBox(width: 8),
-                    Text('Invitations'),
-                  ],
-                ),
-              ),
-            ],
-            // các phần còn lại giữ nguyên
-            labelStyle: tt.titleMedium?.copyWith(
-              fontWeight: FontWeight.w700,
-              fontSize: 16,
+              elevation: 0,
+              scrolledUnderElevation: 0,
+              shadowColor: Colors.transparent,
             ),
-            unselectedLabelStyle: tt.titleMedium?.copyWith(
-              fontSize: 16,
-              fontWeight: FontWeight.w500,
-            ),
-            labelColor: cs.onPrimary,
-            unselectedLabelColor: cs.onPrimary.withOpacity(0.75),
-            indicator: BoxDecoration(
-              borderRadius:
-                  const BorderRadius.vertical(top: Radius.circular(12)),
-              color: cs.primary.withOpacity(0.3),
-            ),
-            indicatorSize: TabBarIndicatorSize.tab,
-            indicatorColor: Colors.transparent,
-            dividerColor: cs.onPrimary.withOpacity(0.15),
-            overlayColor: WidgetStateProperty.all(cs.primary.withOpacity(0.1)),
-          ),
-          flexibleSpace: Container(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [cs.primary, cs.primary.withOpacity(0.85)],
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
+            body: SafeArea(
+              child: TabBarView(
+                children: [
+                  _buildPostsTab(context, manager, avatarUrl),
+                  _buildRecruitmentTab(context, manager),
+                  _buildPartnerSuggestionTab(context, _partnerManager),
+                  _buildCourtInvitesTab(context, _invitationManager),
+                ],
               ),
             ),
-          ),
-          elevation: 0,
-          scrolledUnderElevation: 0,
-          shadowColor: Colors.transparent,
-        ),
-        body: SafeArea(
-          child: TabBarView(
-            children: [
-              _buildPostsTab(context, manager, avatarUrl),
-              _buildRecruitmentTab(context, manager),
-              _buildPartnerSuggestionTab(context, _partnerManager),
-              _buildCourtInvitesTab(context, _invitationManager),
-            ],
-          ),
-        ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add a metadata-driven carousel slide model with CTA support
- update the home carousel to highlight in-app promos for booking, events, and partner search
- allow the social page to open on a specified tab for deep links from the carousel