### PR TITLE
Implement manager schedule filtering

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,9 +6,9 @@ import 'package:badminton_booking_app/pages/user/user_manager.dart';
 import 'package:badminton_booking_app/pages/manager/manager_nav_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:provider/provider.dart';
-import 'package:intl/date_symbol_data_local.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:provider/provider.dart';
 
 import 'package:badminton_booking_app/pages/auth/login_page.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
@@ -42,11 +42,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: mainTheme,
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       supportedLocales: const [
         Locale('en'),
         Locale('vi'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'package:badminton_booking_app/pages/auth/login_page.dart';
 import 'package:badminton_booking_app/pages/auth/auth_manager.dart';
@@ -41,6 +42,15 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: mainTheme,
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+        Locale('vi'),
+      ],
       home: const AppRoot(),
     );
   }

--- a/lib/pages/manager/manager_dashboard_page.dart
+++ b/lib/pages/manager/manager_dashboard_page.dart
@@ -28,8 +28,11 @@ class _ManagerDashboardPageState extends State<ManagerDashboardPage> {
   }
 
   Future<void> _refresh() async {
-    setState(() => _future = _load());
-    await _future;
+    final future = _load();
+    setState(() {
+      _future = future;
+    });
+    await future;
   }
 
   void _changeDay(int delta) {

--- a/lib/pages/manager/manager_schedule_page.dart
+++ b/lib/pages/manager/manager_schedule_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../../models/booking.dart';
+import '../../services/booking_service.dart';
 import '../../services/manager_schedule_service.dart';
 
 class ManagerSchedulePage extends StatefulWidget {
@@ -263,6 +264,7 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
                           statusColor: _statusColor,
                           statusText: _statusText,
                           onAction: _showComingSoon,
+                          onCancelBooking: _confirmCancelBooking,
                         ),
             ),
           ],
@@ -310,6 +312,47 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('$action đang được phát triển.')),
     );
+  }
+
+  Future<void> _confirmCancelBooking(ScheduleItem item) async {
+    final shouldCancel = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Huỷ booking'),
+          content: Text(
+            'Bạn có chắc muốn huỷ booking của ${item.customerName}?\n'
+            'Thời gian: ${_formatRange(item.startTime, item.endTime)}',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Đóng'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Huỷ booking'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldCancel != true) return;
+
+    try {
+      await _service.cancelBooking(item.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Đã huỷ booking thành công.')),
+      );
+      setState(() => _future = _loadSchedule());
+    } on BookingServiceException catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.message)),
+      );
+    }
   }
 }
 
@@ -384,6 +427,7 @@ class _TimelineView extends StatelessWidget {
     required this.statusColor,
     required this.statusText,
     required this.onAction,
+    required this.onCancelBooking,
   });
 
   final List<ScheduleItem> items;
