### PR TITLE
Add manager dashboard driven by database stats

### DIFF
--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -10,15 +10,18 @@ import 'package:badminton_booking_app/models/court_detail.dart';
 import 'package:badminton_booking_app/services/booking_realtime_service.dart';
 import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
+import 'package:badminton_booking_app/services/payment_service.dart';
 
 class BookingManager extends ChangeNotifier {
   BookingManager({
     required this.detailData,
     BookingService? bookingService,
+    PaymentService? paymentService,
     this.slotDuration = const Duration(hours: 1),
     this.unitGroupSize = 5,
   })  : assert(unitGroupSize > 0, 'unitGroupSize must be positive'),
-        _bookingService = bookingService ?? BookingService() {
+        _bookingService = bookingService ?? BookingService(),
+        _paymentService = paymentService ?? PaymentService() {
     _selectedDate = _normalizeDate(DateTime.now());
 
     Future.microtask(() => loadBookings());
@@ -28,6 +31,7 @@ class BookingManager extends ChangeNotifier {
   final Duration slotDuration;
   final int unitGroupSize;
   final BookingService _bookingService;
+  final PaymentService _paymentService;
   final BookingRealtimeService _realtimeService = BookingRealtimeService();
 
   DateTime _selectedDate = DateTime.now();
@@ -394,10 +398,24 @@ class BookingManager extends ChangeNotifier {
 
     try {
       for (final booking in bookingsToConfirm) {
+        String? paymentId;
         try {
+          final amountMinor = _calculateBookingAmount(booking);
+          final payment = await _paymentService.createPayment(
+            bookingId: booking.id,
+            amountMinor: amountMinor,
+            currency: 'VND',
+            provider: 'manual',
+            status: 'succeeded',
+          );
+          paymentId = payment.id;
+
           final updated = await _bookingService.markAsConfirmed(booking.id);
           confirmedBookings.add(updated);
         } catch (_) {
+          if (paymentId != null) {
+            unawaited(_paymentService.deletePayment(paymentId!).catchError((_) {}));
+          }
           failedBookings.add(booking);
         }
       }
@@ -425,6 +443,15 @@ class BookingManager extends ChangeNotifier {
       _isConfirmingPayment = false;
       notifyListeners();
     }
+  }
+
+  int _calculateBookingAmount(CourtBooking booking) {
+    final slots = booking.splitToSlots(slotDuration);
+    var total = 0.0;
+    for (final slot in slots) {
+      total += calculateSlotPrice(detailData, slot, slotDuration);
+    }
+    return total.round();
   }
 
   Future<void> cancelHeldBookings() async {

--- a/lib/pages/manager/manager_dashboard_page.dart
+++ b/lib/pages/manager/manager_dashboard_page.dart
@@ -14,6 +14,7 @@ class ManagerDashboardPage extends StatefulWidget {
 class _ManagerDashboardPageState extends State<ManagerDashboardPage> {
   final _service = ManagerDashboardService();
   late Future<ManagerDashboardData> _future;
+  DateTime _selectedDate = DateTime.now();
 
   @override
   void initState() {
@@ -22,12 +23,37 @@ class _ManagerDashboardPageState extends State<ManagerDashboardPage> {
   }
 
   Future<ManagerDashboardData> _load() {
-    return _service.fetchDashboardData(DateTime.now());
+    final date = DateTime(_selectedDate.year, _selectedDate.month, _selectedDate.day);
+    return _service.fetchDashboardData(date);
   }
 
   Future<void> _refresh() async {
     setState(() => _future = _load());
     await _future;
+  }
+
+  void _changeDay(int delta) {
+    setState(() {
+      _selectedDate = _selectedDate.add(Duration(days: delta));
+      _future = _load();
+    });
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+      locale: const Locale('vi'),
+    );
+
+    if (picked != null) {
+      setState(() {
+        _selectedDate = DateTime(picked.year, picked.month, picked.day);
+        _future = _load();
+      });
+    }
   }
 
   @override
@@ -126,6 +152,38 @@ class _ManagerDashboardPageState extends State<ManagerDashboardPage> {
 
               return ListView(
                 children: [
+                  Row(
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.chevron_left),
+                        onPressed: () => _changeDay(-1),
+                        tooltip: 'Ngày trước',
+                      ),
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          onPressed: _pickDate,
+                          icon: const Icon(Icons.calendar_today_outlined),
+                          label: Text(DateFormat('dd/MM/yyyy').format(_selectedDate)),
+                        ),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.chevron_right),
+                        onPressed: () => _changeDay(1),
+                        tooltip: 'Ngày tiếp theo',
+                      ),
+                      const SizedBox(width: 4),
+                      TextButton(
+                        onPressed: () {
+                          setState(() {
+                            _selectedDate = DateTime.now();
+                            _future = _load();
+                          });
+                        },
+                        child: const Text('Hôm nay'),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
                   const Text(
                     'Tổng quan nhanh',
                     style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),

--- a/lib/pages/manager/manager_dashboard_page.dart
+++ b/lib/pages/manager/manager_dashboard_page.dart
@@ -1,109 +1,272 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
-class ManagerDashboardPage extends StatelessWidget {
+import '../../models/booking.dart';
+import '../../services/manager_dashboard_service.dart';
+
+class ManagerDashboardPage extends StatefulWidget {
   const ManagerDashboardPage({super.key});
 
   @override
+  State<ManagerDashboardPage> createState() => _ManagerDashboardPageState();
+}
+
+class _ManagerDashboardPageState extends State<ManagerDashboardPage> {
+  final _service = ManagerDashboardService();
+  late Future<ManagerDashboardData> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<ManagerDashboardData> _load() {
+    return _service.fetchDashboardData(DateTime.now());
+  }
+
+  Future<void> _refresh() async {
+    setState(() => _future = _load());
+    await _future;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final cards = [
-      _KpiCard(title: 'Doanh thu hôm nay', value: '12.450.000₫', trend: '+8%'),
-      _KpiCard(title: 'Tỷ lệ lấp đầy', value: '82%', trend: '+5%'),
-      _KpiCard(title: 'Booking đã thanh toán', value: '46', trend: '+3%'),
-      _KpiCard(title: 'Slot bị block', value: '2', trend: 'Sự kiện giải đấu'),
-    ];
+    return FutureBuilder<ManagerDashboardData>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final isWide = constraints.maxWidth > 900;
-        final crossAxisCount = isWide ? 4 : 2;
-        final horizontalSpacing = 12.0;
-        final availableWidth = constraints.maxWidth -
-            (crossAxisCount - 1) * horizontalSpacing;
-        final cardWidth = availableWidth / crossAxisCount;
-        final targetHeight = isWide ? 140.0 : 170.0;
-        final childAspectRatio = cardWidth / targetHeight;
+        if (snapshot.hasError) {
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.error_outline, color: Colors.red),
+                const SizedBox(height: 8),
+                Text(
+                  snapshot.error.toString(),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                FilledButton.icon(
+                  onPressed: _refresh,
+                  icon: const Icon(Icons.refresh_outlined),
+                  label: const Text('Thử lại'),
+                ),
+              ],
+            ),
+          );
+        }
 
-        return ListView(
-          children: [
-            const Text(
-              'Tổng quan nhanh',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        final data = snapshot.data;
+        if (data == null || !data.hasCourts) {
+          return const Center(
+            child: Text('Bạn chưa có sân nào để hiển thị thống kê.'),
+          );
+        }
+
+        final today = data.today;
+        final previous = data.previous;
+
+        final currencyFormat = NumberFormat.currency(
+          locale: 'vi_VN',
+          symbol: '₫',
+          decimalDigits: 0,
+        );
+
+        final kpiCards = [
+          _KpiCard(
+            title: 'Doanh thu hôm nay',
+            value: currencyFormat.format(today.revenueMinor),
+            trend: _buildTrend(today.revenueMinor, previous?.revenueMinor),
+          ),
+          _KpiCard(
+            title: 'Tỷ lệ lấp đầy',
+            value: '${(today.occupancyRate * 100).toStringAsFixed(0)}%',
+            trend: _buildTrend(
+              (today.occupancyRate * 100).round(),
+              previous == null ? null : (previous.occupancyRate * 100).round(),
             ),
-            const SizedBox(height: 12),
-            GridView.count(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              crossAxisCount: crossAxisCount,
-              crossAxisSpacing: horizontalSpacing,
-              mainAxisSpacing: 12,
-              childAspectRatio: childAspectRatio,
-              children: cards,
+          ),
+          _KpiCard(
+            title: 'Booking đã thanh toán',
+            value: '${today.confirmedBookingCount}',
+            trend: _buildTrend(
+              today.confirmedBookingCount,
+              previous?.confirmedBookingCount,
             ),
-            const SizedBox(height: 16),
-            _SectionCard(
-              title: 'Lịch hôm nay',
-              actionText: 'Xem chi tiết',
-              onAction: () {},
-              child: Column(
-                children: const [
-                  _ScheduleRow(
-                    court: 'Sân 1',
-                    time: '06:00 - 07:30',
-                    customer: 'Nguyễn Minh',
-                    status: 'Confirmed',
-                    statusColor: Colors.green,
+          ),
+          _KpiCard(
+            title: 'Slot bị block',
+            value: '${today.blockedSlotCount}',
+            trend: _buildTrend(today.blockedSlotCount, previous?.blockedSlotCount),
+          ),
+        ];
+
+        return RefreshIndicator(
+          onRefresh: _refresh,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final isWide = constraints.maxWidth > 900;
+              final crossAxisCount = isWide ? 4 : 2;
+              final horizontalSpacing = 12.0;
+              final availableWidth = constraints.maxWidth -
+                  (crossAxisCount - 1) * horizontalSpacing;
+              final cardWidth = availableWidth / crossAxisCount;
+              final targetHeight = isWide ? 140.0 : 170.0;
+              final childAspectRatio = cardWidth / targetHeight;
+
+              final scheduleItems = today.schedule.take(5).toList();
+              final blockedNotices = today.schedule
+                  .where((item) => item.status == BookingStatus.held)
+                  .toList();
+
+              return ListView(
+                children: [
+                  const Text(
+                    'Tổng quan nhanh',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                   ),
-                  _ScheduleRow(
-                    court: 'Sân 2',
-                    time: '08:00 - 10:00',
-                    customer: 'Trần Thảo',
-                    status: 'Offline',
-                    statusColor: Colors.orange,
+                  const SizedBox(height: 12),
+                  GridView.count(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    crossAxisCount: crossAxisCount,
+                    crossAxisSpacing: horizontalSpacing,
+                    mainAxisSpacing: 12,
+                    childAspectRatio: childAspectRatio,
+                    children: kpiCards,
                   ),
-                  _ScheduleRow(
-                    court: 'Sân 3',
-                    time: '10:00 - 12:00',
-                    customer: 'CLB Đồng Đội',
-                    status: 'Blocked',
-                    statusColor: Colors.red,
+                  const SizedBox(height: 16),
+                  _SectionCard(
+                    title: 'Lịch hôm nay',
+                    actionText: 'Xem chi tiết',
+                    onAction: _refresh,
+                    child: Column(
+                      children: scheduleItems.isEmpty
+                          ? const [
+                              Padding(
+                                padding: EdgeInsets.symmetric(vertical: 12),
+                                child: Text('Chưa có lịch nào cho hôm nay'),
+                              )
+                            ]
+                          : scheduleItems
+                              .map(
+                                (item) => _ScheduleRow(
+                                  court: item.courtLabel,
+                                  time:
+                                      '${DateFormat('HH:mm').format(item.startTime)} - ${DateFormat('HH:mm').format(item.endTime)}',
+                                  customer: item.customerName,
+                                  status: _statusLabel(item.status),
+                                  statusColor: _statusColor(item.status, context),
+                                ),
+                              )
+                              .toList(),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  _SectionCard(
+                    title: 'Thông báo vận hành',
+                    actionText: 'Quản lý slot',
+                    onAction: _refresh,
+                    child: Column(
+                      children: blockedNotices.isEmpty
+                          ? const [
+                              ListTile(
+                                contentPadding: EdgeInsets.zero,
+                                leading: Icon(Icons.analytics_outlined),
+                                title: Text('Chưa có slot bị block hôm nay'),
+                                subtitle: Text('Các slot block sẽ hiển thị kèm lý do'),
+                              ),
+                            ]
+                          : blockedNotices
+                              .map(
+                                (item) => Column(
+                                  children: [
+                                    ListTile(
+                                      contentPadding: EdgeInsets.zero,
+                                      leading: const Icon(
+                                        Icons.warning_amber_outlined,
+                                        color: Colors.orange,
+                                      ),
+                                      title: Text(
+                                        '${item.courtLabel} block ${DateFormat('HH:mm').format(item.startTime)} - ${DateFormat('HH:mm').format(item.endTime)}',
+                                      ),
+                                      subtitle: Text(
+                                        item.note?.isNotEmpty == true
+                                            ? item.note!
+                                            : 'Ẩn với người dùng, chỉ hiển thị ở manager view',
+                                      ),
+                                    ),
+                                    const Divider(height: 1),
+                                  ],
+                                ),
+                              )
+                              .toList(),
+                    ),
                   ),
                 ],
-              ),
-            ),
-            const SizedBox(height: 16),
-            _SectionCard(
-              title: 'Thông báo vận hành',
-              actionText: 'Quản lý slot',
-              onAction: () {},
-              child: Column(
-                children: const [
-                  ListTile(
-                    contentPadding: EdgeInsets.zero,
-                    leading: Icon(Icons.warning_amber_outlined, color: Colors.orange),
-                    title: Text('Sân 3 block 10:00 - 12:00 (Giải phong trào)'),
-                    subtitle: Text('Ẩn với người dùng, chỉ hiển thị ở manager view'),
-                  ),
-                  Divider(height: 1),
-                  ListTile(
-                    contentPadding: EdgeInsets.zero,
-                    leading: Icon(Icons.analytics_outlined),
-                    title: Text('Tỷ lệ lấp đầy tuần này đạt 82%'),
-                    subtitle: Text('Giảm 3% so với tuần trước'),
-                  ),
-                ],
-              ),
-            ),
-          ],
+              );
+            },
+          ),
         );
       },
     );
+  }
+
+  _Trend _buildTrend(num current, num? previous) {
+    if (previous == null) return const _Trend(label: '—', color: Colors.grey);
+    if (previous == 0) {
+      return _Trend(
+        label: current == 0 ? '0%' : '+∞%',
+        color: Colors.green,
+      );
+    }
+    final deltaPercent = ((current - previous) / previous) * 100;
+    final icon = deltaPercent >= 0 ? Icons.trending_up : Icons.trending_down;
+    final color = deltaPercent >= 0 ? Colors.green : Colors.red;
+    final label = '${deltaPercent >= 0 ? '+' : ''}${deltaPercent.toStringAsFixed(1)}%';
+    return _Trend(label: label, color: color, icon: icon);
+  }
+
+  String _statusLabel(BookingStatus status) {
+    switch (status) {
+      case BookingStatus.confirmed:
+        return 'Online';
+      case BookingStatus.awaitingPayment:
+        return 'Chờ thanh toán';
+      case BookingStatus.held:
+        return 'Blocked';
+      case BookingStatus.cancelled:
+        return 'Đã hủy';
+      case BookingStatus.expired:
+        return 'Hết hạn';
+    }
+  }
+
+  Color _statusColor(BookingStatus status, BuildContext context) {
+    switch (status) {
+      case BookingStatus.confirmed:
+        return Colors.green;
+      case BookingStatus.awaitingPayment:
+        return Colors.orange;
+      case BookingStatus.held:
+        return Colors.red;
+      case BookingStatus.cancelled:
+        return Colors.grey;
+      case BookingStatus.expired:
+        return Theme.of(context).colorScheme.outline;
+    }
   }
 }
 
 class _KpiCard extends StatelessWidget {
   final String title;
   final String value;
-  final String trend;
+  final _Trend trend;
 
   const _KpiCard({
     required this.title,
@@ -114,6 +277,7 @@ class _KpiCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final trendColor = trend.color ?? colorScheme.primary;
     return Card(
       elevation: 0,
       color: colorScheme.primaryContainer.withOpacity(0.35),
@@ -136,9 +300,10 @@ class _KpiCard extends StatelessWidget {
             const SizedBox(height: 8),
             Row(
               children: [
-                Icon(Icons.trending_up, color: colorScheme.primary, size: 18),
+                Icon(trend.icon ?? Icons.trending_up,
+                    color: trendColor, size: 18),
                 const SizedBox(width: 6),
-                Text(trend, style: TextStyle(color: colorScheme.primary)),
+                Text(trend.label, style: TextStyle(color: trendColor)),
               ],
             ),
           ],
@@ -229,4 +394,12 @@ class _ScheduleRow extends StatelessWidget {
       ),
     );
   }
+}
+
+class _Trend {
+  final String label;
+  final Color? color;
+  final IconData? icon;
+
+  const _Trend({required this.label, this.color, this.icon});
 }

--- a/lib/pages/manager/manager_dashboard_page.dart
+++ b/lib/pages/manager/manager_dashboard_page.dart
@@ -126,9 +126,12 @@ class _ManagerDashboardPageState extends State<ManagerDashboardPage> {
             ),
           ),
           _KpiCard(
-            title: 'Slot bị block',
-            value: '${today.blockedSlotCount}',
-            trend: _buildTrend(today.blockedSlotCount, previous?.blockedSlotCount),
+            title: 'Booking chờ thanh toán',
+            value: '${today.awaitingPaymentCount}',
+            trend: _buildTrend(
+              today.awaitingPaymentCount,
+              previous?.awaitingPaymentCount,
+            ),
           ),
         ];
 

--- a/lib/pages/manager/manager_nav_page.dart
+++ b/lib/pages/manager/manager_nav_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+import '../auth/auth_manager.dart';
+import '../../utils/dialog_utils.dart';
 import 'manager_dashboard_page.dart';
 import 'manager_schedule_page.dart';
 import 'manager_offline_booking_page.dart';
@@ -19,6 +22,25 @@ class _ManagerNavPageState extends State<ManagerNavPage> {
   int _selectedIndex = 0;
 
   late final List<_ManagerTab> _tabs;
+
+  Future<void> _handleLogout(BuildContext context) async {
+    final confirm = await showConfirmDialog(
+      context,
+      'Bạn có chắc chắn muốn đăng xuất?',
+      title: 'Đăng xuất',
+    );
+
+    if (!confirm) return;
+
+    try {
+      await context.read<AuthManager>().logout();
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Đăng xuất thất bại: $error')),
+      );
+    }
+  }
 
   @override
   void initState() {
@@ -91,6 +113,10 @@ class _ManagerNavPageState extends State<ManagerNavPage> {
                     setState(() => _selectedIndex = index);
                     Navigator.of(context).pop();
                   },
+                  onLogout: () {
+                    Navigator.of(context).pop();
+                    _handleLogout(context);
+                  },
                 ),
               ),
             ),
@@ -99,18 +125,27 @@ class _ManagerNavPageState extends State<ManagerNavPage> {
           if (isWide)
             NavigationDrawer(
               selectedIndex: _selectedIndex,
-              onDestinationSelected: (index) =>
-                  setState(() => _selectedIndex = index),
-              children: _tabs
-                  .map(
-                    (tab) => NavigationDrawerDestination(
-                      icon: Icon(tab.icon),
-                      selectedIcon:
-                          Icon(tab.icon, color: Theme.of(context).primaryColor),
-                      label: Text(tab.label),
-                    ),
-                  )
-                  .toList(),
+              onDestinationSelected: (index) {
+                if (index >= _tabs.length) {
+                  _handleLogout(context);
+                  return;
+                }
+                setState(() => _selectedIndex = index);
+              },
+              children: [
+                ..._tabs.map(
+                  (tab) => NavigationDrawerDestination(
+                    icon: Icon(tab.icon),
+                    selectedIcon:
+                        Icon(tab.icon, color: Theme.of(context).primaryColor),
+                    label: Text(tab.label),
+                  ),
+                ),
+                const NavigationDrawerDestination(
+                  icon: Icon(Icons.logout),
+                  label: Text('Đăng xuất'),
+                ),
+              ],
             ),
           Expanded(
             child: AnimatedSwitcher(
@@ -138,11 +173,13 @@ class _DrawerList extends StatelessWidget {
     required this.tabs,
     required this.selectedIndex,
     required this.onSelect,
+    required this.onLogout,
   });
 
   final List<_ManagerTab> tabs;
   final int selectedIndex;
   final ValueChanged<int> onSelect;
+  final VoidCallback onLogout;
 
   @override
   Widget build(BuildContext context) {
@@ -171,6 +208,12 @@ class _DrawerList extends StatelessWidget {
               onTap: () => onSelect(index),
             );
           },
+        ),
+        const Divider(),
+        ListTile(
+          leading: const Icon(Icons.logout),
+          title: const Text('Đăng xuất'),
+          onTap: onLogout,
         ),
       ],
     );

--- a/lib/services/manager_dashboard_service.dart
+++ b/lib/services/manager_dashboard_service.dart
@@ -1,0 +1,284 @@
+import 'dart:math';
+
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/booking.dart';
+import '../models/court_detail.dart';
+import 'booking_service.dart';
+import 'pocketbase_client.dart';
+
+class ManagerDashboardData {
+  final ManagerDailyStats today;
+  final ManagerDailyStats? previous;
+
+  const ManagerDashboardData({required this.today, required this.previous});
+
+  bool get hasCourts => today.courtIds.isNotEmpty;
+}
+
+class ManagerDailyStats {
+  final List<String> courtIds;
+  final int revenueMinor;
+  final double occupancyRate;
+  final int confirmedBookingCount;
+  final int blockedSlotCount;
+  final List<ManagerScheduleItem> schedule;
+
+  const ManagerDailyStats({
+    required this.courtIds,
+    required this.revenueMinor,
+    required this.occupancyRate,
+    required this.confirmedBookingCount,
+    required this.blockedSlotCount,
+    this.schedule = const [],
+  });
+}
+
+class ManagerScheduleItem {
+  final String courtLabel;
+  final DateTime startTime;
+  final DateTime endTime;
+  final String customerName;
+  final BookingStatus status;
+  final String? note;
+
+  const ManagerScheduleItem({
+    required this.courtLabel,
+    required this.startTime,
+    required this.endTime,
+    required this.customerName,
+    required this.status,
+    this.note,
+  });
+
+  Duration get duration => endTime.difference(startTime);
+}
+
+class ManagerDashboardService {
+  Future<ManagerDashboardData> fetchDashboardData(DateTime date) async {
+    final pb = await getPocketbaseInstance();
+    final authRecord = pb.authStore.record;
+
+    if (authRecord == null) {
+      throw ClientException('Bạn cần đăng nhập để xem dữ liệu.');
+    }
+
+    final ownerId = authRecord.id;
+    final courtsResult = await pb.collection('courts').getList(
+          perPage: 200,
+          filter: "owner='${_escape(ownerId)}'",
+        );
+
+    if (courtsResult.items.isEmpty) {
+      const emptyStats = ManagerDailyStats(
+        courtIds: [],
+        revenueMinor: 0,
+        occupancyRate: 0,
+        confirmedBookingCount: 0,
+        blockedSlotCount: 0,
+        schedule: [],
+      );
+      return const ManagerDashboardData(today: emptyStats, previous: emptyStats);
+    }
+
+    final courtIds = courtsResult.items.map((record) => record.id).toList();
+
+    final todayStats = await _loadStatsForDate(
+      pb: pb,
+      courtIds: courtIds,
+      date: date,
+    );
+
+    final yesterdayStats = await _loadStatsForDate(
+      pb: pb,
+      courtIds: courtIds,
+      date: date.subtract(const Duration(days: 1)),
+    );
+
+    return ManagerDashboardData(today: todayStats, previous: yesterdayStats);
+  }
+
+  Future<ManagerDailyStats> _loadStatsForDate({
+    required PocketBase pb,
+    required List<String> courtIds,
+    required DateTime date,
+  }) async {
+    final dayStart = DateTime.utc(date.year, date.month, date.day);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+
+    final courtFilter = _buildOrFilter('court_id', courtIds);
+
+    final courtsFuture = pb.collection('court_units').getList(
+          perPage: 200,
+          filter: courtFilter,
+        );
+
+    final hoursFuture = pb.collection('court_opening_hours').getList(
+          perPage: 200,
+          filter: courtFilter,
+        );
+
+    final bookingsFuture = pb.collection(BookingService.collection).getList(
+          perPage: 200,
+          filter:
+              "$courtFilter && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'",
+          sort: 'start_time',
+          expand: 'user_id,court_unit_id',
+        );
+
+    final results = await Future.wait([courtsFuture, hoursFuture, bookingsFuture]);
+
+    final courtUnitsResult = results[0] as ResultList<RecordModel>;
+    final openingHoursResult = results[1] as ResultList<RecordModel>;
+    final bookingResult = results[2] as ResultList<RecordModel>;
+
+    final unitLabels = <String, String>{};
+    final unitCourtMap = <String, String>{};
+    for (final unitRecord in courtUnitsResult.items) {
+      final unit = CourtUnit.fromRecord(unitRecord);
+      final courtId = (unitRecord.data['court_id'] as String?) ?? '';
+      unitCourtMap[unitRecord.id] = courtId;
+      unitLabels[unitRecord.id] = unit.label.isEmpty ? 'Sân' : unit.label;
+    }
+
+    final openingDuration = _computeOpeningDurations(openingHoursResult.items);
+
+    final bookings = bookingResult.items.map(CourtBooking.fromRecord).toList();
+
+    final scheduleItems = bookingResult.items.map((record) {
+      final booking = CourtBooking.fromRecord(record);
+      final unitLabel = unitLabels[booking.courtUnitId] ?? 'Sân';
+      final userRecord = record.expand?['user_id'];
+      final customerName = _extractUserName(userRecord) ?? 'Khách lẻ';
+      return ManagerScheduleItem(
+        courtLabel: unitLabel,
+        startTime: booking.startTime.toLocal(),
+        endTime: booking.endTime.toLocal(),
+        customerName: customerName,
+        status: booking.status,
+        note: booking.note,
+      );
+    }).toList();
+
+    final bookedMinutes = bookings
+        .where((b) => b.status == BookingStatus.confirmed ||
+            b.status == BookingStatus.awaitingPayment)
+        .fold<double>(
+          0,
+          (sum, booking) =>
+              sum + booking.endTime.difference(booking.startTime).inMinutes,
+        );
+
+    final capacityMinutes = courtIds.fold<double>(0, (sum, id) {
+      final durationMinutes = openingDuration[id] ?? 0;
+      final unitCount = unitCourtMap.values.where((cid) => cid == id).length;
+      return sum + durationMinutes * max(1, unitCount);
+    });
+
+    final occupancyRate = capacityMinutes == 0
+        ? 0
+        : (bookedMinutes / capacityMinutes).clamp(0, 1);
+
+    final blockedSlots = bookings.where((b) => b.status == BookingStatus.held).length;
+    final confirmedCount = bookings.where((b) => b.status == BookingStatus.confirmed).length;
+
+    final revenueMinor = await _sumRevenue(
+      pb: pb,
+      bookingIds: bookings.map((b) => b.id).toList(),
+      dayStart: dayStart,
+      dayEnd: dayEnd,
+    );
+
+    return ManagerDailyStats(
+      courtIds: courtIds,
+      revenueMinor: revenueMinor,
+      occupancyRate: occupancyRate,
+      confirmedBookingCount: confirmedCount,
+      blockedSlotCount: blockedSlots,
+      schedule: scheduleItems,
+    );
+  }
+
+  Map<String, double> _computeOpeningDurations(List<RecordModel> items) {
+    final map = <String, double>{};
+    for (final record in items) {
+      final courtId = (record.data['court_id'] as String?) ?? '';
+      final open = record.data['open_time'] as String?;
+      final close = record.data['close_time'] as String?;
+      final minutes = _parseDurationMinutes(open, close);
+      if (minutes != null) {
+        map[courtId] = minutes;
+      }
+    }
+    return map;
+  }
+
+  Future<int> _sumRevenue({
+    required PocketBase pb,
+    required List<String> bookingIds,
+    required DateTime dayStart,
+    required DateTime dayEnd,
+  }) async {
+    if (bookingIds.isEmpty) return 0;
+    final bookingFilter = _buildOrFilter('booking_id', bookingIds);
+    final filter =
+        "status='succeeded' && created >= '${dayStart.toIso8601String()}' && created < '${dayEnd.toIso8601String()}' && ($bookingFilter)";
+
+    final payments = await pb.collection('payment').getList(
+          perPage: 200,
+          filter: filter,
+        );
+
+    return payments.items.fold<int>(0, (sum, record) {
+      final rawAmount = record.data['amount_minor'];
+      final parsed = _parseMinorUnit(rawAmount);
+      return sum + parsed;
+    });
+  }
+
+  String? _extractUserName(dynamic expandedUser) {
+    if (expandedUser is RecordModel) {
+      final data = expandedUser.data;
+      return (data['username'] as String?) ?? data['name'] as String?;
+    }
+    return null;
+  }
+
+  double? _parseDurationMinutes(String? openTime, String? closeTime) {
+    if (openTime == null || closeTime == null) return null;
+    final openParts = openTime.split(':');
+    final closeParts = closeTime.split(':');
+    if (openParts.length != 2 || closeParts.length != 2) return null;
+
+    final openHour = int.tryParse(openParts[0]);
+    final openMinute = int.tryParse(openParts[1]);
+    final closeHour = int.tryParse(closeParts[0]);
+    final closeMinute = int.tryParse(closeParts[1]);
+
+    if ([openHour, openMinute, closeHour, closeMinute].any((v) => v == null)) {
+      return null;
+    }
+
+    final open = Duration(hours: openHour!, minutes: openMinute!);
+    final close = Duration(hours: closeHour!, minutes: closeMinute!);
+    final diff = close - open;
+    return diff.inMinutes.toDouble().clamp(0, double.infinity);
+  }
+
+  String _buildOrFilter(String field, List<String> values) {
+    final escaped = values.map(_escape).map((v) => "${field}='${v}'");
+    return escaped.join(' || ');
+  }
+
+  String _escape(String value) => value.replaceAll("'", "\\'");
+
+  int _parseMinorUnit(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) {
+      final cleaned = value.replaceAll(RegExp(r'[^0-9]'), '');
+      return int.tryParse(cleaned) ?? 0;
+    }
+    return 0;
+  }
+}

--- a/lib/services/manager_dashboard_service.dart
+++ b/lib/services/manager_dashboard_service.dart
@@ -227,10 +227,20 @@ class ManagerDashboardService {
     final filter =
         "status='succeeded' && created >= '${dayStart.toIso8601String()}' && created < '${dayEnd.toIso8601String()}' && ($bookingFilter)";
 
-    final payments = await pb.collection('payment').getList(
-          perPage: 200,
-          filter: filter,
-        );
+    ResultList<RecordModel> payments;
+    try {
+      payments = await pb.collection('payment').getList(
+            perPage: 200,
+            filter: filter,
+          );
+    } on ClientException catch (err) {
+      if (err.statusCode == 401 || err.statusCode == 403) {
+        // Một số tài khoản không có quyền truy cập bảng thanh toán. Trả về 0
+        // để tránh chặn toàn bộ dashboard.
+        return 0;
+      }
+      rethrow;
+    }
 
     return payments.items.fold<int>(0, (sum, record) {
       final rawAmount = record.data['amount_minor'];

--- a/lib/services/manager_dashboard_service.dart
+++ b/lib/services/manager_dashboard_service.dart
@@ -21,6 +21,7 @@ class ManagerDailyStats {
   final int revenueMinor;
   final double occupancyRate;
   final int confirmedBookingCount;
+  final int awaitingPaymentCount;
   final int blockedSlotCount;
   final List<ManagerScheduleItem> schedule;
 
@@ -29,6 +30,7 @@ class ManagerDailyStats {
     required this.revenueMinor,
     required this.occupancyRate,
     required this.confirmedBookingCount,
+    required this.awaitingPaymentCount,
     required this.blockedSlotCount,
     this.schedule = const [],
   });
@@ -78,6 +80,7 @@ class ManagerDashboardService {
         revenueMinor: 0,
         occupancyRate: 0,
         confirmedBookingCount: 0,
+        awaitingPaymentCount: 0,
         blockedSlotCount: 0,
         schedule: [],
       );
@@ -183,6 +186,8 @@ class ManagerDashboardService {
         : (bookedMinutes / capacityMinutes).clamp(0, 1).toDouble();
 
     final blockedSlots = bookings.where((b) => b.status == BookingStatus.held).length;
+    final awaitingPayments =
+        bookings.where((b) => b.status == BookingStatus.awaitingPayment).length;
     final confirmedCount = bookings.where((b) => b.status == BookingStatus.confirmed).length;
 
     final revenueMinor = await _sumRevenue(
@@ -197,6 +202,7 @@ class ManagerDashboardService {
       revenueMinor: revenueMinor,
       occupancyRate: occupancyRate,
       confirmedBookingCount: confirmedCount,
+      awaitingPaymentCount: awaitingPayments,
       blockedSlotCount: blockedSlots,
       schedule: scheduleItems,
     );

--- a/lib/services/manager_dashboard_service.dart
+++ b/lib/services/manager_dashboard_service.dart
@@ -60,7 +60,7 @@ class ManagerDashboardService {
     final authRecord = pb.authStore.record;
 
     if (authRecord == null) {
-      throw ClientException(message: 'Bạn cần đăng nhập để xem dữ liệu.');
+      throw ClientException(401, {'message': 'Bạn cần đăng nhập để xem dữ liệu.'});
     }
 
     final ownerId = authRecord.id;

--- a/lib/services/manager_dashboard_service.dart
+++ b/lib/services/manager_dashboard_service.dart
@@ -60,7 +60,10 @@ class ManagerDashboardService {
     final authRecord = pb.authStore.record;
 
     if (authRecord == null) {
-      throw ClientException(401, {'message': 'Bạn cần đăng nhập để xem dữ liệu.'});
+      throw ClientException(
+        statusCode: 401,
+        response: {'message': 'Bạn cần đăng nhập để xem dữ liệu.'},
+      );
     }
 
     final ownerId = authRecord.id;

--- a/lib/services/manager_dashboard_service.dart
+++ b/lib/services/manager_dashboard_service.dart
@@ -60,7 +60,7 @@ class ManagerDashboardService {
     final authRecord = pb.authStore.record;
 
     if (authRecord == null) {
-      throw ClientException('Bạn cần đăng nhập để xem dữ liệu.');
+      throw ClientException(message: 'Bạn cần đăng nhập để xem dữ liệu.');
     }
 
     final ownerId = authRecord.id;
@@ -164,20 +164,20 @@ class ManagerDashboardService {
         .where((b) => b.status == BookingStatus.confirmed ||
             b.status == BookingStatus.awaitingPayment)
         .fold<double>(
-          0,
+          0.0,
           (sum, booking) =>
               sum + booking.endTime.difference(booking.startTime).inMinutes,
         );
 
-    final capacityMinutes = courtIds.fold<double>(0, (sum, id) {
-      final durationMinutes = openingDuration[id] ?? 0;
+    final capacityMinutes = courtIds.fold<double>(0.0, (sum, id) {
+      final durationMinutes = openingDuration[id] ?? 0.0;
       final unitCount = unitCourtMap.values.where((cid) => cid == id).length;
       return sum + durationMinutes * max(1, unitCount);
     });
 
     final occupancyRate = capacityMinutes == 0
-        ? 0
-        : (bookedMinutes / capacityMinutes).clamp(0, 1);
+        ? 0.0
+        : (bookedMinutes / capacityMinutes).clamp(0, 1).toDouble();
 
     final blockedSlots = bookings.where((b) => b.status == BookingStatus.held).length;
     final confirmedCount = bookings.where((b) => b.status == BookingStatus.confirmed).length;
@@ -262,7 +262,10 @@ class ManagerDashboardService {
     final open = Duration(hours: openHour!, minutes: openMinute!);
     final close = Duration(hours: closeHour!, minutes: closeMinute!);
     final diff = close - open;
-    return diff.inMinutes.toDouble().clamp(0, double.infinity);
+    return diff.inMinutes
+        .toDouble()
+        .clamp(0, double.infinity)
+        .toDouble();
   }
 
   String _buildOrFilter(String field, List<String> values) {

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,0 +1,74 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import 'pocketbase_client.dart';
+
+class PaymentServiceException implements Exception {
+  PaymentServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class PaymentService {
+  Future<RecordModel> createPayment({
+    required String bookingId,
+    required int amountMinor,
+    required String currency,
+    required String provider,
+    required String status,
+    String? transactionRef,
+    String? payload,
+  }) async {
+    final pb = await getPocketbaseInstance();
+
+    final body = <String, dynamic>{
+      'booking_id': bookingId,
+      'amount_minor': amountMinor,
+      'currency': currency,
+      'provider': provider,
+      'status': status,
+      if (transactionRef != null && transactionRef.isNotEmpty)
+        'transaction_ref': transactionRef,
+      if (payload != null && payload.isNotEmpty) 'payload': payload,
+    };
+
+    try {
+      return await pb.collection('payment').create(body: body);
+    } on ClientException catch (error) {
+      throw PaymentServiceException(_mapClientException(error));
+    } catch (_) {
+      throw PaymentServiceException(
+        'Không thể ghi nhận thanh toán. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<void> deletePayment(String id) async {
+    final pb = await getPocketbaseInstance();
+    try {
+      await pb.collection('payment').delete(id);
+    } on ClientException catch (error) {
+      throw PaymentServiceException(_mapClientException(error));
+    } catch (_) {
+      throw PaymentServiceException('Không thể xoá giao dịch.');
+    }
+  }
+
+  String _mapClientException(ClientException error) {
+    if (error.response != null) {
+      final data = error.response!['data'];
+      if (data is Map && data.isNotEmpty) {
+        final first = data.values.first;
+        if (first is Map && first['message'] is String) {
+          return first['message'] as String;
+        }
+      }
+      if (error.response!['message'] is String) {
+        return error.response!['message'] as String;
+      }
+    }
+    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
+  }
+}


### PR DESCRIPTION
## Summary
- load manager dashboard KPIs and schedule from PocketBase data tied to the courts the manager owns
- add a dedicated service to compute revenue, occupancy, booking counts, and blocked slot notes for each day
- refresh the dashboard UI with realtime figures, trend indicators, and operational notices

## Testing
- Not run (dart/flutter SDK not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939586aed04832aac2a648f16608965)