### PR TITLE
Build manager UI pages

### DIFF
--- a/docs/manager_role_features.md
+++ b/docs/manager_role_features.md
@@ -1,0 +1,88 @@
+# Chức năng dành cho chủ sân (Manager)
+
+Bản thiết kế tính năng dành cho vai trò `manager` – người quản lý cụm sân. Hệ thống hiện tại tự động duyệt booking ngay sau thanh toán, vì vậy module này tập trung vào giám sát, xử lý ngoại lệ và vận hành sân (không có bước duyệt thủ công từng đơn).
+
+## Nguyên tắc điều hướng & phân quyền
+- Khi người dùng đăng nhập có `role = manager`, điều hướng thẳng đến khu vực quản trị chủ sân.
+- Các tab chính: **Dashboard**, **Lịch đặt sân**, **Booking ngoại lệ**, **Booking offline**, **Sân & dịch vụ**, **Giờ & slot đặc biệt**, **Giá sân**, **Báo cáo**.
+- Mọi thao tác thay đổi booking (hủy/đổi giờ/đổi sân/block slot) phải gọi backend để tái kiểm tra trùng slot.
+
+## (1) Dashboard & Lịch đặt sân
+- **Dashboard**: cards tổng quan (doanh thu hôm nay/tuần/tháng, tỷ lệ lấp đầy, tổng booking đã thanh toán, cảnh báo slot bị block). Dùng API analytics hoặc tổng hợp từ `confirmed` bookings.
+- **Lịch đặt sân**: hai chế độ hiển thị
+  - **Bảng**: bộ lọc theo ngày, sân, khung giờ; bảng có cột: sân, giờ bắt đầu–kết thúc, khách, SĐT, trạng thái (confirmed/offline/block), ghi chú.
+  - **Calendar timeline**: mỗi sân là một hàng timeline, slot hiển thị màu theo trạng thái; hỗ trợ click để mở chi tiết booking.
+- Bộ chọn ngày (date picker) mặc định hôm nay; cho phép nhảy nhanh tới ngày khác.
+
+## (2) Quản lý booking (xử lý ngoại lệ)
+- **Hủy booking**: form nhập lý do, gửi request hủy; backend gửi thông báo cho khách. Booking chuyển trạng thái `cancelled_by_manager`.
+- **Đổi giờ/đổi sân**: màn sửa booking với bộ chọn ngày/giờ/sân; khi submit, backend kiểm tra trùng slot và trả booking mới.
+- **Block slot**: chọn sân, ngày, khung giờ, lý do (bảo trì/giải đấu/đóng cửa); slot bị ẩn khỏi người dùng. Cho phép bỏ block.
+- Nhật ký thao tác (audit log) hiển thị gần đây để dễ truy vết.
+
+## (3) Tạo booking offline (khách vãng lai / khách quen)
+- Form tạo nhanh gồm: tên khách, SĐT, ngày, giờ bắt đầu–kết thúc, sân, ghi chú, hình thức thanh toán (tiền mặt/chuyển khoản). 
+- Booking offline tạo với trạng thái `confirmed` và flag `isOffline=true` để thống kê sau này; thanh toán được đánh dấu `paid_offline`.
+- Hệ thống tái sử dụng endpoint tạo booking, nhưng bypass bước thanh toán online và gắn cờ offline.
+
+## (4) Quản lý thông tin sân
+- Trang chỉnh sửa thông tin chung: tên, địa chỉ, mô tả, SĐT, nội quy (rich text hoặc multiline).
+- **Ảnh sân**: upload/đổi/xóa ảnh; xem trước ảnh hiện tại.
+- **Dịch vụ đi kèm**: danh sách dịch vụ (giữ xe, khăn nước, thuê vợt...). Cho phép thêm/xóa/chỉnh sửa giá mô tả; hiển thị bật/tắt dịch vụ.
+
+## (5) Giờ mở cửa & khung giờ đặc biệt
+- **Lịch mở cửa**: cấu hình 7 ngày/tuần (giờ mở–đóng). Hiển thị preview để người quản lý biết slot hợp lệ cho booking.
+- **Ngày nghỉ / đóng cửa đột xuất**: thêm ngày hoặc dải ngày không mở cửa; tất cả slot trong khoảng bị ẩn khỏi người dùng.
+- **Khung giờ đặc biệt**: đánh dấu các dải thời gian dành cho giải đấu/thuê dài hạn; slot này chỉ hiện ở manager view và bị ẩn khỏi đặt mới.
+- UI nên cho phép copy cấu hình từ một ngày sang ngày khác để thao tác nhanh.
+
+## (6) Quản lý giá sân
+- Bảng giá theo khung giờ và ngày trong tuần (map với `court_pricing` backend). 
+- Mỗi entry gồm: sân hoặc loại sân, ngày áp dụng (thứ 2–CN hoặc ngày đặc biệt), khung giờ, giá, nhãn `cao điểm / thấp điểm`.
+- Cho phép sắp xếp ưu tiên: giá đặc biệt > giá theo ngày > giá mặc định. Backend tính giá dựa trên quy tắc ưu tiên.
+- Hỗ trợ nhân bản dòng giá để chỉnh nhanh các khung giờ gần giống.
+
+## (7) Thống kê – báo cáo doanh thu
+- Biểu đồ/đồ thị: doanh thu hôm nay/tuần/tháng; so sánh với kỳ trước.
+- Tỷ lệ lấp đầy: số slot đã đặt / tổng slot mở, theo ngày và theo sân.
+- Danh sách booking đã thanh toán (trạng thái `confirmed`) có thể lọc theo ngày/sân/kênh (online/offline).
+- Xuất báo cáo CSV: doanh thu, booking offline vs online, hiệu suất từng sân.
+
+## Đề xuất luồng UI
+1. **Manager Home** (tab): chứa dashboard và lối tắt tới Lịch, Booking offline, Block slot, Giá.
+2. **Lịch**: toggle bảng/timeline, bộ lọc ngày–sân–trạng thái. Mỗi booking mở modal chi tiết với hành động hủy/đổi/block.
+3. **Booking offline**: form một bước, hiển thị cảnh báo khi trùng slot.
+4. **Sân & dịch vụ**: danh sách sân; bấm vào sân để chỉnh thông tin, ảnh, dịch vụ.
+5. **Giờ & slot đặc biệt**: bảng tuần + danh sách ngày nghỉ + danh sách khung giờ đặc biệt; nút thêm/sửa/xóa.
+6. **Giá sân**: bảng giá, hỗ trợ import/export JSON để khớp backend `court_pricing`.
+7. **Báo cáo**: thẻ KPI + biểu đồ đường/cột + bảng chi tiết có lọc và export.
+
+## Logic & kỹ thuật gợi ý (Flutter)
+- Tạo `ManagerModule` với `ChangeNotifier` hoặc `Riverpod` provider chứa:
+  - `ManagerScheduleState` (lịch/booking), `ManagerCourtState` (thông tin sân, dịch vụ), `PricingState`, `AnalyticsState`.
+  - Hàm helper dùng chung: `fetchSchedule(date)`, `blockSlot()`, `createOfflineBooking()`, `updatePricing()`, `fetchAnalytics(period)`.
+- Component gợi ý:
+  - `manager_dashboard_page.dart`: KPI cards + chart widgets.
+  - `manager_schedule_page.dart`: toggle giữa `DataTable` và `TimelineView` (sử dụng `Syncfusion Calendar` hoặc custom `ListView` theo sân).
+  - `booking_exception_sheet.dart`: modal cho hủy/đổi giờ/đổi sân/block.
+  - `offline_booking_form.dart`: form + validator + gọi API tạo booking offline.
+  - `court_profile_editor.dart`: form thông tin sân + gallery upload + dịch vụ.
+  - `operating_hours_editor.dart`: chỉnh giờ mở cửa và khung giờ đặc biệt.
+  - `pricing_editor.dart`: bảng giá với drag-to-copy khung giờ.
+  - `reports_page.dart`: chart + export CSV (dùng `csv` package).
+- Backend integration: thêm header `X-Manager-Context` hoặc dùng token có role `manager`; tất cả request phải truyền `courtGroupId` (cụm sân) để lấy đúng dữ liệu.
+- Thông báo cho khách: khi hủy hoặc đổi, backend gửi push/SMS; UI chỉ hiển thị kết quả.
+
+## Ma trận quyền & trạng thái
+| Hành động | Trạng thái đầu vào | Trạng thái đầu ra | Ghi chú |
+|---|---|---|---|
+| Hủy booking | confirmed / offline | cancelled_by_manager | Gửi lý do hủy, thông báo khách |
+| Đổi giờ/sân | confirmed / offline | confirmed (slot mới) | Backend kiểm tra trùng, trả về slot mới |
+| Block slot | (slot trống) | blocked | Ẩn khỏi người dùng, hiện trong timeline với nhãn Blocked |
+| Tạo offline | (slot trống) | confirmed + isOffline | Bypass thanh toán online, lưu payment method |
+
+## Phần việc ưu tiên triển khai
+1. Tạo navigation riêng cho `manager` với tab Dashboard – Lịch – Offline – Sân – Giá – Báo cáo.
+2. Hoàn thiện API client: lịch, block slot, offline booking, pricing, analytics.
+3. Dựng UI lịch (bảng + timeline), form offline booking, modal ngoại lệ.
+4. Sau cùng bổ sung báo cáo và export CSV.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:badminton_booking_app/pages/court/favorite_court_manager.dart';
 import 'package:badminton_booking_app/pages/nav_bar_page.dart';
 import 'package:badminton_booking_app/pages/social/social_manager.dart';
 import 'package:badminton_booking_app/pages/user/user_manager.dart';