@@ -391,6 +435,7 @@ class _TimelineView extends StatelessWidget {
   final Color Function(BookingStatus status) statusColor;
   final String Function(BookingStatus status) statusText;
   final void Function(String action) onAction;
+  final Future<void> Function(ScheduleItem item) onCancelBooking;
 
   @override
   Widget build(BuildContext context) {
@@ -475,7 +520,7 @@ class _TimelineView extends StatelessWidget {
                         _ActionChip(
                           icon: Icons.cancel_outlined,
                           label: 'Hủy booking',
-                          onPressed: () => onAction('Hủy booking'),
+                          onPressed: () => onCancelBooking(item),
                         ),
                         _ActionChip(
                           icon: Icons.phone_forwarded_outlined,

--- a/lib/pages/manager/manager_schedule_page.dart
+++ b/lib/pages/manager/manager_schedule_page.dart
@@ -16,6 +16,7 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
   final _service = ManagerScheduleService();
 
   late Future<ManagerScheduleData> _future;
+  ManagerScheduleData? _latestData;
   bool _tableView = true;
   DateTime _selectedDate = DateTime.now();
   String _selectedCourt = 'all';
@@ -23,21 +24,24 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
     BookingStatus.held,
     BookingStatus.awaitingPayment,
     BookingStatus.confirmed,
+    BookingStatus.cancelled,
   };
 
   @override
   void initState() {
     super.initState();
-    _future = _loadSchedule();
+    _future = _loadAndCacheSchedule();
   }
 
-  Future<ManagerScheduleData> _loadSchedule() {
+  Future<ManagerScheduleData> _loadAndCacheSchedule() async {
     final normalized = DateTime(
       _selectedDate.year,
       _selectedDate.month,
       _selectedDate.day,
     );
-    return _service.fetchSchedule(normalized);
+    final data = await _service.fetchSchedule(normalized);
+    _latestData = data;
+    return data;
   }
 
   Future<void> _pickDate() async {
@@ -52,7 +56,7 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
     if (picked != null) {
       setState(() {
         _selectedDate = picked;
-        _future = _loadSchedule();
+        _future = _loadAndCacheSchedule();
       });
     }
   }
@@ -155,7 +159,8 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
                 ),
                 const SizedBox(height: 12),
                 FilledButton.icon(
-                  onPressed: () => setState(() => _future = _loadSchedule()),
+                  onPressed: () =>
+                      setState(() => _future = _loadAndCacheSchedule()),
                   icon: const Icon(Icons.refresh_outlined),
                   label: const Text('Thử lại'),
                 )
@@ -170,6 +175,8 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
             child: Text('Bạn chưa có sân nào để hiển thị lịch.'),
           );
         }
+
+        _latestData ??= data;
 
         final availableCourtIds = data.courts.map((c) => c.id).toSet();
         if (_selectedCourt != 'all' && !availableCourtIds.contains(_selectedCourt)) {
@@ -346,13 +353,47 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Đã huỷ booking thành công.')),
       );
-      setState(() => _future = _loadSchedule());
+      _applyLocalCancellation(item.id);
+      _refreshScheduleSilently();
     } on BookingServiceException catch (error) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(error.message)),
       );
     }
+  }
+
+  void _applyLocalCancellation(String bookingId) {
+    final cached = _latestData;
+    if (cached == null) return;
+
+    final updatedItems = cached.items
+        .map(
+          (scheduleItem) => scheduleItem.id == bookingId
+              ? scheduleItem.copyWith(status: BookingStatus.cancelled)
+              : scheduleItem,
+        )
+        .toList();
+
+    final updatedData = ManagerScheduleData(
+      courts: cached.courts,
+      items: updatedItems,
+    );
+
+    setState(() {
+      _latestData = updatedData;
+      _future = Future.value(updatedData);
+    });
+  }
+
+  void _refreshScheduleSilently() {
+    _loadAndCacheSchedule().then((freshData) {
+      if (!mounted) return;
+      setState(() {
+        _latestData = freshData;
+        _future = Future.value(freshData);
+      });
+    }).catchError((_) {});
   }
 }
 
