### PR TITLE
Add dismiss option to player suggestion cards

### DIFF
--- a/lib/components/player_suggestion_card.dart
+++ b/lib/components/player_suggestion_card.dart
@@ -14,6 +14,9 @@ class PlayerSuggestionCard extends StatelessWidget {
     this.onTap,
     this.avatarColor,
     this.avatarInitial,
+
+    // NEW: kiểm soát khoảng cách ngoài (để card không dính nhau)
+    this.outerPadding = const EdgeInsets.only(bottom: 20),
   });
 
   final String name;
@@ -21,257 +24,377 @@ class PlayerSuggestionCard extends StatelessWidget {
   final int matchScore;
   final List<String> playTags;
   final String intensityLabel;
+
   final Color? avatarColor;
   final String? avatarInitial;
+
   final VoidCallback? onTap;
   final VoidCallback onProfileTap;
   final VoidCallback onInviteTap;
   final VoidCallback onDismiss;
+
+  /// Khoảng cách bên ngoài card (giữa các thẻ gợi ý).
+  /// Mặc định: bottom 14px.
+  final EdgeInsets outerPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final tt = theme.textTheme;
+
+    final score = matchScore.clamp(0, 100);
+    final tone = _scoreTone(score, cs);
+    final surface = _surfaceColor(theme);
+
+    // FIX: đảm bảo thẻ gợi ý tách nhau ra dù list builder/column không có separator
+    return Padding(
+      padding: outerPadding,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(24),
+          child: Ink(
+            decoration: BoxDecoration(
+              color: surface,
+              borderRadius: BorderRadius.circular(24),
+              border: Border.all(color: cs.outlineVariant.withOpacity(0.55)),
+              boxShadow: [
+                BoxShadow(
+                  blurRadius: 18,
+                  spreadRadius: 0,
+                  offset: const Offset(0, 10),
+                  color: Colors.black.withOpacity(
+                    theme.brightness == Brightness.dark ? 0.18 : 0.08,
+                  ),
+                ),
+              ],
+            ),
+            child: ClipRRect(
+              // giúp ripple/ink nằm gọn trong bo góc
+              borderRadius: BorderRadius.circular(24),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // ===== Header =====
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _Avatar(
+                          initial: (avatarInitial ?? name.characters.first)
+                              .toUpperCase(),
+                          color: avatarColor ?? cs.primaryContainer,
+                        ),
+                        const SizedBox(width: 14),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      name,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: tt.titleMedium?.copyWith(
+                                        fontWeight: FontWeight.w800,
+                                        letterSpacing: -0.2,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 10),
+                                  _MatchBadge(score: score, tone: tone),
+                                  const SizedBox(width: 8),
+                                  _DismissButton(onPressed: onDismiss),
+                                ],
+                              ),
+                              const SizedBox(height: 6),
+                              Row(
+                                children: [
+                                  Icon(Icons.star_rounded,
+                                      size: 18, color: cs.secondary),
+                                  const SizedBox(width: 6),
+                                  Expanded(
+                                    child: Text(
+                                      level,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: tt.bodyMedium?.copyWith(
+                                        fontWeight: FontWeight.w600,
+                                        color: cs.onSurfaceVariant,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: 14),
+
+                    // ===== Tags (chips bên trong card) =====
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        ...playTags.map(
+                          (t) => _PillChip(
+                            label: t,
+                            background: cs.secondaryContainer.withOpacity(0.65),
+                            foreground: cs.onSecondaryContainer,
+                          ),
+                        ),
+                        _PillChip(
+                          icon: Icons.local_fire_department_rounded,
+                          label: 'Intensity: $intensityLabel',
+                          background: cs.tertiaryContainer.withOpacity(0.75),
+                          foreground: cs.onTertiaryContainer,
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: 16),
+
+                    // ===== Actions =====
+                    Row(
+                      children: [
+                        Expanded(
+                          child: FilledButton.tonalIcon(
+                            onPressed: onProfileTap,
+                            icon: const Icon(Icons.remove_red_eye_outlined,
+                                size: 18),
+                            label: const Text('Xem hồ sơ'),
+                            style: FilledButton.styleFrom(
+                              padding: const EdgeInsets.symmetric(
+                                  vertical: 12, horizontal: 14),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(16),
+                              ),
+                              textStyle: tt.labelLarge?.copyWith(
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: FilledButton.icon(
+                            onPressed: onInviteTap,
+                            icon: const Icon(Icons.handshake_rounded, size: 18),
+                            label: const Text('Gửi lời mời'),
+                            style: FilledButton.styleFrom(
+                              padding: const EdgeInsets.symmetric(
+                                  vertical: 12, horizontal: 14),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(16),
+                              ),
+                              textStyle: tt.labelLarge?.copyWith(
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _surfaceColor(ThemeData theme) {
+    final cs = theme.colorScheme;
+    return theme.brightness == Brightness.dark
+        ? cs.surfaceContainerLow
+        : cs.surfaceContainer;
+  }
+
+  _ScoreTone _scoreTone(int score, ColorScheme cs) {
+    if (score >= 80) {
+      return _ScoreTone(
+        bg: cs.primaryContainer,
+        fg: cs.onPrimaryContainer,
+        dot: cs.primary,
+      );
+    }
+    if (score >= 50) {
+      return _ScoreTone(
+        bg: cs.secondaryContainer,
+        fg: cs.onSecondaryContainer,
+        dot: cs.secondary,
+      );
+    }
+    return _ScoreTone(
+      bg: cs.errorContainer,
+      fg: cs.onErrorContainer,
+      dot: cs.error,
+    );
+  }
+}
+
+class _ScoreTone {
+  const _ScoreTone({required this.bg, required this.fg, required this.dot});
+  final Color bg;
+  final Color fg;
+  final Color dot;
+}
+
+class _MatchBadge extends StatelessWidget {
+  const _MatchBadge({required this.score, required this.tone});
+  final int score;
+  final _ScoreTone tone;
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: tone.bg.withOpacity(0.75),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: tone.dot.withOpacity(0.35)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 7,
+            height: 7,
+            decoration: BoxDecoration(
+              color: tone.dot,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            'Match $score%',
+            style: tt.labelMedium?.copyWith(
+              fontWeight: FontWeight.w800,
+              color: tone.fg,
+              letterSpacing: -0.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DismissButton extends StatelessWidget {
+  const _DismissButton({required this.onPressed});
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Tooltip(
+      message: 'Ẩn gợi ý',
+      child: InkResponse(
+        onTap: onPressed,
+        radius: 20,
+        child: Container(
+          width: 30,
+          height: 30,
+          decoration: BoxDecoration(
+            color: cs.surfaceContainerHighest.withOpacity(0.6),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: cs.outlineVariant.withOpacity(0.55)),
+          ),
+          child: Icon(
+            Icons.close_rounded,
+            size: 18,
+            color: cs.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar({required this.initial, required this.color});
+  final String initial;
+  final Color color;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
-    // Gradient cho match score dựa trên giá trị (hiện đại hóa visual feedback)
-    final Color highMatchColor = const Color(0xFF66BB6A); // xanh lá nhạt dễ nhìn
-    Color matchColor = matchScore >= 80
-        ? highMatchColor
-        : (matchScore >= 50 ? cs.secondary : cs.error);
-    Color matchTextColor = matchScore >= 80
-        ? const Color(0xFF1B5E20)
-        : (matchScore >= 50
-            ? cs.onSecondary
-            : matchColor.withOpacity(0.8));
-
-    final dismissBorder = const Color(0xFFC62828);
-    final dismissBackground = const Color(0xFFFFE5E5);
-
-    return Card(
-      elevation: 2, // Elevation nhẹ cho shadow hiện đại
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(20),
-        side: BorderSide(
-            color: cs.outline.withOpacity(0.4),
-            width: 1), // Thêm border cho card
+    return Container(
+      width: 52,
+      height: 52,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.55)),
       ),
-      margin: const EdgeInsets.symmetric(
-          vertical: 8, horizontal: 4), // Tăng vertical margin cho spacing
-      child: InkWell(
-        borderRadius: BorderRadius.circular(20),
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(16), // Tăng padding cho thoáng hơn
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  CircleAvatar(
-                    radius: 28, // Tăng kích thước avatar cho nổi bật
-                    backgroundColor: avatarColor ?? cs.primary.withOpacity(0.15),
-                    child: Text(
-                      (avatarInitial ?? name[0]).toUpperCase(),
-                      style: tt.titleLarge?.copyWith(
-                        // Tăng font size
-                        fontWeight: FontWeight.bold,
-                        color: cs.primary,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Expanded(
-                              child: Text(
-                                name,
-                                style: tt.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 18, // Tăng size cho hiện đại
-                                ),
-                              ),
-                            ),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 12, vertical: 5),
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  // Tăng độ tương phản cho badge match score
-                                  colors: [
-                                    matchColor.withOpacity(0.28),
-                                    matchColor.withOpacity(0.14)
-                                  ],
-                                ),
-                                border: Border.all(
-                                  color: matchColor.withOpacity(0.55),
-                                  width: 0.9,
-                                ),
-                                borderRadius: BorderRadius.circular(11),
-                              ),
-                              child: Text(
-                                'Match: $matchScore%',
-                                style: tt.labelMedium?.copyWith(
-                                  color: matchTextColor,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 10),
-                            SizedBox(
-                              height: 28,
-                              child: OutlinedButton(
-                                onPressed: onDismiss,
-                                style: OutlinedButton.styleFrom(
-                                  padding: EdgeInsets.zero,
-                                  minimumSize: const Size(28, 28),
-                                  maximumSize: const Size(30, 28),
-                                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                                  side: BorderSide(color: dismissBorder, width: 1.4),
-                                  backgroundColor: dismissBackground,
-                                  foregroundColor: dismissBorder,
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(14),
-                                  ),
-                                ),
-                                child: const Icon(
-                                  Icons.remove_rounded,
-                                  size: 16,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 6),
-                        Row(
-                          children: [
-                            Icon(
-                              Icons.star_rate_rounded,
-                              size: 18,
-                              color: cs.secondary
-                                  .withOpacity(0.8), // Giảm opacity để hài hòa
-                            ),
-                            const SizedBox(width: 6),
-                            Text(
-                              level,
-                              style: tt.bodyMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                                color: cs.onSurfaceVariant
-                                    .withOpacity(0.9), // Màu tinh tế hơn
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 12),
-                        Wrap(
-                          spacing: 8,
-                          runSpacing: 8,
-                          alignment:
-                              WrapAlignment.start, // Lệch về bên trái (align left)
-                          children: [
-                            ...playTags.map(
-                              (tag) => Chip(
-                                label: Text(tag),
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: 12,
-                                    vertical: 4), // Tăng padding để tag lớn hơn
-                                backgroundColor:
-                                    cs.secondaryContainer, // Tô đậm màu thẻ
-                                side: BorderSide(
-                                  color: cs.secondary.withOpacity(0.4),
-                                  width: 1,
-                                ),
-                                labelStyle: tt.labelMedium?.copyWith(
-                                  // Tăng từ labelSmall lên labelMedium để chữ lớn hơn
-                                  color: cs.onSecondaryContainer,
-                                  fontWeight: FontWeight.w700,
-                                ),
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(
-                                      16), // Radius lớn hơn cho chip
-                                ),
-                              ),
-                            ),
-                            Chip(
-                              avatar: Icon(
-                                Icons.local_fire_department_rounded,
-                                color: cs.onTertiary, // Giữ màu rõ ràng
-                                size: 18,
-                              ),
-                              label: Text('Intensity: $intensityLabel'),
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 12,
-                                  vertical: 4), // Tăng padding tương tự
-                              backgroundColor:
-                                  cs.tertiaryContainer, // Đầy màu hơn cho tag chính
-                              side: BorderSide(
-                                color: cs.tertiary.withOpacity(0.45),
-                                width: 1,
-                              ),
-                              labelStyle: tt.labelMedium?.copyWith(
-                                // Tăng size chữ
-                                color: cs.onTertiaryContainer,
-                                fontWeight: FontWeight.bold,
-                              ),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Row(
-                children: [
-                  Expanded(
-                    child: FilledButton.icon(
-                      // Chuyển sang FilledButton để nổi bật hơn (thay vì OutlinedButton)
-                      onPressed: onProfileTap,
-                      icon: const Icon(
-                        Icons.remove_red_eye_outlined,
-                        size: 18,
-                        color: Colors.black54,
-                      ),
-                      label: const Text('Xem hồ sơ'),
-                      style: FilledButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 12, horizontal: 16),
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(16)),
-                        backgroundColor: cs.primaryContainer
-                            .withOpacity(0.8), // Giảm opacity nhẹ để hài hòa
-                        foregroundColor: cs.onPrimaryContainer,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: FilledButton.icon(
-                      onPressed: onInviteTap,
-                      icon: const Icon(Icons.handshake_rounded, size: 18),
-                      label: const Text('Gửi lời mời'),
-                      style: FilledButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 12, horizontal: 16),
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(16)),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
+      alignment: Alignment.center,
+      child: Text(
+        initial,
+        style: tt.titleLarge?.copyWith(
+          fontWeight: FontWeight.w900,
+          color: cs.primary,
+          letterSpacing: -0.3,
         ),
+      ),
+    );
+  }
+}
+
+class _PillChip extends StatelessWidget {
+  const _PillChip({
+    required this.label,
+    required this.background,
+    required this.foreground,
+    this.icon,
+  });
+
+  final String label;
+  final Color background;
+  final Color foreground;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: foreground.withOpacity(0.12)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 16, color: foreground.withOpacity(0.9)),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            label,
+            style: tt.labelMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: foreground,
+              letterSpacing: -0.1,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/components/player_suggestion_card.dart
+++ b/lib/components/player_suggestion_card.dart
@@ -66,7 +66,7 @@ class PlayerSuggestionCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   CircleAvatar(
                     radius: 28, // Tăng kích thước avatar cho nổi bật
@@ -86,7 +86,7 @@ class PlayerSuggestionCard extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.center,
                           children: [
                             Expanded(
                               child: Text(
@@ -99,7 +99,7 @@ class PlayerSuggestionCard extends StatelessWidget {
                             ),
                             Container(
                               padding: const EdgeInsets.symmetric(
-                                  horizontal: 12, vertical: 6),
+                                  horizontal: 12, vertical: 5),
                               decoration: BoxDecoration(
                                 gradient: LinearGradient(
                                   // Tăng độ tương phản cho badge match score
@@ -112,7 +112,7 @@ class PlayerSuggestionCard extends StatelessWidget {
                                   color: matchColor.withOpacity(0.55),
                                   width: 0.9,
                                 ),
-                                borderRadius: BorderRadius.circular(12),
+                                borderRadius: BorderRadius.circular(11),
                               ),
                               child: Text(
                                 'Match: $matchScore%',
@@ -122,25 +122,26 @@ class PlayerSuggestionCard extends StatelessWidget {
                                 ),
                               ),
                             ),
-                            const SizedBox(width: 8),
-                            IconButton.filled(
-                              onPressed: onDismiss,
-                              tooltip: 'Bỏ qua gợi ý',
-                              icon: const Icon(Icons.remove_rounded, size: 18),
-                              constraints: const BoxConstraints(
-                                minHeight: 32,
-                                minWidth: 32,
-                              ),
-                              style: IconButton.styleFrom(
-                                backgroundColor: dismissBackground,
-                                foregroundColor: dismissBorder,
-                                padding: const EdgeInsets.all(6),
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(10),
-                                  side: BorderSide(
-                                    color: dismissBorder,
-                                    width: 1.4,
+                            const SizedBox(width: 10),
+                            SizedBox(
+                              height: 28,
+                              child: OutlinedButton(
+                                onPressed: onDismiss,
+                                style: OutlinedButton.styleFrom(
+                                  padding: EdgeInsets.zero,
+                                  minimumSize: const Size(28, 28),
+                                  maximumSize: const Size(30, 28),
+                                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                                  side: BorderSide(color: dismissBorder, width: 1.4),
+                                  backgroundColor: dismissBackground,
+                                  foregroundColor: dismissBorder,
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(14),
                                   ),
+                                ),
+                                child: const Icon(
+                                  Icons.remove_rounded,
+                                  size: 16,
                                 ),
                               ),
                             ),

--- a/lib/components/player_suggestion_card.dart
+++ b/lib/components/player_suggestion_card.dart
@@ -44,6 +44,9 @@ class PlayerSuggestionCard extends StatelessWidget {
             ? cs.onSecondary
             : matchColor.withOpacity(0.8));
 
+    final dismissBorder = const Color(0xFFC62828);
+    final dismissBackground = const Color(0xFFFFE5E5);
+
     return Card(
       elevation: 2, // Elevation nhẹ cho shadow hiện đại
       shape: RoundedRectangleBorder(
@@ -123,12 +126,22 @@ class PlayerSuggestionCard extends StatelessWidget {
                             IconButton.filled(
                               onPressed: onDismiss,
                               tooltip: 'Bỏ qua gợi ý',
-                              icon: const Icon(Icons.remove_rounded),
+                              icon: const Icon(Icons.remove_rounded, size: 18),
+                              constraints: const BoxConstraints(
+                                minHeight: 32,
+                                minWidth: 32,
+                              ),
                               style: IconButton.styleFrom(
-                                backgroundColor: const Color(0xFFFFE5E5),
-                                foregroundColor: const Color(0xFFC62828),
-                                minimumSize: const Size(40, 40),
-                                padding: const EdgeInsets.all(8),
+                                backgroundColor: dismissBackground,
+                                foregroundColor: dismissBorder,
+                                padding: const EdgeInsets.all(6),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(10),
+                                  side: BorderSide(
+                                    color: dismissBorder,
+                                    width: 1.4,
+                                  ),
+                                ),
                               ),
                             ),
                           ],

--- a/lib/components/player_suggestion_card.dart
+++ b/lib/components/player_suggestion_card.dart
@@ -59,207 +59,202 @@ class PlayerSuggestionCard extends StatelessWidget {
         onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.all(16), // Tăng padding cho thoáng hơn
-          child: Stack(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Column(
+              Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      CircleAvatar(
-                        radius: 28, // Tăng kích thước avatar cho nổi bật
-                        backgroundColor:
-                            avatarColor ?? cs.primary.withOpacity(0.15),
-                        child: Text(
-                          (avatarInitial ?? name[0]).toUpperCase(),
-                          style: tt.titleLarge?.copyWith(
-                            // Tăng font size
-                            fontWeight: FontWeight.bold,
-                            color: cs.primary,
-                          ),
-                        ),
+                  CircleAvatar(
+                    radius: 28, // Tăng kích thước avatar cho nổi bật
+                    backgroundColor: avatarColor ?? cs.primary.withOpacity(0.15),
+                    child: Text(
+                      (avatarInitial ?? name[0]).toUpperCase(),
+                      style: tt.titleLarge?.copyWith(
+                        // Tăng font size
+                        fontWeight: FontWeight.bold,
+                        color: cs.primary,
                       ),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: Column(
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    name,
-                                    style: tt.titleMedium?.copyWith(
-                                      fontWeight: FontWeight.bold,
-                                      fontSize: 18, // Tăng size cho hiện đại
-                                    ),
-                                  ),
+                            Expanded(
+                              child: Text(
+                                name,
+                                style: tt.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 18, // Tăng size cho hiện đại
                                 ),
-                                Container(
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 12, vertical: 6),
-                                  decoration: BoxDecoration(
-                                    gradient: LinearGradient(
-                                      // Tăng độ tương phản cho badge match score
-                                      colors: [
-                                        matchColor.withOpacity(0.28),
-                                        matchColor.withOpacity(0.14)
-                                      ],
-                                    ),
-                                    border: Border.all(
-                                      color: matchColor.withOpacity(0.55),
-                                      width: 0.9,
-                                    ),
-                                    borderRadius: BorderRadius.circular(12),
-                                  ),
-                                  child: Text(
-                                    'Match: $matchScore%',
-                                    style: tt.labelMedium?.copyWith(
-                                      color: matchTextColor,
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                                  ),
-                                ),
-                              ],
+                              ),
                             ),
-                            const SizedBox(height: 6),
-                            Row(
-                              children: [
-                                Icon(
-                                  Icons.star_rate_rounded,
-                                  size: 18,
-                                  color: cs.secondary
-                                      .withOpacity(0.8), // Giảm opacity để hài hòa
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 6),
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  // Tăng độ tương phản cho badge match score
+                                  colors: [
+                                    matchColor.withOpacity(0.28),
+                                    matchColor.withOpacity(0.14)
+                                  ],
                                 ),
-                                const SizedBox(width: 6),
-                                Text(
-                                  level,
-                                  style: tt.bodyMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                    color: cs.onSurfaceVariant
-                                        .withOpacity(0.9), // Màu tinh tế hơn
-                                  ),
+                                border: Border.all(
+                                  color: matchColor.withOpacity(0.55),
+                                  width: 0.9,
                                 ),
-                              ],
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: Text(
+                                'Match: $matchScore%',
+                                style: tt.labelMedium?.copyWith(
+                                  color: matchTextColor,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
                             ),
-                            const SizedBox(height: 12),
-                            Wrap(
-                              spacing: 8,
-                              runSpacing: 8,
-                              alignment:
-                                  WrapAlignment.start, // Lệch về bên trái (align left)
-                              children: [
-                                ...playTags.map(
-                                  (tag) => Chip(
-                                    label: Text(tag),
-                                    padding: const EdgeInsets.symmetric(
-                                        horizontal: 12,
-                                        vertical: 4), // Tăng padding để tag lớn hơn
-                                    backgroundColor: cs
-                                        .secondaryContainer, // Tô đậm màu thẻ
-                                    side: BorderSide(
-                                      color: cs.secondary.withOpacity(0.4),
-                                      width: 1,
-                                    ),
-                                    labelStyle: tt.labelMedium?.copyWith(
-                                      // Tăng từ labelSmall lên labelMedium để chữ lớn hơn
-                                      color: cs.onSecondaryContainer,
-                                      fontWeight: FontWeight.w700,
-                                    ),
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(
-                                          16), // Radius lớn hơn cho chip
-                                    ),
-                                  ),
-                                ),
-                                Chip(
-                                  avatar: Icon(
-                                    Icons.local_fire_department_rounded,
-                                    color: cs.onTertiary, // Giữ màu rõ ràng
-                                    size: 18,
-                                  ),
-                                  label: Text('Intensity: $intensityLabel'),
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 12,
-                                      vertical: 4), // Tăng padding tương tự
-                                  backgroundColor: cs
-                                      .tertiaryContainer, // Đầy màu hơn cho tag chính
-                                  side: BorderSide(
-                                    color: cs.tertiary.withOpacity(0.45),
-                                    width: 1,
-                                  ),
-                                  labelStyle: tt.labelMedium?.copyWith(
-                                    // Tăng size chữ
-                                    color: cs.onTertiaryContainer,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(16),
-                                  ),
-                                ),
-                              ],
+                            const SizedBox(width: 8),
+                            IconButton.filled(
+                              onPressed: onDismiss,
+                              tooltip: 'Bỏ qua gợi ý',
+                              icon: const Icon(Icons.remove_rounded),
+                              style: IconButton.styleFrom(
+                                backgroundColor: const Color(0xFFFFE5E5),
+                                foregroundColor: const Color(0xFFC62828),
+                                minimumSize: const Size(40, 40),
+                                padding: const EdgeInsets.all(8),
+                              ),
                             ),
                           ],
                         ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: FilledButton.icon(
-                          // Chuyển sang FilledButton để nổi bật hơn (thay vì OutlinedButton)
-                          onPressed: onProfileTap,
-                          icon: const Icon(
-                            Icons.remove_red_eye_outlined,
-                            size: 18,
-                            color: Colors.black54,
-                          ),
-                          label: const Text('Xem hồ sơ'),
-                          style: FilledButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(
-                                vertical: 12, horizontal: 16),
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16)),
-                            backgroundColor: cs.primaryContainer
-                                .withOpacity(0.8), // Giảm opacity nhẹ để hài hòa
-                            foregroundColor: cs.onPrimaryContainer,
-                          ),
+                        const SizedBox(height: 6),
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.star_rate_rounded,
+                              size: 18,
+                              color: cs.secondary
+                                  .withOpacity(0.8), // Giảm opacity để hài hòa
+                            ),
+                            const SizedBox(width: 6),
+                            Text(
+                              level,
+                              style: tt.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                                color: cs.onSurfaceVariant
+                                    .withOpacity(0.9), // Màu tinh tế hơn
+                              ),
+                            ),
+                          ],
                         ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: FilledButton.icon(
-                          onPressed: onInviteTap,
-                          icon: const Icon(Icons.handshake_rounded, size: 18),
-                          label: const Text('Gửi lời mời'),
-                          style: FilledButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(
-                                vertical: 12, horizontal: 16),
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16)),
-                          ),
+                        const SizedBox(height: 12),
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          alignment:
+                              WrapAlignment.start, // Lệch về bên trái (align left)
+                          children: [
+                            ...playTags.map(
+                              (tag) => Chip(
+                                label: Text(tag),
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 12,
+                                    vertical: 4), // Tăng padding để tag lớn hơn
+                                backgroundColor:
+                                    cs.secondaryContainer, // Tô đậm màu thẻ
+                                side: BorderSide(
+                                  color: cs.secondary.withOpacity(0.4),
+                                  width: 1,
+                                ),
+                                labelStyle: tt.labelMedium?.copyWith(
+                                  // Tăng từ labelSmall lên labelMedium để chữ lớn hơn
+                                  color: cs.onSecondaryContainer,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(
+                                      16), // Radius lớn hơn cho chip
+                                ),
+                              ),
+                            ),
+                            Chip(
+                              avatar: Icon(
+                                Icons.local_fire_department_rounded,
+                                color: cs.onTertiary, // Giữ màu rõ ràng
+                                size: 18,
+                              ),
+                              label: Text('Intensity: $intensityLabel'),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 4), // Tăng padding tương tự
+                              backgroundColor:
+                                  cs.tertiaryContainer, // Đầy màu hơn cho tag chính
+                              side: BorderSide(
+                                color: cs.tertiary.withOpacity(0.45),
+                                width: 1,
+                              ),
+                              labelStyle: tt.labelMedium?.copyWith(
+                                // Tăng size chữ
+                                color: cs.onTertiaryContainer,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(16),
+                              ),
+                            ),
+                          ],
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ],
               ),
-              Positioned(
-                top: 0,
-                right: 0,
-                child: IconButton.filledTonal(
-                  onPressed: onDismiss,
-                  tooltip: 'Bỏ qua gợi ý',
-                  icon: const Icon(Icons.close_rounded),
-                  style: IconButton.styleFrom(
-                    minimumSize: const Size(40, 40),
-                    padding: const EdgeInsets.all(8),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: FilledButton.icon(
+                      // Chuyển sang FilledButton để nổi bật hơn (thay vì OutlinedButton)
+                      onPressed: onProfileTap,
+                      icon: const Icon(
+                        Icons.remove_red_eye_outlined,
+                        size: 18,
+                        color: Colors.black54,
+                      ),
+                      label: const Text('Xem hồ sơ'),
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 12, horizontal: 16),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16)),
+                        backgroundColor: cs.primaryContainer
+                            .withOpacity(0.8), // Giảm opacity nhẹ để hài hòa
+                        foregroundColor: cs.onPrimaryContainer,
+                      ),
+                    ),
                   ),
-                ),
-              )
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: onInviteTap,
+                      icon: const Icon(Icons.handshake_rounded, size: 18),
+                      label: const Text('Gửi lời mời'),
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 12, horizontal: 16),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16)),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ],
           ),
         ),

--- a/lib/components/player_suggestion_card.dart
+++ b/lib/components/player_suggestion_card.dart
@@ -10,6 +10,7 @@ class PlayerSuggestionCard extends StatelessWidget {
     required this.intensityLabel,
     required this.onProfileTap,
     required this.onInviteTap,
+    required this.onDismiss,
     this.onTap,
     this.avatarColor,
     this.avatarInitial,
@@ -25,6 +26,7 @@ class PlayerSuggestionCard extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback onProfileTap;
   final VoidCallback onInviteTap;
+  final VoidCallback onDismiss;
 
   @override
   Widget build(BuildContext context) {
@@ -57,189 +59,208 @@ class PlayerSuggestionCard extends StatelessWidget {
         onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.all(16), // Tăng padding cho thoáng hơn
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          child: Stack(
             children: [
-              Row(
+              Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  CircleAvatar(
-                    radius: 28, // Tăng kích thước avatar cho nổi bật
-                    backgroundColor: avatarColor ?? cs.primary.withOpacity(0.15),
-                    child: Text(
-                      (avatarInitial ?? name[0]).toUpperCase(),
-                      style: tt.titleLarge?.copyWith(
-                        // Tăng font size
-                        fontWeight: FontWeight.bold,
-                        color: cs.primary,
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      CircleAvatar(
+                        radius: 28, // Tăng kích thước avatar cho nổi bật
+                        backgroundColor:
+                            avatarColor ?? cs.primary.withOpacity(0.15),
+                        child: Text(
+                          (avatarInitial ?? name[0]).toUpperCase(),
+                          style: tt.titleLarge?.copyWith(
+                            // Tăng font size
+                            fontWeight: FontWeight.bold,
+                            color: cs.primary,
+                          ),
+                        ),
                       ),
-                    ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    name,
+                                    style: tt.titleMedium?.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 18, // Tăng size cho hiện đại
+                                    ),
+                                  ),
+                                ),
+                                Container(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 12, vertical: 6),
+                                  decoration: BoxDecoration(
+                                    gradient: LinearGradient(
+                                      // Tăng độ tương phản cho badge match score
+                                      colors: [
+                                        matchColor.withOpacity(0.28),
+                                        matchColor.withOpacity(0.14)
+                                      ],
+                                    ),
+                                    border: Border.all(
+                                      color: matchColor.withOpacity(0.55),
+                                      width: 0.9,
+                                    ),
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  child: Text(
+                                    'Match: $matchScore%',
+                                    style: tt.labelMedium?.copyWith(
+                                      color: matchTextColor,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+                            Row(
+                              children: [
+                                Icon(
+                                  Icons.star_rate_rounded,
+                                  size: 18,
+                                  color: cs.secondary
+                                      .withOpacity(0.8), // Giảm opacity để hài hòa
+                                ),
+                                const SizedBox(width: 6),
+                                Text(
+                                  level,
+                                  style: tt.bodyMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                    color: cs.onSurfaceVariant
+                                        .withOpacity(0.9), // Màu tinh tế hơn
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 12),
+                            Wrap(
+                              spacing: 8,
+                              runSpacing: 8,
+                              alignment:
+                                  WrapAlignment.start, // Lệch về bên trái (align left)
+                              children: [
+                                ...playTags.map(
+                                  (tag) => Chip(
+                                    label: Text(tag),
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 12,
+                                        vertical: 4), // Tăng padding để tag lớn hơn
+                                    backgroundColor: cs
+                                        .secondaryContainer, // Tô đậm màu thẻ
+                                    side: BorderSide(
+                                      color: cs.secondary.withOpacity(0.4),
+                                      width: 1,
+                                    ),
+                                    labelStyle: tt.labelMedium?.copyWith(
+                                      // Tăng từ labelSmall lên labelMedium để chữ lớn hơn
+                                      color: cs.onSecondaryContainer,
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          16), // Radius lớn hơn cho chip
+                                    ),
+                                  ),
+                                ),
+                                Chip(
+                                  avatar: Icon(
+                                    Icons.local_fire_department_rounded,
+                                    color: cs.onTertiary, // Giữ màu rõ ràng
+                                    size: 18,
+                                  ),
+                                  label: Text('Intensity: $intensityLabel'),
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 12,
+                                      vertical: 4), // Tăng padding tương tự
+                                  backgroundColor: cs
+                                      .tertiaryContainer, // Đầy màu hơn cho tag chính
+                                  side: BorderSide(
+                                    color: cs.tertiary.withOpacity(0.45),
+                                    width: 1,
+                                  ),
+                                  labelStyle: tt.labelMedium?.copyWith(
+                                    // Tăng size chữ
+                                    color: cs.onTertiaryContainer,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(16),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            Expanded(
-                              child: Text(
-                                name,
-                                style: tt.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 18, // Tăng size cho hiện đại
-                                ),
-                              ),
-                            ),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 12, vertical: 6),
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  // Tăng độ tương phản cho badge match score
-                                  colors: [
-                                    matchColor.withOpacity(0.28),
-                                    matchColor.withOpacity(0.14)
-                                  ],
-                                ),
-                                border: Border.all(
-                                  color: matchColor.withOpacity(0.55),
-                                  width: 0.9,
-                                ),
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              child: Text(
-                                'Match: $matchScore%',
-                                style: tt.labelMedium?.copyWith(
-                                  color: matchTextColor,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ],
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: FilledButton.icon(
+                          // Chuyển sang FilledButton để nổi bật hơn (thay vì OutlinedButton)
+                          onPressed: onProfileTap,
+                          icon: const Icon(
+                            Icons.remove_red_eye_outlined,
+                            size: 18,
+                            color: Colors.black54,
+                          ),
+                          label: const Text('Xem hồ sơ'),
+                          style: FilledButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                                vertical: 12, horizontal: 16),
+                            shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(16)),
+                            backgroundColor: cs.primaryContainer
+                                .withOpacity(0.8), // Giảm opacity nhẹ để hài hòa
+                            foregroundColor: cs.onPrimaryContainer,
+                          ),
                         ),
-                        const SizedBox(height: 6),
-                        Row(
-                          children: [
-                            Icon(
-                              Icons.star_rate_rounded,
-                              size: 18,
-                              color: cs.secondary
-                                  .withOpacity(0.8), // Giảm opacity để hài hòa
-                            ),
-                            const SizedBox(width: 6),
-                            Text(
-                              level,
-                              style: tt.bodyMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                                color: cs.onSurfaceVariant
-                                    .withOpacity(0.9), // Màu tinh tế hơn
-                              ),
-                            ),
-                          ],
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: FilledButton.icon(
+                          onPressed: onInviteTap,
+                          icon: const Icon(Icons.handshake_rounded, size: 18),
+                          label: const Text('Gửi lời mời'),
+                          style: FilledButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                                vertical: 12, horizontal: 16),
+                            shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(16)),
+                          ),
                         ),
-                        const SizedBox(height: 12),
-                        Wrap(
-                          spacing: 8,
-                          runSpacing: 8,
-                          alignment:
-                              WrapAlignment.start, // Lệch về bên trái (align left)
-                          children: [
-                            ...playTags.map(
-                              (tag) => Chip(
-                                label: Text(tag),
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: 12,
-                                    vertical: 4), // Tăng padding để tag lớn hơn
-                                backgroundColor:
-                                    cs.secondaryContainer, // Tô đậm màu thẻ
-                                side: BorderSide(
-                                  color: cs.secondary.withOpacity(0.4),
-                                  width: 1,
-                                ),
-                                labelStyle: tt.labelMedium?.copyWith(
-                                  // Tăng từ labelSmall lên labelMedium để chữ lớn hơn
-                                  color: cs.onSecondaryContainer,
-                                  fontWeight: FontWeight.w700,
-                                ),
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(
-                                      16), // Radius lớn hơn cho chip
-                                ),
-                              ),
-                            ),
-                            Chip(
-                              avatar: Icon(
-                                Icons.local_fire_department_rounded,
-                                color: cs.onTertiary, // Giữ màu rõ ràng
-                                size: 18,
-                              ),
-                              label: Text('Intensity: $intensityLabel'),
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 12,
-                                  vertical: 4), // Tăng padding tương tự
-                              backgroundColor: cs.tertiaryContainer, // Đầy màu hơn cho tag chính
-                              side: BorderSide(
-                                color: cs.tertiary.withOpacity(0.45),
-                                width: 1,
-                              ),
-                              labelStyle: tt.labelMedium?.copyWith(
-                                // Tăng size chữ
-                                color: cs.onTertiaryContainer,
-                                fontWeight: FontWeight.bold,
-                              ),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
                 ],
               ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                Expanded(
-                  child: FilledButton.icon(
-                    // Chuyển sang FilledButton để nổi bật hơn (thay vì OutlinedButton)
-                    onPressed: onProfileTap,
-                    icon: const Icon(
-                      Icons.remove_red_eye_outlined,
-                      size: 18,
-                      color: Colors.black54,
-                    ),
-                    label: const Text('Xem hồ sơ'),
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 12, horizontal: 16),
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16)),
-                      backgroundColor: cs.primaryContainer
-                          .withOpacity(0.8), // Giảm opacity nhẹ để hài hòa
-                      foregroundColor: cs.onPrimaryContainer,
-                    ),
+              Positioned(
+                top: 0,
+                right: 0,
+                child: IconButton.filledTonal(
+                  onPressed: onDismiss,
+                  tooltip: 'Bỏ qua gợi ý',
+                  icon: const Icon(Icons.close_rounded),
+                  style: IconButton.styleFrom(
+                    minimumSize: const Size(40, 40),
+                    padding: const EdgeInsets.all(8),
                   ),
                 ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: FilledButton.icon(
-                    onPressed: onInviteTap,
-                    icon: const Icon(Icons.handshake_rounded, size: 18),
-                    label: const Text('Gửi lời mời'),
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 12, horizontal: 16),
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16)),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ],
+              )
+            ],
           ),
         ),
       ),

--- a/lib/pages/social/partner_suggestion_manager.dart
+++ b/lib/pages/social/partner_suggestion_manager.dart
@@ -163,6 +163,13 @@ class PartnerSuggestionManager extends ChangeNotifier {
     _notifyListeners();
   }
 
+  void dismissSuggestion(String userId) {
+    _suggestions = _suggestions
+        .where((suggestion) => suggestion.friend.user.id != userId)
+        .toList(growable: false);
+    _applyFilters();
+  }
+
   @override
   void dispose() {
     _isDisposed = true;

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -739,6 +739,8 @@ class SocialPageState extends State<SocialPage> {
                             context: context,
                             friend: suggestion.friend,
                           ),
+                          onDismiss: () => partnerManager
+                              .dismissSuggestion(suggestion.friend.user.id),
                         );
                       },
                       childCount: suggestions.length,


### PR DESCRIPTION
## Summary
- add dismiss control to player suggestion cards to let users decline recommendations
- handle suggestion removal in the partner suggestion manager
- wire new action into the social page suggestion list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ed221ef20832abd0eef6b2593d83e)