+import 'package:badminton_booking_app/pages/manager/manager_nav_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
@@ -57,6 +58,9 @@ class AppRoot extends StatelessWidget {
         }
 
         if (authManager.isAuth) {
+          if (authManager.user?.role == 'manager') {
+            return const ManagerNavPage();
+          }
           return const NavBarPage();
         }
 

--- a/lib/pages/manager/manager_court_page.dart
+++ b/lib/pages/manager/manager_court_page.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+class ManagerCourtPage extends StatelessWidget {
+  const ManagerCourtPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final courts = [
+      _CourtProfile(
+        name: 'Sân A1',
+        address: '123 Trần Phú, Quận 5',
+        phone: '0909 888 777',
+        services: const ['Gửi xe', 'Khăn nước', 'Thuê vợt'],
+      ),
+      _CourtProfile(
+        name: 'Sân A2',
+        address: '123 Trần Phú, Quận 5',
+        phone: '0903 111 222',
+        services: const ['Gửi xe', 'Nước suối'],
+      ),
+    ];
+
+    return ListView(
+      children: [
+        const Text(
+          'Thông tin sân',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        ...courts.map((court) => _CourtCard(profile: court)).toList(),
+        const SizedBox(height: 12),
+        Card(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Dịch vụ đi kèm', style: TextStyle(fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  children: const [
+                    _ServiceChip(label: 'Gửi xe • 5.000đ'),
+                    _ServiceChip(label: 'Thuê vợt • 25.000đ'),
+                    _ServiceChip(label: 'Nước suối • 8.000đ'),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                OutlinedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.add_circle_outline),
+                  label: const Text('Thêm dịch vụ'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CourtCard extends StatelessWidget {
+  final _CourtProfile profile;
+
+  const _CourtCard({required this.profile});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(profile.name, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                      const SizedBox(height: 6),
+                      Text(profile.address),
+                      const SizedBox(height: 4),
+                      Text('SĐT: ${profile.phone}'),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Chỉnh sửa',
+                  icon: const Icon(Icons.edit_outlined),
+                  onPressed: () {},
+                )
+              ],
+            ),
+            const SizedBox(height: 12),
+            const Text('Mô tả & nội quy'),
+            const SizedBox(height: 6),
+            Text(
+              'Giữ sạch sân, không mang giày đinh. Check-in trước 10 phút. Có nước uống và khăn lạnh tại quầy.',
+              style: TextStyle(color: Colors.grey.shade800),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 6,
+              children: profile.services.map((s) => Chip(label: Text(s))).toList(),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                OutlinedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.image_outlined),
+                  label: const Text('Cập nhật hình ảnh'),
+                ),
+                const SizedBox(width: 8),
+                OutlinedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.rule_folder_outlined),
+                  label: const Text('Nội quy chi tiết'),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CourtProfile {
+  final String name;
+  final String address;
+  final String phone;
+  final List<String> services;
+
+  _CourtProfile({
+    required this.name,
+    required this.address,
+    required this.phone,
+    required this.services,
+  });
+}
+
+class _ServiceChip extends StatelessWidget {
+  final String label;
+
+  const _ServiceChip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      label: Text(label),
+      avatar: const Icon(Icons.miscellaneous_services, size: 16),
+    );
+  }
+}

--- a/lib/pages/manager/manager_dashboard_page.dart
+++ b/lib/pages/manager/manager_dashboard_page.dart
@@ -116,12 +116,13 @@ class _KpiCard extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
             Text(
               title,
               style: const TextStyle(fontWeight: FontWeight.w600),
             ),
-            const Spacer(),
+            const SizedBox(height: 12),
             Text(
               value,
               style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),

