### PR TITLE
Add recommendation event endpoints

### DIFF
--- a/recommender_system/app/models/events.py
+++ b/recommender_system/app/models/events.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 from pydantic import BaseModel
 
 
@@ -14,3 +14,37 @@ class InvitationEvent(BaseModel):
     to_user_id: str
     invitation_id: Optional[str] = None
     mode: Optional[str] = None
+
+
+class RecommendationShownItem(BaseModel):
+    to_user_id: str
+    rank_shown: int
+
+
+class RecommendationShownEvent(BaseModel):
+    from_user_id: str
+    session_id: str
+    items: List[RecommendationShownItem]
+
+
+class RecommendationClickedEvent(BaseModel):
+    from_user_id: str
+    to_user_id: str
+
+
+class RecommendationActionEvent(BaseModel):
+    from_user_id: str
+    to_user_id: str
+    action: str  # invited | accepted
+
+
+class RecommendationOutcomeEvent(BaseModel):
+    from_user_id: str
+    to_user_id: str
+    outcome: str  # accepted | rejected | ignored
+
+
+class RecommendationDismissEvent(BaseModel):
+    from_user_id: str
+    to_user_id: str
+    reason: Optional[str] = None

--- a/recommender_system/app/routers/events.py
+++ b/recommender_system/app/routers/events.py
@@ -3,14 +3,25 @@ from fastapi import APIRouter, HTTPException
 from pocketbase_service import (
     mark_recommendation_invited,
     mark_recommendation_accepted,
+    mark_recommendation_shown,
+    mark_recommendation_clicked_profile,
+    mark_recommendation_dismissed,
+    mark_recommendation_outcome,
 )
 
-from app.models.events import InvitationEvent
+from app.models.events import (
+    InvitationEvent,
+    RecommendationActionEvent,
+    RecommendationClickedEvent,
+    RecommendationDismissEvent,
+    RecommendationOutcomeEvent,
+    RecommendationShownEvent,
+)
 
-router = APIRouter(prefix="/events/invitations", tags=["events"])
+router = APIRouter(prefix="/events", tags=["events"])
 
 
-@router.post("/sent")
+@router.post("/invitations/sent")
 async def invitation_sent(event: InvitationEvent):
     """
     Gọi khi user A gửi lời mời cho user B.
@@ -26,7 +37,7 @@ async def invitation_sent(event: InvitationEvent):
         raise HTTPException(status_code=500, detail="Cannot mark as invited")
 
 
-@router.post("/accepted")
+@router.post("/invitations/accepted")
 async def invitation_accepted(event: InvitationEvent):
     """
     Gọi khi user B chấp nhận lời mời của A.
@@ -40,3 +51,105 @@ async def invitation_accepted(event: InvitationEvent):
     except Exception as e:
         print("[INVITATION_ACCEPTED][ERROR]", e)
         raise HTTPException(status_code=500, detail="Cannot mark as accepted")
