### PR TITLE
Add recommendation dismiss handling and event logging

### DIFF
--- a/lib/pages/social/partner_suggestion_manager.dart
+++ b/lib/pages/social/partner_suggestion_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:badminton_booking_app/models/partner_recommendation.dart';
 import 'package:badminton_booking_app/models/friend_relation.dart';
 import 'package:badminton_booking_app/services/recommender_service.dart';
@@ -27,6 +29,8 @@ class PartnerSuggestionManager extends ChangeNotifier {
   double _minMatchScore = 0;
   bool _hideExistingRelations = false;
   String? _homeCourtId;
+  bool _hasLoggedShown = false;
+  final Set<String> _dismissedUserIds = <String>{};
   final Map<String, FriendRelationStatus> _relations =
       <String, FriendRelationStatus>{};
 
@@ -44,6 +48,7 @@ class PartnerSuggestionManager extends ChangeNotifier {
     if (_isLoading) return;
     _isLoading = true;
     _error = null;
+    _hasLoggedShown = false;
     if (force) {
       _suggestions = const <PartnerRecommendation>[];
       _filteredSuggestions = const <PartnerRecommendation>[];
@@ -51,7 +56,10 @@ class PartnerSuggestionManager extends ChangeNotifier {
     _notifyListeners();
 
     try {
-      _suggestions = await _service.fetchRecommendations();
+      final results = await _service.fetchRecommendations();
+      _suggestions = results
+          .where((rec) => !_dismissedUserIds.contains(rec.friend.user.id))
+          .toList(growable: false);
       await _maybeLoadRelations();
       _applyFilters();
     } catch (err) {
@@ -131,6 +139,10 @@ class PartnerSuggestionManager extends ChangeNotifier {
     _filteredSuggestions = _suggestions.where((suggestion) {
       final details = suggestion.friend.details;
 
+      if (_dismissedUserIds.contains(suggestion.friend.user.id)) {
+        return false;
+      }
+
       if (_selectedMatchType != null &&
           !(details?.matchTypes.contains(_selectedMatchType) ?? false)) {
         return false;
@@ -161,13 +173,50 @@ class PartnerSuggestionManager extends ChangeNotifier {
     }).toList(growable: false);
 
     _notifyListeners();
+    _logShownIfNeeded();
   }
 
   void dismissSuggestion(String userId) {
+    _dismissedUserIds.add(userId);
     _suggestions = _suggestions
         .where((suggestion) => suggestion.friend.user.id != userId)
         .toList(growable: false);
     _applyFilters();
+  }
+
+  Future<void> logProfileClicked(String userId) async {
+    await _safeLog(() => _service.logProfileClicked(userId));
+  }
+
+  Future<void> logInviteAction(String userId) async {
+    await _safeLog(
+      () => _service.logRecommendationAction(action: 'invited', targetUserId: userId),
+    );
+  }
+
+  Future<void> logActionOutcome(String userId, String outcome) async {
+    await _safeLog(
+      () => _service.logRecommendationOutcome(outcome: outcome, targetUserId: userId),
+    );
+  }
+
+  void _logShownIfNeeded() {
+    if (_hasLoggedShown || _filteredSuggestions.isEmpty) return;
+    _hasLoggedShown = true;
+
+    final ids = _filteredSuggestions
+        .map((suggestion) => suggestion.friend.user.id)
+        .toList(growable: false);
+
+    unawaited(_safeLog(() => _service.logRecommendationsShown(ids)));
+  }
+
+  Future<void> _safeLog(Future<void> Function() runner) async {
+    try {
+      await runner();
+    } catch (_) {
+      // Bỏ qua lỗi log để không ảnh hưởng trải nghiệm người dùng
+    }
   }
 
   @override

--- a/lib/pages/social/partner_suggestion_manager.dart
+++ b/lib/pages/social/partner_suggestion_manager.dart
@@ -30,6 +30,7 @@ class PartnerSuggestionManager extends ChangeNotifier {
   bool _hideExistingRelations = false;
   String? _homeCourtId;
   bool _hasLoggedShown = false;
+  String _currentSessionId = _newSessionId();
   final Set<String> _dismissedUserIds = <String>{};
   final Map<String, FriendRelationStatus> _relations =
       <String, FriendRelationStatus>{};
@@ -49,6 +50,7 @@ class PartnerSuggestionManager extends ChangeNotifier {
     _isLoading = true;
     _error = null;
     _hasLoggedShown = false;
+    _currentSessionId = _newSessionId();
     if (force) {
       _suggestions = const <PartnerRecommendation>[];
       _filteredSuggestions = const <PartnerRecommendation>[];
@@ -181,6 +183,9 @@ class PartnerSuggestionManager extends ChangeNotifier {
     _suggestions = _suggestions
         .where((suggestion) => suggestion.friend.user.id != userId)
         .toList(growable: false);
+    unawaited(
+      _safeLog(() => _service.logRecommendationDismissed(userId)),
+    );
     _applyFilters();
   }
 
@@ -204,11 +209,18 @@ class PartnerSuggestionManager extends ChangeNotifier {
     if (_hasLoggedShown || _filteredSuggestions.isEmpty) return;
     _hasLoggedShown = true;
 
-    final ids = _filteredSuggestions
-        .map((suggestion) => suggestion.friend.user.id)
-        .toList(growable: false);
+    final items = <RecommendationShownItem>[
+      for (int i = 0; i < _filteredSuggestions.length; i++)
+        RecommendationShownItem(
+          toUserId: _filteredSuggestions[i].friend.user.id,
+          rankShown: i + 1,
+        )
+    ];
 
-    unawaited(_safeLog(() => _service.logRecommendationsShown(ids)));
+    unawaited(_safeLog(() => _service.logRecommendationsShown(
+          sessionId: _currentSessionId,
+          items: items,
+        )));
   }
 
   Future<void> _safeLog(Future<void> Function() runner) async {
@@ -229,4 +241,7 @@ class PartnerSuggestionManager extends ChangeNotifier {
     if (_isDisposed) return;
     notifyListeners();
   }
+
+  static String _newSessionId() =>
+      DateTime.now().microsecondsSinceEpoch.toString();
 }

--- a/lib/pages/social/social_page.dart
+++ b/lib/pages/social/social_page.dart
@@ -957,6 +957,7 @@ class SocialPageState extends State<SocialPage> {
   }
 
   void _openProfile(BuildContext context, FriendSearchResult friend) {
+    unawaited(_partnerManager.logProfileClicked(friend.user.id));
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => UserPublicProfilePage(result: friend),
@@ -974,6 +975,8 @@ class SocialPageState extends State<SocialPage> {
     setState(() {
       _pendingRequests.add(userId);
     });
+
+    unawaited(_partnerManager.logInviteAction(friend.user.id));
 
     try {
       await showModalBottomSheet<void>(

--- a/lib/services/friend_request_service.dart
+++ b/lib/services/friend_request_service.dart
@@ -5,13 +5,19 @@ import '../models/friend_request.dart';
 import '../models/friend_search_result.dart';
 import '../models/user.dart';
 import '../services/pocketbase_client.dart';
+import '../services/recommender_service.dart';
 import '../services/user_service.dart';
 import '../utils/time_ago.dart';
 
 class FriendRequestService {
-  FriendRequestService() : _userDetailsService = UserDetailsService();
+  FriendRequestService({
+    UserDetailsService? userDetailsService,
+    RecommenderService? recommenderService,
+  })  : _userDetailsService = userDetailsService ?? UserDetailsService(),
+        _recommenderService = recommenderService ?? RecommenderService();
 
   final UserDetailsService _userDetailsService;
+  final RecommenderService _recommenderService;
 
   Future<List<FriendRequestItem>> fetchIncomingRequests() async {
     final pb = await getPocketbaseInstance();
@@ -177,6 +183,13 @@ class FriendRequestService {
         'to_user': toUserId,
         'status': 'pending',
       });
+
+      await _safeLog(
+        () => _recommenderService.logRecommendationAction(
+          action: 'invited',
+          targetUserId: toUserId,
+        ),
+      );
       return rec.id;
     } on ClientException catch (err) {
       final msg = err.response['message'] ?? 'Không thể gửi lời mời kết bạn.';
@@ -214,6 +227,13 @@ class FriendRequestService {
     );
 
     await _createFriendship(pb, request.from.user.id, currentUserId);
+
+    await _safeLog(
+      () => _recommenderService.logRecommendationOutcome(
+        outcome: 'accepted',
+        targetUserId: request.from.user.id,
+      ),
+    );
   }
 
   Future<void> acceptFriendRequestById(
@@ -232,6 +252,13 @@ class FriendRequestService {
     );
 
     await _createFriendship(pb, fromUserId, currentUserId);
+
+    await _safeLog(
+      () => _recommenderService.logRecommendationOutcome(
+        outcome: 'accepted',
+        targetUserId: fromUserId,
+      ),
+    );
   }
 
   Future<void> rejectFriendRequest(String requestId) async {
@@ -266,6 +293,14 @@ class FriendRequestService {
       final msg = err.response['message'] ?? '';
       if (msg.contains('idx_friendships_pair')) return;
       rethrow;
+    }
+  }
+
+  Future<void> _safeLog(Future<void> Function() runner) async {
+    try {
+      await runner();
+    } catch (_) {
+      // ignore logging errors to avoid blocking the main action
     }
   }
 }

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -182,9 +182,23 @@ class InvitationService {
             mode:
                 invitation.type.name, // 'recruitment' | 'booking' | 'proposed'
           );
+          await recommender.logRecommendationAction(
+            action: 'accepted',
+            targetUserId: invitation.fromUserId,
+          );
         } catch (e) {
           // Không để lỗi log làm hỏng UX accept
           print('[INVITATION][ACCEPT][RECO_ERROR] $e');
+        }
+      } else {
+        try {
+          final recommender = RecommenderService();
+          await recommender.logRecommendationOutcome(
+            outcome: 'rejected',
+            targetUserId: invitation.fromUserId,
+          );
+        } catch (e) {
+          print('[INVITATION][REJECT][RECO_ERROR] $e');
         }
       }
       // ------------------------------------------------------------

--- a/lib/services/recommender_service.dart
+++ b/lib/services/recommender_service.dart
@@ -78,6 +78,62 @@ class RecommenderService {
     return results;
   }
 
+  Future<void> logRecommendationsShown(List<String> shownUserIds) async {
+    final userId = await _requireCurrentUserId();
+
+    await _postEvent(
+      path: '/events/recommendations/shown',
+      body: {
+        'user_id': userId,
+        'shown_user_ids': shownUserIds,
+      },
+    );
+  }
+
+  Future<void> logProfileClicked(String targetUserId) async {
+    final userId = await _requireCurrentUserId();
+
+    await _postEvent(
+      path: '/events/recommendations/clicked_profile',
+      body: {
+        'user_id': userId,
+        'target_user_id': targetUserId,
+      },
+    );
+  }
+
+  Future<void> logRecommendationAction({
+    required String action,
+    required String targetUserId,
+  }) async {
+    final userId = await _requireCurrentUserId();
+
+    await _postEvent(
+      path: '/events/recommendations/action',
+      body: {
+        'user_id': userId,
+        'target_user_id': targetUserId,
+        'action': action,
+      },
+    );
+  }
+
+  Future<void> logRecommendationOutcome({
+    required String outcome,
+    required String targetUserId,
+  }) async {
+    final userId = await _requireCurrentUserId();
+
+    await _postEvent(
+      path: '/events/recommendations/outcome',
+      body: {
+        'user_id': userId,
+        'target_user_id': targetUserId,
+        'outcome': outcome,
+      },
+    );
+  }
+
   Future<PartnerRecommendation> _mapCandidate(
     Map<String, dynamic> json,
     PocketBase pb,
@@ -168,6 +224,31 @@ class RecommenderService {
       throw Exception(
         'notifyInvitationAccepted failed: ${res.statusCode} -> ${res.body}',
       );
+    }
+  }
+
+  Future<String> _requireCurrentUserId() async {
+    final pb = await getPocketbaseInstance();
+    final currentUserId = pb.authStore.record?.id;
+    if (currentUserId == null) {
+      throw Exception('Bạn chưa đăng nhập.');
+    }
+    return currentUserId;
+  }
+
+  Future<void> _postEvent({
+    required String path,
+    required Map<String, dynamic> body,
+  }) async {
+    final uri = Uri.parse('$_baseUrl$path');
+    final res = await _client.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(body),
+    );
+
+    if (res.statusCode != 200) {
+      throw Exception('Event $path failed: ${res.statusCode} -> ${res.body}');
     }
   }
 }

--- a/lib/services/recommender_service.dart
+++ b/lib/services/recommender_service.dart
@@ -78,14 +78,20 @@ class RecommenderService {
     return results;
   }
 
-  Future<void> logRecommendationsShown(List<String> shownUserIds) async {
+  Future<void> logRecommendationsShown({
+    required String sessionId,
+    required List<RecommendationShownItem> items,
+  }) async {
+    if (items.isEmpty) return;
+
     final userId = await _requireCurrentUserId();
 
     await _postEvent(
       path: '/events/recommendations/shown',
       body: {
-        'user_id': userId,
-        'shown_user_ids': shownUserIds,
+        'from_user_id': userId,
+        'session_id': sessionId,
+        'items': items.map((item) => item.toJson()).toList(),
       },
     );
   }
@@ -96,8 +102,8 @@ class RecommenderService {
     await _postEvent(
       path: '/events/recommendations/clicked_profile',
       body: {
-        'user_id': userId,
-        'target_user_id': targetUserId,
+        'from_user_id': userId,
+        'to_user_id': targetUserId,
       },
     );
   }
@@ -111,8 +117,8 @@ class RecommenderService {
     await _postEvent(
       path: '/events/recommendations/action',
       body: {
-        'user_id': userId,
-        'target_user_id': targetUserId,
+        'from_user_id': userId,
+        'to_user_id': targetUserId,
         'action': action,
       },
     );
@@ -127,9 +133,25 @@ class RecommenderService {
     await _postEvent(
       path: '/events/recommendations/outcome',
       body: {
-        'user_id': userId,
-        'target_user_id': targetUserId,
+        'from_user_id': userId,
+        'to_user_id': targetUserId,
         'outcome': outcome,
+      },
+    );
+  }
+
+  Future<void> logRecommendationDismissed(
+    String targetUserId, {
+    String? reason,
+  }) async {
+    final userId = await _requireCurrentUserId();
+
+    await _postEvent(
+      path: '/events/recommendations/dismiss',
+      body: {
+        'from_user_id': userId,
+        'to_user_id': targetUserId,
+        if (reason != null) 'reason': reason,
       },
     );
   }
@@ -251,4 +273,19 @@ class RecommenderService {
       throw Exception('Event $path failed: ${res.statusCode} -> ${res.body}');
     }
   }
+}
+
+class RecommendationShownItem {
+  RecommendationShownItem({
+    required this.toUserId,
+    required this.rankShown,
+  });
+
+  final String toUserId;
+  final int rankShown;
+
+  Map<String, dynamic> toJson() => {
+        'to_user_id': toUserId,
+        'rank_shown': rankShown,
+      };
 }


### PR DESCRIPTION
## Summary
- add recommender event endpoints for shown, profile clicks, invitation actions, and outcomes
- ensure partner recommendations respect dismissals and log list impressions
- record invite interactions in the social page and invitation service

## Testing
- not run (environment lacks `dart`/`flutter` tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ee24e0df8832ab9eb114efe28653e)