--- a/lib/pages/manager/manager_dashboard_page.dart
+++ b/lib/pages/manager/manager_dashboard_page.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+
+class ManagerDashboardPage extends StatelessWidget {
+  const ManagerDashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cards = [
+      _KpiCard(title: 'Doanh thu hôm nay', value: '12.450.000₫', trend: '+8%'),
+      _KpiCard(title: 'Tỷ lệ lấp đầy', value: '82%', trend: '+5%'),
+      _KpiCard(title: 'Booking đã thanh toán', value: '46', trend: '+3%'),
+      _KpiCard(title: 'Slot bị block', value: '2', trend: 'Sự kiện giải đấu'),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth > 900;
+        final crossAxisCount = isWide ? 4 : 2;
+
+        return ListView(
+          children: [
+            const Text(
+              'Tổng quan nhanh',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            GridView.count(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              crossAxisCount: crossAxisCount,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+              childAspectRatio: 1.4,
+              children: cards,
+            ),
+            const SizedBox(height: 16),
+            _SectionCard(
+              title: 'Lịch hôm nay',
+              actionText: 'Xem chi tiết',
+              onAction: () {},
+              child: Column(
+                children: const [
+                  _ScheduleRow(
+                    court: 'Sân 1',
+                    time: '06:00 - 07:30',
+                    customer: 'Nguyễn Minh',
+                    status: 'Confirmed',
+                    statusColor: Colors.green,
+                  ),
+                  _ScheduleRow(
+                    court: 'Sân 2',
+                    time: '08:00 - 10:00',
+                    customer: 'Trần Thảo',
+                    status: 'Offline',
+                    statusColor: Colors.orange,
+                  ),
+                  _ScheduleRow(
+                    court: 'Sân 3',
+                    time: '10:00 - 12:00',
+                    customer: 'CLB Đồng Đội',
+                    status: 'Blocked',
+                    statusColor: Colors.red,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            _SectionCard(
+              title: 'Thông báo vận hành',
+              actionText: 'Quản lý slot',
+              onAction: () {},
+              child: Column(
+                children: const [
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: Icon(Icons.warning_amber_outlined, color: Colors.orange),
+                    title: Text('Sân 3 block 10:00 - 12:00 (Giải phong trào)'),
+                    subtitle: Text('Ẩn với người dùng, chỉ hiển thị ở manager view'),
+                  ),
+                  Divider(height: 1),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: Icon(Icons.analytics_outlined),
+                    title: Text('Tỷ lệ lấp đầy tuần này đạt 82%'),
+                    subtitle: Text('Giảm 3% so với tuần trước'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _KpiCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final String trend;
+
+  const _KpiCard({
+    required this.title,
+    required this.value,
+    required this.trend,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      elevation: 0,
+      color: colorScheme.primaryContainer.withOpacity(0.35),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            const Spacer(),
+            Text(
+              value,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(Icons.trending_up, color: colorScheme.primary, size: 18),
+                const SizedBox(width: 6),
+                Text(trend, style: TextStyle(color: colorScheme.primary)),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  final String title;
+  final String? actionText;
+  final VoidCallback? onAction;
+  final Widget child;
+
+  const _SectionCard({
+    required this.title,
+    required this.child,
+    this.actionText,
+    this.onAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    title,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                if (actionText != null)
+                  TextButton(
+                    onPressed: onAction,
+                    child: Text(actionText!),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ScheduleRow extends StatelessWidget {
+  final String court;
+  final String time;
+  final String customer;
+  final String status;
+  final Color statusColor;
+
+  const _ScheduleRow({
+    required this.court,
+    required this.time,
+    required this.customer,
+    required this.status,
+    required this.statusColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Row(
+        children: [
+          SizedBox(width: 90, child: Text(court, style: const TextStyle(fontWeight: FontWeight.w600))),
+          Expanded(child: Text(time)),
+          Expanded(child: Text(customer)),
+          Chip(
+            label: Text(status),
+            side: BorderSide(color: statusColor.withOpacity(0.6)),
+            backgroundColor: statusColor.withOpacity(0.1),
+            labelStyle: TextStyle(color: statusColor),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/manager/manager_dashboard_page.dart
+++ b/lib/pages/manager/manager_dashboard_page.dart
@@ -16,6 +16,12 @@ class ManagerDashboardPage extends StatelessWidget {
       builder: (context, constraints) {
         final isWide = constraints.maxWidth > 900;
         final crossAxisCount = isWide ? 4 : 2;
+        final horizontalSpacing = 12.0;
+        final availableWidth = constraints.maxWidth -
+            (crossAxisCount - 1) * horizontalSpacing;
+        final cardWidth = availableWidth / crossAxisCount;
+        final targetHeight = isWide ? 140.0 : 170.0;
+        final childAspectRatio = cardWidth / targetHeight;
 
         return ListView(
           children: [
@@ -28,9 +34,9 @@ class ManagerDashboardPage extends StatelessWidget {
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),
               crossAxisCount: crossAxisCount,
-              crossAxisSpacing: 12,
+              crossAxisSpacing: horizontalSpacing,
               mainAxisSpacing: 12,
-              childAspectRatio: 1.4,
+              childAspectRatio: childAspectRatio,
               children: cards,
             ),
             const SizedBox(height: 16),

--- a/lib/pages/manager/manager_nav_page.dart
+++ b/lib/pages/manager/manager_nav_page.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+
+import 'manager_dashboard_page.dart';
+import 'manager_schedule_page.dart';
+import 'manager_offline_booking_page.dart';
+import 'manager_court_page.dart';
+import 'manager_operating_hours_page.dart';
+import 'manager_pricing_page.dart';
+import 'manager_reports_page.dart';
+
+class ManagerNavPage extends StatefulWidget {
+  const ManagerNavPage({super.key});
+
+  @override
+  State<ManagerNavPage> createState() => _ManagerNavPageState();
+}
+
+class _ManagerNavPageState extends State<ManagerNavPage> {
+  int _selectedIndex = 0;
+
+  late final List<_ManagerTab> _tabs;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabs = [
+      _ManagerTab(
+        label: 'Dashboard',
+        icon: Icons.dashboard_outlined,
+        builder: (context) => const ManagerDashboardPage(),
+      ),
+      _ManagerTab(
+        label: 'Lịch',
+        icon: Icons.calendar_month_outlined,
+        builder: (context) => const ManagerSchedulePage(),
+      ),
+      _ManagerTab(
+        label: 'Booking offline',
+        icon: Icons.phone_forwarded_outlined,
+        builder: (context) => const ManagerOfflineBookingPage(),
+      ),
+      _ManagerTab(
+        label: 'Sân & dịch vụ',
+        icon: Icons.sports_tennis_outlined,
+        builder: (context) => const ManagerCourtPage(),
+      ),
+      _ManagerTab(
+        label: 'Giờ & slot',
+        icon: Icons.schedule_outlined,
+        builder: (context) => const ManagerOperatingHoursPage(),
+      ),
+      _ManagerTab(
+        label: 'Giá sân',
+        icon: Icons.price_change_outlined,
+        builder: (context) => const ManagerPricingPage(),
+      ),
+      _ManagerTab(
+        label: 'Báo cáo',
+        icon: Icons.show_chart_outlined,
+        builder: (context) => const ManagerReportsPage(),
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentTab = _tabs[_selectedIndex];
+    final isWide = MediaQuery.of(context).size.width > 960;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(currentTab.label),
+        actions: [
+          IconButton(
+            tooltip: 'Làm mới',
+            icon: const Icon(Icons.refresh_outlined),
+            onPressed: () {
+              setState(() {});
+            },
+          ),
+        ],
+      ),
+      body: Row(
+        children: [
+          if (isWide) _buildSideRail(context),
+          Expanded(
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 250),
+              child: IndexedStack(
+                index: _selectedIndex,
+                children: _tabs
+                    .map((tab) => Padding(
+                          key: ValueKey(tab.label),
+                          padding: const EdgeInsets.all(16),
+                          child: tab.builder(context),
+                        ))
+                    .toList(),
+              ),
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: isWide ? null : _buildBottomBar(context),
+    );
+  }
+
+  Widget _buildSideRail(BuildContext context) {
+    return NavigationRail(
+      selectedIndex: _selectedIndex,
+      onDestinationSelected: (index) => setState(() => _selectedIndex = index),
+      labelType: NavigationRailLabelType.all,
+      destinations: _tabs
+          .map(
+            (tab) => NavigationRailDestination(
+              icon: Icon(tab.icon),
+              selectedIcon: Icon(tab.icon, color: Theme.of(context).primaryColor),
+              label: Text(tab.label),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  Widget _buildBottomBar(BuildContext context) {
+    return NavigationBar(
+      selectedIndex: _selectedIndex,
+      onDestinationSelected: (index) => setState(() => _selectedIndex = index),
+      destinations: _tabs
+          .map(
+            (tab) => NavigationDestination(
+              icon: Icon(tab.icon),
+              label: tab.label,
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _ManagerTab {
+  final String label;
+  final IconData icon;
+  final WidgetBuilder builder;
+
+  _ManagerTab({
+    required this.label,
+    required this.icon,
+    required this.builder,
+  });
+}

--- a/lib/pages/manager/manager_nav_page.dart
+++ b/lib/pages/manager/manager_nav_page.dart
@@ -80,9 +80,38 @@ class _ManagerNavPageState extends State<ManagerNavPage> {
           ),
         ],
       ),
+      drawer: isWide
+          ? null
+          : Drawer(
+              child: SafeArea(
+                child: _DrawerList(
+                  tabs: _tabs,
+                  selectedIndex: _selectedIndex,
+                  onSelect: (index) {
+                    setState(() => _selectedIndex = index);
+                    Navigator.of(context).pop();
+                  },
+                ),
+              ),
+            ),
       body: Row(
         children: [
-          if (isWide) _buildSideRail(context),
+          if (isWide)
+            NavigationDrawer(
+              selectedIndex: _selectedIndex,
+              onDestinationSelected: (index) =>
+                  setState(() => _selectedIndex = index),
+              children: _tabs
+                  .map(
+                    (tab) => NavigationDrawerDestination(
+                      icon: Icon(tab.icon),
+                      selectedIcon:
+                          Icon(tab.icon, color: Theme.of(context).primaryColor),
+                      label: Text(tab.label),
+                    ),
+                  )
+                  .toList(),
+            ),
           Expanded(
             child: AnimatedSwitcher(
               duration: const Duration(milliseconds: 250),
@@ -100,39 +129,50 @@ class _ManagerNavPageState extends State<ManagerNavPage> {
           ),
         ],
       ),
-      bottomNavigationBar: isWide ? null : _buildBottomBar(context),
     );
   }
+}
 
-  Widget _buildSideRail(BuildContext context) {
-    return NavigationRail(
-      selectedIndex: _selectedIndex,
-      onDestinationSelected: (index) => setState(() => _selectedIndex = index),
-      labelType: NavigationRailLabelType.all,
-      destinations: _tabs
-          .map(
-            (tab) => NavigationRailDestination(
-              icon: Icon(tab.icon),
-              selectedIcon: Icon(tab.icon, color: Theme.of(context).primaryColor),
-              label: Text(tab.label),
-            ),
-          )
-          .toList(),
-    );
-  }
+class _DrawerList extends StatelessWidget {
+  const _DrawerList({
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onSelect,
+  });
 
-  Widget _buildBottomBar(BuildContext context) {
-    return NavigationBar(
-      selectedIndex: _selectedIndex,
-      onDestinationSelected: (index) => setState(() => _selectedIndex = index),
-      destinations: _tabs
-          .map(
-            (tab) => NavigationDestination(
-              icon: Icon(tab.icon),
-              label: tab.label,
-            ),
-          )
-          .toList(),
+  final List<_ManagerTab> tabs;
+  final int selectedIndex;
+  final ValueChanged<int> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            'Chủ sân',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+        ),
+        ...tabs.indexed.map(
+          (entry) {
+            final index = entry.$1;
+            final tab = entry.$2;
+            final isSelected = index == selectedIndex;
+            return ListTile(
+              leading: Icon(tab.icon,
+                  color: isSelected
+                      ? Theme.of(context).colorScheme.primary
+                      : null),
+              title: Text(tab.label),
+              selected: isSelected,
+              onTap: () => onSelect(index),
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/manager/manager_offline_booking_page.dart
+++ b/lib/pages/manager/manager_offline_booking_page.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+
+class ManagerOfflineBookingPage extends StatefulWidget {
+  const ManagerOfflineBookingPage({super.key});
+
+  @override
+  State<ManagerOfflineBookingPage> createState() => _ManagerOfflineBookingPageState();
+}
+
+class _ManagerOfflineBookingPageState extends State<ManagerOfflineBookingPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _noteController = TextEditingController();
+  DateTime _selectedDate = DateTime.now();
+  TimeOfDay _start = const TimeOfDay(hour: 7, minute: 0);
+  TimeOfDay _end = const TimeOfDay(hour: 9, minute: 0);
+  String _court = 'Sân 1';
+  String _paymentMethod = 'Tiền mặt';
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _phoneController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Card(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Tạo booking offline',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 16,
+                  runSpacing: 12,
+                  children: [
+                    _buildTextField(
+                      controller: _nameController,
+                      label: 'Tên khách',
+                      validator: (v) => (v == null || v.isEmpty) ? 'Nhập tên khách' : null,
+                    ),
+                    _buildTextField(
+                      controller: _phoneController,
+                      label: 'Số điện thoại',
+                      keyboardType: TextInputType.phone,
+                      validator: (v) => (v == null || v.isEmpty) ? 'Nhập SĐT' : null,
+                    ),
+                    _buildPickerField(
+                      label: 'Ngày',
+                      value: '${_selectedDate.day}/${_selectedDate.month}/${_selectedDate.year}',
+                      onTap: _pickDate,
+                    ),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _buildPickerField(
+                          label: 'Giờ bắt đầu',
+                          value: _start.format(context),
+                          onTap: () => _pickTime(isStart: true),
+                        ),
+                        const SizedBox(width: 12),
+                        _buildPickerField(
+                          label: 'Giờ kết thúc',
+                          value: _end.format(context),
+                          onTap: () => _pickTime(isStart: false),
+                        ),
+                      ],
+                    ),
+                    DropdownButtonFormField<String>(
+                      value: _court,
+                      decoration: const InputDecoration(labelText: 'Chọn sân'),
+                      items: const [
+                        DropdownMenuItem(value: 'Sân 1', child: Text('Sân 1')),
+                        DropdownMenuItem(value: 'Sân 2', child: Text('Sân 2')),
+                        DropdownMenuItem(value: 'Sân 3', child: Text('Sân 3')),
+                      ],
+                      onChanged: (value) => setState(() => _court = value ?? 'Sân 1'),
+                    ),
+                    DropdownButtonFormField<String>(
+                      value: _paymentMethod,
+                      decoration: const InputDecoration(labelText: 'Hình thức thanh toán'),
+                      items: const [
+                        DropdownMenuItem(value: 'Tiền mặt', child: Text('Tiền mặt')),
+                        DropdownMenuItem(value: 'Chuyển khoản', child: Text('Chuyển khoản')),
+                      ],
+                      onChanged: (value) => setState(() => _paymentMethod = value ?? 'Tiền mặt'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _noteController,
+                  maxLines: 3,
+                  decoration: const InputDecoration(labelText: 'Ghi chú / nhu cầu đặc biệt'),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    FilledButton.icon(
+                      onPressed: _submit,
+                      icon: const Icon(Icons.check_circle_outline),
+                      label: const Text('Tạo booking'),
+                    ),
+                    const SizedBox(width: 12),
+                    OutlinedButton.icon(
+                      onPressed: () => _formKey.currentState?.reset(),
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Làm mới'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                const Divider(),
+                const SizedBox(height: 12),
+                const Text(
+                  'Lịch sử gần đây',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8),
+                ...const [
+                  _OfflineHistoryTile(name: 'Đặng Khoa', time: 'Hôm qua • Sân 2 • 18:00 - 20:00', payment: 'Tiền mặt'),
+                  _OfflineHistoryTile(name: 'CLB Z', time: 'Tuần trước • Sân 1 • 06:00 - 08:00', payment: 'Chuyển khoản'),
+                ]
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTextField({
+    required TextEditingController controller,
+    required String label,
+    TextInputType? keyboardType,
+    String? Function(String?)? validator,
+  }) {
+    return SizedBox(
+      width: 260,
+      child: TextFormField(
+        controller: controller,
+        keyboardType: keyboardType,
+        decoration: InputDecoration(labelText: label),
+        validator: validator,
+      ),
+    );
+  }
+
+  Widget _buildPickerField({required String label, required String value, required VoidCallback onTap}) {
+    return SizedBox(
+      width: 200,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: InputDecorator(
+          decoration: InputDecoration(labelText: label),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: Text(value),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+    if (picked != null) setState(() => _selectedDate = picked);
+  }
+
+  Future<void> _pickTime({required bool isStart}) async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: isStart ? _start : _end,
+    );
+    if (picked == null) return;
+    setState(() {
+      if (isStart) {
+        _start = picked;
+      } else {
+        _end = picked;
+      }
+    });
+  }
+
+  void _submit() {
+    if (_formKey.currentState?.validate() != true) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Đã tạo booking offline cho $_court (${_start.format(context)} - ${_end.format(context)})'),
+      ),
+    );
+  }
+}
+
+class _OfflineHistoryTile extends StatelessWidget {
+  final String name;
+  final String time;
+  final String payment;
+
+  const _OfflineHistoryTile({required this.name, required this.time, required this.payment});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: const CircleAvatar(child: Icon(Icons.person)),
+      title: Text(name, style: const TextStyle(fontWeight: FontWeight.w600)),
+      subtitle: Text(time),
+      trailing: Chip(
+        label: Text(payment),
+        avatar: const Icon(Icons.payments_outlined),
+      ),
+    );
+  }
+}

--- a/lib/pages/manager/manager_offline_booking_page.dart
+++ b/lib/pages/manager/manager_offline_booking_page.dart
@@ -63,15 +63,15 @@ class _ManagerOfflineBookingPageState extends State<ManagerOfflineBookingPage> {
                       value: '${_selectedDate.day}/${_selectedDate.month}/${_selectedDate.year}',
                       onTap: _pickDate,
                     ),
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
+                    Wrap(
+                      spacing: 12,
+                      runSpacing: 12,
                       children: [
                         _buildPickerField(
                           label: 'Giờ bắt đầu',
                           value: _start.format(context),
                           onTap: () => _pickTime(isStart: true),
                         ),
-                        const SizedBox(width: 12),
                         _buildPickerField(
                           label: 'Giờ kết thúc',
                           value: _end.format(context),

--- a/lib/pages/manager/manager_operating_hours_page.dart
+++ b/lib/pages/manager/manager_operating_hours_page.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+
+class ManagerOperatingHoursPage extends StatelessWidget {
+  const ManagerOperatingHoursPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final weekly = [
+      _OperatingHour(day: 'Thứ 2', open: '06:00', close: '22:00'),
+      _OperatingHour(day: 'Thứ 3', open: '06:00', close: '22:00'),
+      _OperatingHour(day: 'Thứ 4', open: '06:00', close: '22:00'),
+      _OperatingHour(day: 'Thứ 5', open: '06:00', close: '22:00'),
+      _OperatingHour(day: 'Thứ 6', open: '06:00', close: '22:00'),
+      _OperatingHour(day: 'Thứ 7', open: '06:00', close: '23:00'),
+      _OperatingHour(day: 'Chủ nhật', open: '07:00', close: '23:00'),
+    ];
+
+    final closures = [
+      _ClosureRange(label: 'Nghỉ lễ 2/9', range: '01/09 - 02/09'),
+      _ClosureRange(label: 'Bảo trì điện', range: '15/10 (cả ngày)'),
+    ];
+
+    final specialSlots = [
+      _SpecialSlot(label: 'Giải phong trào CLB', time: 'Sân 3 • 10:00 - 12:00 • 12/10'),
+      _SpecialSlot(label: 'Thuê dài hạn', time: 'Sân 1 • Thứ 3 & 5 • 18:00 - 20:00'),
+    ];
+
+    return ListView(
+      children: [
+        const Text('Giờ mở cửa 7 ngày', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+        const SizedBox(height: 12),
+        Card(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          child: Column(
+            children: weekly
+                .map(
+                  (item) => ListTile(
+                    title: Text(item.day),
+                    subtitle: Text('${item.open} - ${item.close}'),
+                    trailing: IconButton(
+                      onPressed: () {},
+                      icon: const Icon(Icons.edit_outlined),
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Card(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Text('Ngày nghỉ / đóng cửa', style: TextStyle(fontWeight: FontWeight.bold)),
+                    ),
+                    TextButton.icon(
+                      onPressed: () {},
+                      icon: const Icon(Icons.add_circle_outline),
+                      label: const Text('Thêm ngày nghỉ'),
+                    )
+                  ],
+                ),
+                const SizedBox(height: 8),
+                ...closures
+                    .map(
+                      (closure) => ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: const Icon(Icons.event_busy_outlined),
+                        title: Text(closure.label),
+                        subtitle: Text(closure.range),
+                        trailing: IconButton(
+                          onPressed: () {},
+                          icon: const Icon(Icons.delete_outline),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Card(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Text('Khung giờ đặc biệt', style: TextStyle(fontWeight: FontWeight.bold)),
+                    ),
+                    TextButton.icon(
+                      onPressed: () {},
+                      icon: const Icon(Icons.add_alert_outlined),
+                      label: const Text('Thêm khung giờ'),
+                    )
+                  ],
+                ),
+                const SizedBox(height: 8),
+                ...specialSlots
+                    .map(
+                      (slot) => ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: const Icon(Icons.block_outlined),
+                        title: Text(slot.label),
+                        subtitle: Text(slot.time),
+                        trailing: IconButton(
+                          onPressed: () {},
+                          icon: const Icon(Icons.edit_calendar_outlined),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OperatingHour {
+  final String day;
+  final String open;
+  final String close;
+
+  _OperatingHour({required this.day, required this.open, required this.close});
+}
+
+class _ClosureRange {
+  final String label;
+  final String range;
+
+  _ClosureRange({required this.label, required this.range});
+}
+
+class _SpecialSlot {
+  final String label;
+  final String time;
+
+  _SpecialSlot({required this.label, required this.time});
+}

--- a/lib/pages/manager/manager_pricing_page.dart
+++ b/lib/pages/manager/manager_pricing_page.dart
@@ -12,70 +12,101 @@ class ManagerPricingPage extends StatelessWidget {
       _PriceRow(label: 'Giải đấu 12/10', day: '12/10', time: 'Cả ngày', price: 'Block', tag: 'Sự kiện'),
     ];
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth >= 600;
+
+        final actionButtons = Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          alignment: isWide ? WrapAlignment.end : WrapAlignment.start,
           children: [
-            const Text('Bảng giá sân', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-            const Spacer(),
             OutlinedButton.icon(
               onPressed: () {},
               icon: const Icon(Icons.upload_file_outlined),
               label: const Text('Import/Export JSON'),
             ),
-            const SizedBox(width: 8),
             FilledButton.icon(
               onPressed: () {},
               icon: const Icon(Icons.add),
               label: const Text('Thêm dòng giá'),
             ),
           ],
-        ),
-        const SizedBox(height: 12),
-        Expanded(
-          child: Card(
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-            child: ListView.separated(
-              padding: const EdgeInsets.all(16),
-              itemBuilder: (context, index) {
-                final row = pricing[index];
-                return ListTile(
-                  leading: const Icon(Icons.price_change_outlined),
-                  title: Text(row.label, style: const TextStyle(fontWeight: FontWeight.bold)),
-                  subtitle: Text('${row.day} • ${row.time}'),
-                  trailing: Wrap(
-                    spacing: 8,
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    children: [
-                      Chip(
-                        label: Text(row.tag),
-                        avatar: const Icon(Icons.bolt, size: 16),
-                      ),
-                      Chip(
-                        label: Text(row.price),
-                        backgroundColor: Colors.green.shade50,
-                      ),
-                      IconButton(
-                        onPressed: () {},
-                        icon: const Icon(Icons.copy_outlined),
-                        tooltip: 'Nhân bản',
-                      ),
-                      IconButton(
-                        onPressed: () {},
-                        icon: const Icon(Icons.edit_outlined),
-                        tooltip: 'Chỉnh sửa',
-                      ),
-                    ],
+        );
+
+        final header = isWide
+            ? Row(
+                children: [
+                  const Text(
+                    'Bảng giá sân',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                   ),
-                );
-              },
-              separatorBuilder: (_, __) => const Divider(),
-              itemCount: pricing.length,
+                  const Spacer(),
+                  actionButtons,
+                ],
+              )
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Bảng giá sân',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 12),
+                  actionButtons,
+                ],
+              );
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            header,
+            const SizedBox(height: 12),
+            Expanded(
+              child: Card(
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                child: ListView.separated(
+                  padding: const EdgeInsets.all(16),
+                  itemBuilder: (context, index) {
+                    final row = pricing[index];
+                    return ListTile(
+                      leading: const Icon(Icons.price_change_outlined),
+                      title: Text(row.label, style: const TextStyle(fontWeight: FontWeight.bold)),
+                      subtitle: Text('${row.day} • ${row.time}'),
+                      trailing: Wrap(
+                        spacing: 8,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          Chip(
+                            label: Text(row.tag),
+                            avatar: const Icon(Icons.bolt, size: 16),
+                          ),
+                          Chip(
+                            label: Text(row.price),
+                            backgroundColor: Colors.green.shade50,
+                          ),
+                          IconButton(
+                            onPressed: () {},
+                            icon: const Icon(Icons.copy_outlined),
+                            tooltip: 'Nhân bản',
+                          ),
+                          IconButton(
+                            onPressed: () {},
+                            icon: const Icon(Icons.edit_outlined),
+                            tooltip: 'Chỉnh sửa',
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                  separatorBuilder: (_, __) => const Divider(),
+                  itemCount: pricing.length,
+                ),
+              ),
             ),
-          ),
-        ),
-      ],
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/pages/manager/manager_pricing_page.dart
+++ b/lib/pages/manager/manager_pricing_page.dart
@@ -58,42 +58,62 @@ class ManagerPricingPage extends StatelessWidget {
             Expanded(
               child: Card(
                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                child: ListView.separated(
-                  padding: const EdgeInsets.all(16),
-                  itemBuilder: (context, index) {
-                    final row = pricing[index];
-                    return ListTile(
-                      leading: const Icon(Icons.price_change_outlined),
-                      title: Text(row.label, style: const TextStyle(fontWeight: FontWeight.bold)),
-                      subtitle: Text('${row.day} • ${row.time}'),
-                      trailing: Wrap(
-                        spacing: 8,
-                        crossAxisAlignment: WrapCrossAlignment.center,
-                        children: [
-                          Chip(
-                            label: Text(row.tag),
-                            avatar: const Icon(Icons.bolt, size: 16),
-                          ),
-                          Chip(
-                            label: Text(row.price),
-                            backgroundColor: Colors.green.shade50,
-                          ),
-                          IconButton(
-                            onPressed: () {},
-                            icon: const Icon(Icons.copy_outlined),
-                            tooltip: 'Nhân bản',
-                          ),
-                          IconButton(
-                            onPressed: () {},
-                            icon: const Icon(Icons.edit_outlined),
-                            tooltip: 'Chỉnh sửa',
-                          ),
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(minWidth: constraints.maxWidth),
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.all(16),
+                      child: DataTable(
+                        columns: const [
+                          DataColumn(label: Text('Loại sân')),
+                          DataColumn(label: Text('Ngày áp dụng')),
+                          DataColumn(label: Text('Khung giờ')),
+                          DataColumn(label: Text('Loại giá')),
+                          DataColumn(label: Text('Giá')), 
+                          DataColumn(label: Text('Thao tác')),
                         ],
+                        rows: pricing.map((row) {
+                          return DataRow(
+                            cells: [
+                              DataCell(Text(row.label, style: const TextStyle(fontWeight: FontWeight.bold))),
+                              DataCell(Text(row.day)),
+                              DataCell(Text(row.time)),
+                              DataCell(
+                                Chip(
+                                  label: Text(row.tag),
+                                  avatar: const Icon(Icons.bolt, size: 16),
+                                ),
+                              ),
+                              DataCell(
+                                Chip(
+                                  label: Text(row.price),
+                                  backgroundColor: Colors.green.shade50,
+                                ),
+                              ),
+                              DataCell(
+                                Wrap(
+                                  spacing: 8,
+                                  children: [
+                                    IconButton(
+                                      onPressed: () {},
+                                      icon: const Icon(Icons.copy_outlined),
+                                      tooltip: 'Nhân bản',
+                                    ),
+                                    IconButton(
+                                      onPressed: () {},
+                                      icon: const Icon(Icons.edit_outlined),
+                                      tooltip: 'Chỉnh sửa',
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          );
+                        }).toList(),
                       ),
-                    );
-                  },
-                  separatorBuilder: (_, __) => const Divider(),
-                  itemCount: pricing.length,
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/lib/pages/manager/manager_pricing_page.dart
+++ b/lib/pages/manager/manager_pricing_page.dart
@@ -14,12 +14,10 @@ class ManagerPricingPage extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final isWide = constraints.maxWidth >= 600;
-
         final actionButtons = Wrap(
           spacing: 8,
           runSpacing: 8,
-          alignment: isWide ? WrapAlignment.end : WrapAlignment.start,
+          alignment: WrapAlignment.end,
           children: [
             OutlinedButton.icon(
               onPressed: () {},
@@ -34,28 +32,22 @@ class ManagerPricingPage extends StatelessWidget {
           ],
         );
 
-        final header = isWide
-            ? Row(
-                children: [
-                  const Text(
-                    'Bảng giá sân',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                  ),
-                  const Spacer(),
-                  actionButtons,
-                ],
-              )
-            : Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    'Bảng giá sân',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 12),
-                  actionButtons,
-                ],
-              );
+        final header = SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minWidth: constraints.maxWidth),
+            child: Row(
+              children: [
+                const Text(
+                  'Bảng giá sân',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                const Spacer(),
+                actionButtons,
+              ],
+            ),
+          ),
+        );
 
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/pages/manager/manager_pricing_page.dart
+++ b/lib/pages/manager/manager_pricing_page.dart
@@ -63,7 +63,7 @@ class ManagerPricingPage extends StatelessWidget {
                   child: ConstrainedBox(
                     constraints: BoxConstraints(minWidth: constraints.maxWidth),
                     child: SingleChildScrollView(
-                      padding: const EdgeInsets.all(16),
+                      padding: const EdgeInsets.symmetric(vertical: 16),
                       child: DataTable(
                         columns: const [
                           DataColumn(label: Text('Loại sân')),

--- a/lib/pages/manager/manager_pricing_page.dart
+++ b/lib/pages/manager/manager_pricing_page.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+class ManagerPricingPage extends StatelessWidget {
+  const ManagerPricingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final pricing = [
+      _PriceRow(label: 'Sân tiêu chuẩn', day: 'Thứ 2 - Thứ 6', time: '06:00 - 17:00', price: '120.000đ', tag: 'Thấp điểm'),
+      _PriceRow(label: 'Sân tiêu chuẩn', day: 'Thứ 2 - Thứ 6', time: '17:00 - 22:00', price: '180.000đ', tag: 'Cao điểm'),
+      _PriceRow(label: 'Sân VIP', day: 'Thứ 7, CN', time: '06:00 - 22:00', price: '220.000đ', tag: 'Cao điểm'),
+      _PriceRow(label: 'Giải đấu 12/10', day: '12/10', time: 'Cả ngày', price: 'Block', tag: 'Sự kiện'),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Text('Bảng giá sân', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const Spacer(),
+            OutlinedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.upload_file_outlined),
+              label: const Text('Import/Export JSON'),
+            ),
+            const SizedBox(width: 8),
+            FilledButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('Thêm dòng giá'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Expanded(
+          child: Card(
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemBuilder: (context, index) {
+                final row = pricing[index];
+                return ListTile(
+                  leading: const Icon(Icons.price_change_outlined),
+                  title: Text(row.label, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  subtitle: Text('${row.day} • ${row.time}'),
+                  trailing: Wrap(
+                    spacing: 8,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      Chip(
+                        label: Text(row.tag),
+                        avatar: const Icon(Icons.bolt, size: 16),
+                      ),
+                      Chip(
+                        label: Text(row.price),
+                        backgroundColor: Colors.green.shade50,
+                      ),
+                      IconButton(
+                        onPressed: () {},
+                        icon: const Icon(Icons.copy_outlined),
+                        tooltip: 'Nhân bản',
+                      ),
+                      IconButton(
+                        onPressed: () {},
+                        icon: const Icon(Icons.edit_outlined),
+                        tooltip: 'Chỉnh sửa',
+                      ),
+                    ],
+                  ),
+                );
+              },
+              separatorBuilder: (_, __) => const Divider(),
+              itemCount: pricing.length,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PriceRow {
+  final String label;
+  final String day;
+  final String time;
+  final String price;
+  final String tag;
+
+  _PriceRow({
+    required this.label,
+    required this.day,
+    required this.time,
+    required this.price,
+    required this.tag,
+  });
+}

--- a/lib/pages/manager/manager_pricing_page.dart
+++ b/lib/pages/manager/manager_pricing_page.dart
@@ -37,12 +37,13 @@ class ManagerPricingPage extends StatelessWidget {
           child: ConstrainedBox(
             constraints: BoxConstraints(minWidth: constraints.maxWidth),
             child: Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
                 const Text(
                   'Bảng giá sân',
                   style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),
-                const Spacer(),
+                const SizedBox(width: 24),
                 actionButtons,
               ],
             ),

--- a/lib/pages/manager/manager_reports_page.dart
+++ b/lib/pages/manager/manager_reports_page.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+
+class ManagerReportsPage extends StatelessWidget {
+  const ManagerReportsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = [
+      _ReportCard(title: 'Doanh thu hôm nay', value: '12.450.000₫', note: '+8% so với hôm qua'),
+      _ReportCard(title: 'Tuần này', value: '86.200.000₫', note: '+12% WoW'),
+      _ReportCard(title: 'Tháng này', value: '302.500.000₫', note: '+5% MoM'),
+      _ReportCard(title: 'Tỷ lệ lấp đầy', value: '82%', note: 'Sân 2 cao nhất'),
+    ];
+
+    final bookings = [
+      _BookingReportRow(customer: 'Nguyễn Minh', court: 'Sân 1', time: '06:00 - 07:30', channel: 'Online'),
+      _BookingReportRow(customer: 'CLB Z', court: 'Sân 2', time: '18:00 - 20:00', channel: 'Offline'),
+      _BookingReportRow(customer: 'Trần Thảo', court: 'Sân 3', time: '08:00 - 10:00', channel: 'Online'),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Báo cáo & thống kê', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+        const SizedBox(height: 12),
+        GridView.count(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          crossAxisCount: MediaQuery.of(context).size.width > 900 ? 4 : 2,
+          crossAxisSpacing: 12,
+          mainAxisSpacing: 12,
+          childAspectRatio: 1.5,
+          children: stats,
+        ),
+        const SizedBox(height: 16),
+        Card(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Text('Danh sách booking đã thanh toán',
+                          style: TextStyle(fontWeight: FontWeight.bold)),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () {},
+                      icon: const Icon(Icons.download_outlined),
+                      label: const Text('Export CSV'),
+                    )
+                  ],
+                ),
+                const SizedBox(height: 12),
+                ...bookings
+                    .map(
+                      (b) => ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: const Icon(Icons.receipt_long_outlined),
+                        title: Text(b.customer),
+                        subtitle: Text('${b.court} • ${b.time}'),
+                        trailing: Chip(
+                          avatar: Icon(
+                            b.channel == 'Online' ? Icons.wifi : Icons.phone_forwarded,
+                            size: 16,
+                          ),
+                          label: Text(b.channel),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ],
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class _ReportCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final String note;
+
+  const _ReportCard({required this.title, required this.value, required this.note});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      color: colorScheme.secondaryContainer.withOpacity(0.5),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+            const Spacer(),
+            Text(value, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(Icons.trending_up, color: colorScheme.primary, size: 18),
+                const SizedBox(width: 6),
+                Text(note, style: TextStyle(color: colorScheme.primary)),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BookingReportRow {
+  final String customer;
+  final String court;
+  final String time;
+  final String channel;
+
+  _BookingReportRow({
+    required this.customer,
+    required this.court,
+    required this.time,
+    required this.channel,
+  });
+}

--- a/lib/pages/manager/manager_reports_page.dart
+++ b/lib/pages/manager/manager_reports_page.dart
@@ -23,14 +23,23 @@ class ManagerReportsPage extends StatelessWidget {
       children: [
         const Text('Báo cáo & thống kê', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
         const SizedBox(height: 12),
-        GridView.count(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          crossAxisCount: MediaQuery.of(context).size.width > 900 ? 4 : 2,
-          crossAxisSpacing: 12,
-          mainAxisSpacing: 12,
-          childAspectRatio: 1.5,
-          children: stats,
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final isWide = constraints.maxWidth > 900;
+            final crossAxisCount = isWide ? 4 : 2;
+            // Give cards more height on narrow screens to avoid vertical overflow.
+            final aspectRatio = isWide ? 1.35 : 1.1;
+
+            return GridView.count(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              crossAxisCount: crossAxisCount,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+              childAspectRatio: aspectRatio,
+              children: stats,
+            );
+          },
         ),
         const SizedBox(height: 16),
         Card(
@@ -96,12 +105,13 @@ class _ReportCard extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
-            const Spacer(),
+            const SizedBox(height: 10),
             Text(value, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-            const SizedBox(height: 8),
+            const SizedBox(height: 10),
             Row(
               children: [
                 Icon(Icons.trending_up, color: colorScheme.primary, size: 18),

--- a/lib/pages/manager/manager_reports_page.dart
+++ b/lib/pages/manager/manager_reports_page.dart
@@ -113,10 +113,17 @@ class _ReportCard extends StatelessWidget {
             Text(value, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
             const SizedBox(height: 10),
             Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Icon(Icons.trending_up, color: colorScheme.primary, size: 18),
                 const SizedBox(width: 6),
-                Text(note, style: TextStyle(color: colorScheme.primary)),
+                Flexible(
+                  child: Text(
+                    note,
+                    style: TextStyle(color: colorScheme.primary),
+                    softWrap: true,
+                  ),
+                ),
               ],
             ),
           ],

--- a/lib/pages/manager/manager_schedule_page.dart
+++ b/lib/pages/manager/manager_schedule_page.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+
+class ManagerSchedulePage extends StatefulWidget {
+  const ManagerSchedulePage({super.key});
+
+  @override
+  State<ManagerSchedulePage> createState() => _ManagerSchedulePageState();
+}
+
+class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
+  bool _tableView = true;
+  DateTime _selectedDate = DateTime.now();
+  String _selectedCourt = 'Tất cả';
+
+  final List<String> _courts = const ['Tất cả', 'Sân 1', 'Sân 2', 'Sân 3'];
+  final List<_ScheduleItem> _items = const [
+    _ScheduleItem(
+      court: 'Sân 1',
+      start: '06:00',
+      end: '07:30',
+      customer: 'Nguyễn Minh',
+      phone: '0901 234 567',
+      status: 'Confirmed',
+      color: Colors.green,
+    ),
+    _ScheduleItem(
+      court: 'Sân 2',
+      start: '08:00',
+      end: '10:00',
+      customer: 'Trần Thảo',
+      phone: '0933 888 999',
+      status: 'Offline',
+      color: Colors.orange,
+    ),
+    _ScheduleItem(
+      court: 'Sân 3',
+      start: '10:00',
+      end: '12:00',
+      customer: 'CLB Đồng Đội',
+      phone: '0912 456 789',
+      status: 'Blocked',
+      color: Colors.red,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final filteredItems = _selectedCourt == 'Tất cả'
+        ? _items
+        : _items.where((item) => item.court == _selectedCourt).toList();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 12,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            ChoiceChip(
+              label: const Text('Bảng'),
+              selected: _tableView,
+              onSelected: (_) => setState(() => _tableView = true),
+            ),
+            ChoiceChip(
+              label: const Text('Timeline'),
+              selected: !_tableView,
+              onSelected: (_) => setState(() => _tableView = false),
+            ),
+            ElevatedButton.icon(
+              onPressed: _pickDate,
+              icon: const Icon(Icons.calendar_today_outlined),
+              label: Text(_formattedDate(_selectedDate)),
+            ),
+            DropdownButton<String>(
+              value: _selectedCourt,
+              items: _courts
+                  .map((court) => DropdownMenuItem(
+                        value: court,
+                        child: Text(court),
+                      ))
+                  .toList(),
+              onChanged: (value) {
+                if (value != null) setState(() => _selectedCourt = value);
+              },
+            ),
+            FilledButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.search),
+              label: const Text('Lọc'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Expanded(
+          child: _tableView
+              ? _ScheduleTable(items: filteredItems)
+              : _TimelineView(items: filteredItems),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+
+    if (picked != null) {
+      setState(() => _selectedDate = picked);
+    }
+  }
+
+  String _formattedDate(DateTime date) {
+    return '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}';
+  }
+}
+
+class _ScheduleTable extends StatelessWidget {
+  final List<_ScheduleItem> items;
+
+  const _ScheduleTable({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: SingleChildScrollView(
+        child: DataTable(
+          columns: const [
+            DataColumn(label: Text('Sân')),
+            DataColumn(label: Text('Giờ')),
+            DataColumn(label: Text('Khách')),
+            DataColumn(label: Text('SĐT')),
+            DataColumn(label: Text('Trạng thái')),
+          ],
+          rows: items
+              .map(
+                (item) => DataRow(cells: [
+                  DataCell(Text(item.court)),
+                  DataCell(Text('${item.start} - ${item.end}')),
+                  DataCell(Text(item.customer)),
+                  DataCell(Text(item.phone)),
+                  DataCell(Chip(
+                    label: Text(item.status),
+                    backgroundColor: item.color.withOpacity(0.1),
+                    side: BorderSide(color: item.color.withOpacity(0.6)),
+                    labelStyle: TextStyle(color: item.color),
+                  )),
+                ]),
+              )
+              .toList(),
+        ),
+      ),
+    );
+  }
+}
+
+class _TimelineView extends StatelessWidget {
+  final List<_ScheduleItem> items;
+
+  const _TimelineView({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      itemCount: items.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return Container(
+          decoration: BoxDecoration(
+            color: item.color.withOpacity(0.05),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: item.color.withOpacity(0.3)),
+          ),
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Column(
+                children: [
+                  CircleAvatar(radius: 6, backgroundColor: item.color),
+                  Container(
+                    width: 2,
+                    height: 60,
+                    color: item.color.withOpacity(0.4),
+                  ),
+                ],
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(item.court, style: const TextStyle(fontWeight: FontWeight.w700)),
+                        const SizedBox(width: 8),
+                        Chip(
+                          label: Text(item.status),
+                          backgroundColor: item.color.withOpacity(0.12),
+                          labelStyle: TextStyle(color: item.color),
+                          side: BorderSide(color: item.color.withOpacity(0.6)),
+                        ),
+                      ],
+                    ),
+                    Text('${item.start} - ${item.end}', style: const TextStyle(fontWeight: FontWeight.w600)),
+                    const SizedBox(height: 4),
+                    Text('${item.customer} • ${item.phone}'),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 8,
+                      children: const [
+                        _ActionChip(icon: Icons.swap_horiz, label: 'Đổi giờ/sân'),
+                        _ActionChip(icon: Icons.cancel_outlined, label: 'Hủy booking'),
+                        _ActionChip(icon: Icons.block, label: 'Block slot'),
+                      ],
+                    ),
+                  ],
+                ),
+              )
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ActionChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _ActionChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return ActionChip(
+      avatar: Icon(icon, size: 18),
+      label: Text(label),
+      onPressed: () {},
+    );
+  }
+}
+
+class _ScheduleItem {
+  final String court;
+  final String start;
+  final String end;
+  final String customer;
+  final String phone;
+  final String status;
+  final Color color;
+
+  const _ScheduleItem({
+    required this.court,
+    required this.start,
+    required this.end,
+    required this.customer,
+    required this.phone,
+    required this.status,
+    required this.color,
+  });
+}

--- a/lib/pages/manager/manager_schedule_page.dart
+++ b/lib/pages/manager/manager_schedule_page.dart
@@ -129,30 +129,33 @@ class _ScheduleTable extends StatelessWidget {
     return Card(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: SingleChildScrollView(
-        child: DataTable(
-          columns: const [
-            DataColumn(label: Text('Sân')),
-            DataColumn(label: Text('Giờ')),
-            DataColumn(label: Text('Khách')),
-            DataColumn(label: Text('SĐT')),
-            DataColumn(label: Text('Trạng thái')),
-          ],
-          rows: items
-              .map(
-                (item) => DataRow(cells: [
-                  DataCell(Text(item.court)),
-                  DataCell(Text('${item.start} - ${item.end}')),
-                  DataCell(Text(item.customer)),
-                  DataCell(Text(item.phone)),
-                  DataCell(Chip(
-                    label: Text(item.status),
-                    backgroundColor: item.color.withOpacity(0.1),
-                    side: BorderSide(color: item.color.withOpacity(0.6)),
-                    labelStyle: TextStyle(color: item.color),
-                  )),
-                ]),
-              )
-              .toList(),
+        scrollDirection: Axis.horizontal,
+        child: SingleChildScrollView(
+          child: DataTable(
+            columns: const [
+              DataColumn(label: Text('Sân')),
+              DataColumn(label: Text('Giờ')),
+              DataColumn(label: Text('Khách')),
+              DataColumn(label: Text('SĐT')),
+              DataColumn(label: Text('Trạng thái')),
+            ],
+            rows: items
+                .map(
+                  (item) => DataRow(cells: [
+                    DataCell(Text(item.court)),
+                    DataCell(Text('${item.start} - ${item.end}')),
+                    DataCell(Text(item.customer)),
+                    DataCell(Text(item.phone)),
+                    DataCell(Chip(
+                      label: Text(item.status),
+                      backgroundColor: item.color.withOpacity(0.1),
+                      side: BorderSide(color: item.color.withOpacity(0.6)),
+                      labelStyle: TextStyle(color: item.color),
+                    )),
+                  ]),
+                )
+                .toList(),
+          ),
         ),
       ),
     );

--- a/lib/pages/manager/manager_schedule_page.dart
+++ b/lib/pages/manager/manager_schedule_page.dart
@@ -67,10 +67,17 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
               selected: !_tableView,
               onSelected: (_) => setState(() => _tableView = false),
             ),
-            ElevatedButton.icon(
+            FilledButton.tonalIcon(
               onPressed: _pickDate,
               icon: const Icon(Icons.calendar_today_outlined),
               label: Text(_formattedDate(_selectedDate)),
+              style: FilledButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
             ),
             DropdownButton<String>(
               value: _selectedCourt,
@@ -128,35 +135,42 @@ class _ScheduleTable extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: SingleChildScrollView(
-          child: DataTable(
-            columns: const [
-              DataColumn(label: Text('Sân')),
-              DataColumn(label: Text('Giờ')),
-              DataColumn(label: Text('Khách')),
-              DataColumn(label: Text('SĐT')),
-              DataColumn(label: Text('Trạng thái')),
-            ],
-            rows: items
-                .map(
-                  (item) => DataRow(cells: [
-                    DataCell(Text(item.court)),
-                    DataCell(Text('${item.start} - ${item.end}')),
-                    DataCell(Text(item.customer)),
-                    DataCell(Text(item.phone)),
-                    DataCell(Chip(
-                      label: Text(item.status),
-                      backgroundColor: item.color.withOpacity(0.1),
-                      side: BorderSide(color: item.color.withOpacity(0.6)),
-                      labelStyle: TextStyle(color: item.color),
-                    )),
-                  ]),
-                )
-                .toList(),
-          ),
-        ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minWidth: constraints.maxWidth),
+              child: SingleChildScrollView(
+                child: DataTable(
+                  columns: const [
+                    DataColumn(label: Text('Sân')),
+                    DataColumn(label: Text('Giờ')),
+                    DataColumn(label: Text('Khách')),
+                    DataColumn(label: Text('SĐT')),
+                    DataColumn(label: Text('Trạng thái')),
+                  ],
+                  rows: items
+                      .map(
+                        (item) => DataRow(cells: [
+                          DataCell(Text(item.court)),
+                          DataCell(Text('${item.start} - ${item.end}')),
+                          DataCell(Text(item.customer)),
+                          DataCell(Text(item.phone)),
+                          DataCell(Chip(
+                            label: Text(item.status),
+                            backgroundColor: item.color.withOpacity(0.1),
+                            side: BorderSide(color: item.color.withOpacity(0.6)),
+                            labelStyle: TextStyle(color: item.color),
+                          )),
+                        ]),
+                      )
+                      .toList(),
+                ),
+              ),
+            ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add manager navigation shell that routes managers into dedicated dashboard tabs
- scaffold manager pages for schedule views, offline booking, court info, hours, pricing, and reports with placeholder data
- wire manager role detection in app root to open the new manager experience after login

## Testing
- not run (UI scaffolding only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939413f2cc0832a89d8297586b801c4)