+
+
+@router.post("/recommendations/shown")
+async def recommendation_shown(event: RecommendationShownEvent):
+    """
+    UI gọi khi danh sách gợi ý đã được render.
+    """
+
+    try:
+        for item in event.items:
+            await mark_recommendation_shown(
+                from_user_id=event.from_user_id,
+                to_user_id=item.to_user_id,
+                session_id=event.session_id,
+                rank_shown=item.rank_shown,
+            )
+
+        return {"status": "ok"}
+    except Exception as e:
+        print("[RECO_SHOWN][ERROR]", e)
+        raise HTTPException(status_code=500, detail="Cannot mark as shown")
+
+
+@router.post("/recommendations/clicked_profile")
+async def recommendation_clicked(event: RecommendationClickedEvent):
+    """
+    UI gọi khi user click xem hồ sơ một gợi ý.
+    """
+
+    try:
+        await mark_recommendation_clicked_profile(
+            from_user_id=event.from_user_id,
+            to_user_id=event.to_user_id,
+        )
+        return {"status": "ok"}
+    except Exception as e:
+        print("[RECO_CLICK_PROFILE][ERROR]", e)
+        raise HTTPException(status_code=500, detail="Cannot mark as clicked")
+
+
+@router.post("/recommendations/action")
+async def recommendation_action(event: RecommendationActionEvent):
+    """
+    Log hành động khi user tương tác với gợi ý (gửi lời mời, accept,...).
+    """
+
+    try:
+        if event.action == "invited":
+            await mark_recommendation_invited(
+                from_user_id=event.from_user_id,
+                to_user_id=event.to_user_id,
+            )
+        elif event.action == "accepted":
+            await mark_recommendation_accepted(
+                from_user_id=event.from_user_id,
+                to_user_id=event.to_user_id,
+            )
+        else:
+            raise HTTPException(status_code=400, detail="Unknown action")
+
+        return {"status": "ok"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        print("[RECO_ACTION][ERROR]", e)
+        raise HTTPException(status_code=500, detail="Cannot log action")
+
+
+@router.post("/recommendations/outcome")
+async def recommendation_outcome(event: RecommendationOutcomeEvent):
+    """
+    Log kết quả cuối cùng của gợi ý.
+    """
+
+    try:
+        await mark_recommendation_outcome(
+            from_user_id=event.from_user_id,
+            to_user_id=event.to_user_id,
+            outcome=event.outcome,
+        )
+        return {"status": "ok"}
+    except Exception as e:
+        print("[RECO_OUTCOME][ERROR]", e)
+        raise HTTPException(status_code=500, detail="Cannot log outcome")
+
+
+@router.post("/recommendations/dismiss")
+async def recommendation_dismiss(event: RecommendationDismissEvent):
+    """
+    Log khi user ẩn/không quan tâm gợi ý.
+    """
+
+    try:
+        await mark_recommendation_dismissed(
+            from_user_id=event.from_user_id,
+            to_user_id=event.to_user_id,
+            reason=event.reason,
+        )
+        return {"status": "ok"}
+    except Exception as e:
+        print("[RECO_DISMISS][ERROR]", e)
+        raise HTTPException(status_code=500, detail="Cannot dismiss recommendation")

--- a/recommender_system/app/routers/recommend.py
+++ b/recommender_system/app/routers/recommend.py
@@ -16,10 +16,15 @@ router = APIRouter(prefix="/recommend", tags=["recommend"])
 
 
 @router.get("/players", response_model=List[MatchCandidate])
-async def recommend_players_endpoint(user_id: str, limit: int = 20):
+async def recommend_players_endpoint(user_id: str, limit: int = 10, offset: int = 0):
     """
     Gợi ý người chơi (partner) cho user_id.
     """
+
+    if limit <= 0:
+        raise HTTPException(status_code=400, detail="limit must be positive")
+
+    offset = max(offset, 0)
 
     me_record = await get_user_details_by_user_id(user_id)
     if not me_record:
@@ -33,22 +38,28 @@ async def recommend_players_endpoint(user_id: str, limit: int = 20):
 
     others = [UserDetails.from_pb_record(r) for r in others_records]
 
-    candidates = recommend_partners(me, others, limit=limit)
+    candidates = recommend_partners(me, others, limit=limit, offset=offset)
 
     await log_recommendations(
         from_user_id=user_id,
         candidates=candidates,
         mode="partner",
+        start_rank=offset + 1,
     )
 
     return candidates
 
 
 @router.get("/friends", response_model=List[MatchCandidate])
-async def recommend_friends_endpoint(user_id: str, limit: int = 10):
+async def recommend_friends_endpoint(user_id: str, limit: int = 10, offset: int = 0):
     """
     Gợi ý KẾT BẠN.
     """
+
+    if limit <= 0:
+        raise HTTPException(status_code=400, detail="limit must be positive")
+
+    offset = max(offset, 0)
 
     me_record = await get_user_details_by_user_id(user_id)
     if not me_record:
@@ -62,12 +73,13 @@ async def recommend_friends_endpoint(user_id: str, limit: int = 10):
 
     others = [UserDetails.from_pb_record(r) for r in others_records]
 
-    candidates = recommend_friends(me, others, limit=limit)
+    candidates = recommend_friends(me, others, limit=limit, offset=offset)
 
     await log_recommendations(
         from_user_id=user_id,
         candidates=candidates,
         mode="friend",
+        start_rank=offset + 1,
     )
 
     return candidates

--- a/recommender_system/app/services/logging_service.py
+++ b/recommender_system/app/services/logging_service.py
@@ -12,11 +12,12 @@ async def log_recommendations(
     from_user_id: str,
     candidates: List[MatchCandidate],
     mode: str,  # "partner" | "friend"
+    start_rank: int = 1,
 ) -> None:
     """
     Ghi log cho mỗi candidate vào collection recommendation_logs.
     """
-    for index, c in enumerate(candidates, start=1):
+    for index, c in enumerate(candidates, start=start_rank):
         try:
             features: Dict[str, Any] = dict(c.debug_info or {})
             features["mode"] = mode

--- a/recommender_system/app/services/recommender.py
+++ b/recommender_system/app/services/recommender.py
@@ -98,6 +98,7 @@ def recommend_partners(
     me: UserDetails,
     others: List[UserDetails],
     limit: int = 10,
+    offset: int = 0,
 ) -> List[MatchCandidate]:
 
     # 1) Tính rule-based score như cũ
@@ -158,7 +159,13 @@ def recommend_partners(
 
     # 3) Sort lần 2 theo combined_score
     final_candidates.sort(key=lambda c: c.score, reverse=True)
-    return final_candidates[:limit]
+    if offset < 0:
+        offset = 0
+
+    if limit <= 0:
+        return []
+
+    return final_candidates[offset : offset + limit]
 
 
 # --------- RECOMMEND FRIENDS (TẠM THỜI GIỮ NGUYÊN RULE-BASED) --------- #
@@ -168,6 +175,7 @@ def recommend_friends(
     me: UserDetails,
     others: List[UserDetails],
     limit: int = 10,
+    offset: int = 0,
 ) -> List[MatchCandidate]:
 
     candidates: List[MatchCandidate] = []
@@ -186,4 +194,10 @@ def recommend_friends(
         )
 
     candidates.sort(key=lambda c: c.score, reverse=True)
-    return candidates[:limit]
+    if offset < 0:
+        offset = 0
+
+    if limit <= 0:
+        return []
+
+    return candidates[offset : offset + limit]


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to log recommendation interactions (shown, clicked, actions, outcomes, dismiss)
- extend event models to validate recommendation event payloads
- adjust router prefix to keep invitation endpoints and support new recommendation event paths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f0f22328c832a8a8323f18cd66686)