@@ -520,7 +561,9 @@ class _TimelineView extends StatelessWidget {
                         _ActionChip(
                           icon: Icons.cancel_outlined,
                           label: 'Hủy booking',
-                          onPressed: () => onCancelBooking(item),
+                          onPressed: item.status == BookingStatus.cancelled
+                              ? null
+                              : () => onCancelBooking(item),
                         ),
                         _ActionChip(
                           icon: Icons.phone_forwarded_outlined,
@@ -549,7 +592,7 @@ class _ActionChip extends StatelessWidget {
 
   final IconData icon;
   final String label;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/manager/manager_schedule_page.dart
+++ b/lib/pages/manager/manager_schedule_page.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../models/booking.dart';
+import '../../services/manager_schedule_service.dart';
 
 class ManagerSchedulePage extends StatefulWidget {
   const ManagerSchedulePage({super.key});
@@ -8,104 +12,31 @@ class ManagerSchedulePage extends StatefulWidget {
 }
 
 class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
+  final _service = ManagerScheduleService();
+
+  late Future<ManagerScheduleData> _future;
   bool _tableView = true;
   DateTime _selectedDate = DateTime.now();
-  String _selectedCourt = 'Tất cả';
-
-  final List<String> _courts = const ['Tất cả', 'Sân 1', 'Sân 2', 'Sân 3'];
-  final List<_ScheduleItem> _items = const [
-    _ScheduleItem(
-      court: 'Sân 1',
-      start: '06:00',
-      end: '07:30',
-      customer: 'Nguyễn Minh',
-      phone: '0901 234 567',
-      status: 'Confirmed',
-      color: Colors.green,
-    ),
-    _ScheduleItem(
-      court: 'Sân 2',
-      start: '08:00',
-      end: '10:00',
-      customer: 'Trần Thảo',
-      phone: '0933 888 999',
-      status: 'Offline',
-      color: Colors.orange,
-    ),
-    _ScheduleItem(
-      court: 'Sân 3',
-      start: '10:00',
-      end: '12:00',
-      customer: 'CLB Đồng Đội',
-      phone: '0912 456 789',
-      status: 'Blocked',
-      color: Colors.red,
-    ),
-  ];
+  String _selectedCourt = 'all';
+  Set<BookingStatus> _statusFilters = {
+    BookingStatus.held,
+    BookingStatus.awaitingPayment,
+    BookingStatus.confirmed,
+  };
 
   @override
-  Widget build(BuildContext context) {
-    final filteredItems = _selectedCourt == 'Tất cả'
-        ? _items
-        : _items.where((item) => item.court == _selectedCourt).toList();
+  void initState() {
+    super.initState();
+    _future = _loadSchedule();
+  }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Wrap(
-          spacing: 12,
-          runSpacing: 8,
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: [
-            ChoiceChip(
-              label: const Text('Bảng'),
-              selected: _tableView,
-              onSelected: (_) => setState(() => _tableView = true),
-            ),
-            ChoiceChip(
-              label: const Text('Timeline'),
-              selected: !_tableView,
-              onSelected: (_) => setState(() => _tableView = false),
-            ),
-            FilledButton.tonalIcon(
-              onPressed: _pickDate,
-              icon: const Icon(Icons.calendar_today_outlined),
-              label: Text(_formattedDate(_selectedDate)),
-              style: FilledButton.styleFrom(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-              ),
-            ),
-            DropdownButton<String>(
-              value: _selectedCourt,
-              items: _courts
-                  .map((court) => DropdownMenuItem(
-                        value: court,
-                        child: Text(court),
-                      ))
-                  .toList(),
-              onChanged: (value) {
-                if (value != null) setState(() => _selectedCourt = value);
-              },
-            ),
-            FilledButton.icon(
-              onPressed: () {},
-              icon: const Icon(Icons.search),
-              label: const Text('Lọc'),
-            ),
-          ],
-        ),
-        const SizedBox(height: 16),
-        Expanded(
-          child: _tableView
-              ? _ScheduleTable(items: filteredItems)
-              : _TimelineView(items: filteredItems),
-        ),
-      ],
+  Future<ManagerScheduleData> _loadSchedule() {
+    final normalized = DateTime(
+      _selectedDate.year,
+      _selectedDate.month,
+      _selectedDate.day,
     );
+    return _service.fetchSchedule(normalized);
   }
 
   Future<void> _pickDate() async {
@@ -114,22 +45,286 @@ class _ManagerSchedulePageState extends State<ManagerSchedulePage> {
       initialDate: _selectedDate,
       firstDate: DateTime.now().subtract(const Duration(days: 365)),
       lastDate: DateTime.now().add(const Duration(days: 365)),
+      locale: const Locale('vi'),
     );
 
     if (picked != null) {
-      setState(() => _selectedDate = picked);
+      setState(() {
+        _selectedDate = picked;
+        _future = _loadSchedule();
+      });
     }
   }
 
-  String _formattedDate(DateTime date) {
-    return '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}';
+  Future<void> _openFilterSheet() async {
+    final current = Set<BookingStatus>.from(_statusFilters);
+    final result = await showModalBottomSheet<Set<BookingStatus>>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        final statuses = BookingStatus.values;
+        return StatefulBuilder(
+          builder: (context, modalSetState) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Lọc trạng thái',
+                    style: TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 4),
+                  const Text('Chọn những trạng thái muốn hiển thị trong lịch.'),
+                  const SizedBox(height: 12),
+                  ...statuses.map((status) {
+                    final checked = current.contains(status);
+                    return CheckboxListTile(
+                      value: checked,
+                      dense: true,
+                      title: Text(_statusText(status)),
+                      activeColor: _statusColor(status),
+                      onChanged: (value) {
+                        modalSetState(() {
+                          if (value == true) {
+                            current.add(status);
+                          } else {
+                            current.remove(status);
+                          }
+                        });
+                      },
+                    );
+                  }),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      TextButton(
+                        onPressed: () {
+                          modalSetState(
+                            () => current.addAll(BookingStatus.values),
+                          );
+                        },
+                        child: const Text('Chọn tất cả'),
+                      ),
+                      const Spacer(),
+                      TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text('Huỷ'),
+                      ),
+                      const SizedBox(width: 8),
+                      FilledButton(
+                        onPressed: () => Navigator.pop(context, current),
+                        child: const Text('Áp dụng'),
+                      )
+                    ],
+                  )
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+
+    if (result != null) {
+      setState(() => _statusFilters = result);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<ManagerScheduleData>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.error_outline, color: Colors.red),
+                const SizedBox(height: 8),
+                Text(
+                  'Không thể tải lịch: ${snapshot.error}',
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                FilledButton.icon(
+                  onPressed: () => setState(() => _future = _loadSchedule()),
+                  icon: const Icon(Icons.refresh_outlined),
+                  label: const Text('Thử lại'),
+                )
+              ],
+            ),
+          );
+        }
+
+        final data = snapshot.data;
+        if (data == null || !data.hasCourts) {
+          return const Center(
+            child: Text('Bạn chưa có sân nào để hiển thị lịch.'),
+          );
+        }
+
+        final availableCourtIds = data.courts.map((c) => c.id).toSet();
+        if (_selectedCourt != 'all' && !availableCourtIds.contains(_selectedCourt)) {
+          WidgetsBinding.instance.addPostFrameCallback(
+            (_) => setState(() => _selectedCourt = 'all'),
+          );
+        }
+
+        final filteredItems = data.items
+            .where((item) {
+              final matchesCourt =
+                  _selectedCourt == 'all' || item.courtId == _selectedCourt;
+              final matchesStatus = _statusFilters.contains(item.status);
+              return matchesCourt && matchesStatus;
+            })
+            .toList()
+          ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                ChoiceChip(
+                  label: const Text('Bảng'),
+                  selected: _tableView,
+                  onSelected: (_) => setState(() => _tableView = true),
+                ),
+                ChoiceChip(
+                  label: const Text('Timeline'),
+                  selected: !_tableView,
+                  onSelected: (_) => setState(() => _tableView = false),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: _pickDate,
+                  icon: const Icon(Icons.calendar_today_outlined),
+                  label: Text(DateFormat('dd/MM').format(_selectedDate)),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 12,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                ),
+                DropdownButton<String>(
+                  value: _selectedCourt,
+                  items: [
+                    const DropdownMenuItem(
+                      value: 'all',
+                      child: Text('Tất cả'),
+                    ),
+                    ...data.courts
+                        .map(
+                          (court) => DropdownMenuItem(
+                            value: court.id,
+                            child: Text(court.label),
+                          ),
+                        )
+                        .toList(),
+                  ],
+                  onChanged: (value) {
+                    if (value != null) setState(() => _selectedCourt = value);
+                  },
+                ),
+                FilledButton.icon(
+                  onPressed: _openFilterSheet,
+                  icon: const Icon(Icons.tune),
+                  label: const Text('Lọc'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: filteredItems.isEmpty
+                  ? const Center(child: Text('Không có lịch trong ngày.'))
+                  : _tableView
+                      ? _ScheduleTable(
+                          items: filteredItems,
+                          formatRange: _formatRange,
+                          statusColor: _statusColor,
+                          statusText: _statusText,
+                        )
+                      : _TimelineView(
+                          items: filteredItems,
+                          formatRange: _formatRange,
+                          statusColor: _statusColor,
+                          statusText: _statusText,
+                          onAction: _showComingSoon,
+                        ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  String _formatRange(DateTime start, DateTime end) {
+    final formatter = DateFormat('HH:mm');
+    return '${formatter.format(start)} - ${formatter.format(end)}';
+  }
+
+  Color _statusColor(BookingStatus status) {
+    switch (status) {
+      case BookingStatus.held:
+        return Colors.orange;
+      case BookingStatus.awaitingPayment:
+        return Colors.blue;
+      case BookingStatus.confirmed:
+        return Colors.green;
+      case BookingStatus.cancelled:
+        return Colors.grey;
+      case BookingStatus.expired:
+        return Colors.red.shade300;
+    }
+  }
+
+  String _statusText(BookingStatus status) {
+    switch (status) {
+      case BookingStatus.held:
+        return 'Giữ chỗ';
+      case BookingStatus.awaitingPayment:
+        return 'Chờ thanh toán';
+      case BookingStatus.confirmed:
+        return 'Đã thanh toán';
+      case BookingStatus.cancelled:
+        return 'Đã huỷ';
+      case BookingStatus.expired:
+        return 'Hết hạn';
+    }
+  }
+
+  void _showComingSoon(String action) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('$action đang được phát triển.')),
+    );
   }
 }
 
 class _ScheduleTable extends StatelessWidget {
-  final List<_ScheduleItem> items;
+  const _ScheduleTable({
+    required this.items,
+    required this.formatRange,
+    required this.statusColor,
+    required this.statusText,
+  });
 
-  const _ScheduleTable({required this.items});
+  final List<ScheduleItem> items;
+  final String Function(DateTime start, DateTime end) formatRange;
+  final Color Function(BookingStatus status) statusColor;
+  final String Function(BookingStatus status) statusText;
 
   @override
   Widget build(BuildContext context) {
@@ -152,18 +347,24 @@ class _ScheduleTable extends StatelessWidget {
                   ],
                   rows: items
                       .map(
-                        (item) => DataRow(cells: [
-                          DataCell(Text(item.court)),
-                          DataCell(Text('${item.start} - ${item.end}')),
-                          DataCell(Text(item.customer)),
-                          DataCell(Text(item.phone)),
-                          DataCell(Chip(
-                            label: Text(item.status),
-                            backgroundColor: item.color.withOpacity(0.1),
-                            side: BorderSide(color: item.color.withOpacity(0.6)),
-                            labelStyle: TextStyle(color: item.color),
-                          )),
-                        ]),
+                        (item) => DataRow(
+                          cells: [
+                            DataCell(Text(item.courtLabel)),
+                            DataCell(Text(formatRange(item.startTime, item.endTime))),
+                            DataCell(Text(item.customerName)),
+                            DataCell(Text(item.customerPhone ?? '-')),
+                            DataCell(
+                              Chip(
+                                label: Text(statusText(item.status)),
+                                backgroundColor: statusColor(item.status).withOpacity(0.1),
+                                side: BorderSide(
+                                  color: statusColor(item.status).withOpacity(0.6),
+                                ),
+                                labelStyle: TextStyle(color: statusColor(item.status)),
+                              ),
+                            ),
+                          ],
+                        ),
                       )
                       .toList(),
                 ),
@@ -177,9 +378,19 @@ class _ScheduleTable extends StatelessWidget {
 }
 
 class _TimelineView extends StatelessWidget {
-  final List<_ScheduleItem> items;
+  const _TimelineView({
+    required this.items,
+    required this.formatRange,
+    required this.statusColor,
+    required this.statusText,
+    required this.onAction,
+  });
 
-  const _TimelineView({required this.items});
+  final List<ScheduleItem> items;
+  final String Function(DateTime start, DateTime end) formatRange;
+  final Color Function(BookingStatus status) statusColor;
+  final String Function(BookingStatus status) statusText;
+  final void Function(String action) onAction;
 
   @override
   Widget build(BuildContext context) {
@@ -190,9 +401,9 @@ class _TimelineView extends StatelessWidget {
         final item = items[index];
         return Container(
           decoration: BoxDecoration(
-            color: item.color.withOpacity(0.05),
+            color: statusColor(item.status).withOpacity(0.05),
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: item.color.withOpacity(0.3)),
+            border: Border.all(color: statusColor(item.status).withOpacity(0.3)),
           ),
           padding: const EdgeInsets.all(16),
           child: Row(
@@ -200,11 +411,14 @@ class _TimelineView extends StatelessWidget {
             children: [
               Column(
                 children: [
-                  CircleAvatar(radius: 6, backgroundColor: item.color),
+                  CircleAvatar(
+                    radius: 6,
+                    backgroundColor: statusColor(item.status),
+                  ),
                   Container(
                     width: 2,
                     height: 60,
-                    color: item.color.withOpacity(0.4),
+                    color: statusColor(item.status).withOpacity(0.4),
                   ),
                 ],
               ),
@@ -215,26 +429,59 @@ class _TimelineView extends StatelessWidget {
                   children: [
                     Row(
                       children: [
-                        Text(item.court, style: const TextStyle(fontWeight: FontWeight.w700)),
+                        Text(
+                          item.courtLabel,
+                          style: const TextStyle(fontWeight: FontWeight.w700),
+                        ),
                         const SizedBox(width: 8),
                         Chip(
-                          label: Text(item.status),
-                          backgroundColor: item.color.withOpacity(0.12),
-                          labelStyle: TextStyle(color: item.color),
-                          side: BorderSide(color: item.color.withOpacity(0.6)),
+                          label: Text(statusText(item.status)),
+                          backgroundColor:
+                              statusColor(item.status).withOpacity(0.12),
+                          labelStyle: TextStyle(color: statusColor(item.status)),
+                          side: BorderSide(
+                            color: statusColor(item.status).withOpacity(0.6),
+                          ),
                         ),
                       ],
                     ),
-                    Text('${item.start} - ${item.end}', style: const TextStyle(fontWeight: FontWeight.w600)),
+                    Text(
+                      formatRange(item.startTime, item.endTime),
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
                     const SizedBox(height: 4),
-                    Text('${item.customer} • ${item.phone}'),
+                    Text(
+                      [
+                        item.customerName,
+                        if (item.customerPhone != null) item.customerPhone!,
+                      ].join(' • '),
+                    ),
+                    if (item.note != null && item.note!.isNotEmpty) ...[
+                      const SizedBox(height: 6),
+                      Text(
+                        'Ghi chú: ${item.note}',
+                        style: const TextStyle(color: Colors.black54),
+                      ),
+                    ],
                     const SizedBox(height: 8),
                     Wrap(
                       spacing: 8,
-                      children: const [
-                        _ActionChip(icon: Icons.swap_horiz, label: 'Đổi giờ/sân'),
-                        _ActionChip(icon: Icons.cancel_outlined, label: 'Hủy booking'),
-                        _ActionChip(icon: Icons.block, label: 'Block slot'),
+                      children: [
+                        _ActionChip(
+                          icon: Icons.swap_horiz,
+                          label: 'Đổi giờ/sân',
+                          onPressed: () => onAction('Đổi giờ/sân'),
+                        ),
+                        _ActionChip(
+                          icon: Icons.cancel_outlined,
+                          label: 'Hủy booking',
+                          onPressed: () => onAction('Hủy booking'),
+                        ),
+                        _ActionChip(
+                          icon: Icons.phone_forwarded_outlined,
+                          label: 'Liên hệ',
+                          onPressed: () => onAction('Liên hệ khách'),
+                        ),
                       ],
                     ),
                   ],
@@ -249,37 +496,22 @@ class _TimelineView extends StatelessWidget {
 }
 
 class _ActionChip extends StatelessWidget {
+  const _ActionChip({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+  });
+
   final IconData icon;
   final String label;
-
-  const _ActionChip({required this.icon, required this.label});
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
     return ActionChip(
       avatar: Icon(icon, size: 18),
       label: Text(label),
-      onPressed: () {},
+      onPressed: onPressed,
     );
   }
-}
-
-class _ScheduleItem {
-  final String court;
-  final String start;
-  final String end;
-  final String customer;
-  final String phone;
-  final String status;
-  final Color color;
-
-  const _ScheduleItem({
-    required this.court,
-    required this.start,
-    required this.end,
-    required this.customer,
-    required this.phone,
-    required this.status,
-    required this.color,
-  });
 }

--- a/lib/services/manager_dashboard_service.dart
+++ b/lib/services/manager_dashboard_service.dart
@@ -231,7 +231,7 @@ class ManagerDashboardService {
     if (bookingIds.isEmpty) return 0;
     final bookingFilter = _buildOrFilter('booking_id', bookingIds);
     final filter =
-        "status='succeeded' && created >= '${dayStart.toIso8601String()}' && created < '${dayEnd.toIso8601String()}' && ($bookingFilter)";
+        "(status='succeeded' || status='success') && created >= '${dayStart.toIso8601String()}' && created < '${dayEnd.toIso8601String()}' && ($bookingFilter)";
 
     ResultList<RecordModel> payments;
     try {

--- a/lib/services/manager_schedule_service.dart
+++ b/lib/services/manager_schedule_service.dart
@@ -133,11 +133,44 @@ class ManagerScheduleService {
     return ScheduleCourt(id: record.id, label: label);
   }
 
+  Future<void> cancelBooking(String bookingId) async {
+    final pocketBase = await getPocketbaseInstance();
+
+    try {
+      await pocketBase.collection(BookingService.collection).update(
+        bookingId,
+        body: {'status': 'cancelled'},
+      );
+    } on ClientException catch (error) {
+      throw BookingServiceException(_mapClientException(error));
+    } catch (_) {
+      throw BookingServiceException(
+        'Không thể huỷ booking. Vui lòng thử lại.',
+      );
+    }
+  }
+
   String _escape(String value) => value.replaceAll("'", "\\'");
 
   String _buildOrFilter(String field, List<String> values) {
     final escaped = values.map(_escape).map((v) => "${field}='${v}'");
     return escaped.join(' || ');
+  }
+
+  String _mapClientException(ClientException error) {
+    if (error.response != null) {
+      final data = error.response!['data'];
+      if (data is Map && data.isNotEmpty) {
+        final first = data.values.first;
+        if (first is Map && first['message'] is String) {
+          return first['message'] as String;
+        }
+      }
+      if (error.response!['message'] is String) {
+        return error.response!['message'] as String;
+      }
+    }
+    return 'Đã xảy ra lỗi. Vui lòng thử lại.';
   }
 
   RecordModel? _resolveExpandedRecord(dynamic expanded) {

--- a/lib/services/manager_schedule_service.dart
+++ b/lib/services/manager_schedule_service.dart
@@ -1,0 +1,167 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/booking.dart';
+import '../models/court_detail.dart';
+import 'booking_service.dart';
+import 'pocketbase_client.dart';
+
+class ManagerScheduleData {
+  const ManagerScheduleData({
+    required this.courts,
+    required this.items,
+  });
+
+  final List<ScheduleCourt> courts;
+  final List<ScheduleItem> items;
+
+  bool get hasCourts => courts.isNotEmpty;
+}
+
+class ScheduleCourt {
+  const ScheduleCourt({required this.id, required this.label});
+
+  final String id;
+  final String label;
+}
+
+class ScheduleItem {
+  const ScheduleItem({
+    required this.id,
+    required this.courtId,
+    required this.courtLabel,
+    required this.startTime,
+    required this.endTime,
+    required this.customerName,
+    required this.status,
+    this.customerPhone,
+    this.note,
+  });
+
+  final String id;
+  final String courtId;
+  final String courtLabel;
+  final DateTime startTime;
+  final DateTime endTime;
+  final String customerName;
+  final String? customerPhone;
+  final BookingStatus status;
+  final String? note;
+}
+
+class ManagerScheduleService {
+  Future<ManagerScheduleData> fetchSchedule(DateTime date) async {
+    final pocketBase = await getPocketbaseInstance();
+    final authRecord = pocketBase.authStore.record;
+
+    if (authRecord == null) {
+      throw ClientException(
+        statusCode: 401,
+        response: {'message': 'Bạn cần đăng nhập để xem lịch.'},
+      );
+    }
+
+    final ownerId = _escape(authRecord.id);
+    final courtsResult = await pocketBase.collection('courts').getList(
+          perPage: 200,
+          filter: "owner='$ownerId'",
+        );
+
+    if (courtsResult.items.isEmpty) {
+      return const ManagerScheduleData(courts: [], items: []);
+    }
+
+    final courtIds = courtsResult.items.map((record) => record.id).toList();
+    final courtFilter = _buildOrFilter('court_id', courtIds);
+
+    final unitsFuture = pocketBase.collection('court_units').getList(
+          perPage: 200,
+          filter: courtFilter,
+        );
+
+    final dayStart = DateTime.utc(date.year, date.month, date.day);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+
+    final bookingsFuture = pocketBase.collection(BookingService.collection).getList(
+          perPage: 200,
+          filter:
+              "$courtFilter && status != 'cancelled' && status != 'expired' && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'",
+          sort: 'start_time',
+          expand: 'user_id,court_unit_id',
+        );
+
+    final results = await Future.wait([unitsFuture, bookingsFuture]);
+
+    final unitResult = results[0] as ResultList<RecordModel>;
+    final bookingResult = results[1] as ResultList<RecordModel>;
+
+    final courts = unitResult.items.map(_mapCourtOption).toList();
+
+    final unitLabelMap = <String, String>{
+      for (final unit in unitResult.items)
+        unit.id: CourtUnit.fromRecord(unit).label.isEmpty
+            ? 'Sân'
+            : CourtUnit.fromRecord(unit).label,
+    };
+
+    final bookings = bookingResult.items.map((record) {
+      final booking = CourtBooking.fromRecord(record);
+      final courtLabel = unitLabelMap[booking.courtUnitId] ?? 'Sân';
+
+      final expandedUser = _resolveExpandedRecord(record.expand?['user_id']);
+      final customerName = _extractUserName(expandedUser) ?? 'Khách lẻ';
+      final customerPhone = _extractUserPhone(expandedUser);
+
+      return ScheduleItem(
+        id: booking.id,
+        courtId: booking.courtUnitId,
+        courtLabel: courtLabel,
+        startTime: booking.startTime.toLocal(),
+        endTime: booking.endTime.toLocal(),
+        customerName: customerName,
+        customerPhone: customerPhone,
+        status: booking.status,
+        note: booking.note,
+      );
+    }).toList(growable: false);
+
+    return ManagerScheduleData(courts: courts, items: bookings);
+  }
+
+  ScheduleCourt _mapCourtOption(RecordModel record) {
+    final unit = CourtUnit.fromRecord(record);
+    final label = unit.label.isEmpty ? 'Sân' : unit.label;
+    return ScheduleCourt(id: record.id, label: label);
+  }
+
+  String _escape(String value) => value.replaceAll("'", "\\'");
+
+  String _buildOrFilter(String field, List<String> values) {
+    final escaped = values.map(_escape).map((v) => "${field}='${v}'");
+    return escaped.join(' || ');
+  }
+
+  RecordModel? _resolveExpandedRecord(dynamic expanded) {
+    if (expanded is RecordModel) return expanded;
+    if (expanded is List) {
+      for (final item in expanded) {
+        if (item is RecordModel) return item;
+      }
+    }
+    return null;
+  }
+
+  String? _extractUserName(RecordModel? expandedUser) {
+    if (expandedUser == null) return null;
+    final data = expandedUser.data;
+    return (data['username'] as String?)?.trim().isNotEmpty == true
+        ? (data['username'] as String?)?.trim()
+        : (data['name'] as String?)?.trim();
+  }
+
+  String? _extractUserPhone(RecordModel? expandedUser) {
+    if (expandedUser == null) return null;
+    final rawPhone = (expandedUser.data['phone'] as String?)?.trim();
+    if (rawPhone == null || rawPhone.isEmpty) return null;
+    return rawPhone;
+  }
+}

--- a/lib/services/manager_schedule_service.dart
+++ b/lib/services/manager_schedule_service.dart
@@ -46,6 +46,30 @@ class ScheduleItem {
   final String? customerPhone;
   final BookingStatus status;
   final String? note;
+
+  ScheduleItem copyWith({
+    String? id,
+    String? courtId,
+    String? courtLabel,
+    DateTime? startTime,
+    DateTime? endTime,
+    String? customerName,
+    String? customerPhone,
+    BookingStatus? status,
+    String? note,
+  }) {
+    return ScheduleItem(
+      id: id ?? this.id,
+      courtId: courtId ?? this.courtId,
+      courtLabel: courtLabel ?? this.courtLabel,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      customerName: customerName ?? this.customerName,
+      customerPhone: customerPhone ?? this.customerPhone,
+      status: status ?? this.status,
+      note: note ?? this.note,
+    );
+  }
 }
 
 class ManagerScheduleService {
@@ -84,7 +108,7 @@ class ManagerScheduleService {
     final bookingsFuture = pocketBase.collection(BookingService.collection).getList(
           perPage: 200,
           filter:
-              "$courtFilter && status != 'cancelled' && status != 'expired' && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'",
+              "$courtFilter && status != 'expired' && start_time < '${dayEnd.toIso8601String()}' && end_time > '${dayStart.toIso8601String()}'",
           sort: 'start_time',
           expand: 'user_id,court_unit_id',
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   intl_phone_field: ^3.2.0
   curved_navigation_bar: ^1.0.6
   image_picker: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   curved_navigation_bar: ^1.0.6
   image_picker: ^1.2.0
   http: ^1.5.0
-  intl: ^0.20.2
+  intl: ^0.19.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add a manager schedule service to load courts and bookings from PocketBase
- update the manager schedule page to use live data with date, court, and status filters
- enhance schedule views with status chips, customer details, and timeline actions

## Testing
- not run (Flutter/Dart SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69397e96e308832ab3b573aa544f0870)