### PR TITLE
Add owner court editing flow

### DIFF
--- a/lib/pages/manager/court_images_page.dart
+++ b/lib/pages/manager/court_images_page.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart' as p;
+
+import '../../models/court.dart';
+import '../../services/court_service.dart';
+
+class CourtImagesPage extends StatefulWidget {
+  const CourtImagesPage({super.key, required this.court});
+
+  final Court court;
+
+  @override
+  State<CourtImagesPage> createState() => _CourtImagesPageState();
+}
+
+class _CourtImagesPageState extends State<CourtImagesPage> {
+  final _service = CourtService();
+  final _picker = ImagePicker();
+
+  bool _loading = true;
+  bool _uploading = false;
+  String? _error;
+  List<CourtImageFile> _images = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final images = await _service.listCourtImages(widget.court.id);
+      if (mounted) {
+        setState(() {
+          _images = images;
+        });
+      }
+    } catch (err) {
+      if (mounted) {
+        setState(() => _error = err.toString());
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _pickAndUpload() async {
+    if (_uploading) return;
+    final picked = await _picker.pickMultiImage();
+    if (picked.isEmpty) return;
+
+    setState(() => _uploading = true);
+
+    try {
+      final files = <http.MultipartFile>[];
+      for (final file in picked) {
+        final bytes = await file.readAsBytes();
+        files.add(
+          http.MultipartFile.fromBytes(
+            'image',
+            bytes,
+            filename: p.basename(file.path),
+          ),
+        );
+      }
+
+      await _service.uploadCourtImages(courtId: widget.court.id, files: files);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Đã thêm hình ảnh cho sân.')),
+        );
+        await _load();
+      }
+    } catch (err) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(err.toString())),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _uploading = false);
+    }
+  }
+
+  Future<void> _removeImage(CourtImageFile image) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Xóa hình ảnh'),
+        content: const Text('Bạn có chắc muốn xóa hình ảnh này khỏi sân?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Hủy'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Xóa'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      await _service.removeCourtImage(
+        recordId: image.recordId,
+        fileName: image.fileName,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Đã xóa hình ảnh.')),
+        );
+        await _load();
+      }
+    } catch (err) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(err.toString())),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Hình ảnh sân'),
+            Text(
+              widget.court.name,
+              style: Theme.of(context)
+                  .textTheme
+                  .labelLarge
+                  ?.copyWith(color: cs.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _uploading ? null : _pickAndUpload,
+        icon: _uploading
+            ? const SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Icon(Icons.add_photo_alternate_outlined),
+        label: Text(_uploading ? 'Đang tải lên...' : 'Thêm hình ảnh'),
+      ),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: _buildBody(cs),
+      ),
+    );
+  }
+
+  Widget _buildBody(ColorScheme cs) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return ListView(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.error_outline, color: Colors.redAccent, size: 48),
+                const SizedBox(height: 12),
+                Text(
+                  _error!,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(color: Colors.redAccent),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                FilledButton.icon(
+                  onPressed: _load,
+                  icon: const Icon(Icons.refresh_outlined),
+                  label: const Text('Thử lại'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (_images.isEmpty) {
+      return ListView(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.photo_library_outlined, size: 52, color: cs.primary),
+                const SizedBox(height: 12),
+                Text(
+                  'Chưa có hình ảnh nào cho sân này.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                FilledButton.icon(
+                  onPressed: _uploading ? null : _pickAndUpload,
+                  icon: const Icon(Icons.add_photo_alternate_outlined),
+                  label: const Text('Thêm hình ảnh'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }
+
+    return GridView.builder(
+      padding: const EdgeInsets.all(16),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+      ),
+      itemCount: _images.length,
+      itemBuilder: (context, index) {
+        final image = _images[index];
+        return _ImageTile(
+          image: image,
+          onDelete: () => _removeImage(image),
+        );
+      },
+    );
+  }
+}
+
+class _ImageTile extends StatelessWidget {
+  const _ImageTile({required this.image, required this.onDelete});
+
+  final CourtImageFile image;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Ink.image(
+            image: NetworkImage(image.url),
+            fit: BoxFit.cover,
+            child: const SizedBox.shrink(),
+          ),
+          Positioned(
+            top: 8,
+            right: 8,
+            child: Material(
+              color: Colors.black54,
+              shape: const CircleBorder(),
+              child: IconButton(
+                onPressed: onDelete,
+                icon: const Icon(Icons.delete_outline, color: Colors.white),
+                tooltip: 'Xóa hình ảnh',
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/manager/court_services_page.dart
+++ b/lib/pages/manager/court_services_page.dart
@@ -1,0 +1,577 @@
+import 'package:flutter/material.dart';
+
+import '../../models/court.dart';
+import '../../models/court_detail.dart';
+import '../../services/court_service.dart';
+
+class CourtServicesPage extends StatefulWidget {
+  const CourtServicesPage({super.key, required this.court});
+
+  final Court court;
+
+  @override
+  State<CourtServicesPage> createState() => _CourtServicesPageState();
+}
+
+class _CourtServicesPageState extends State<CourtServicesPage> {
+  final _service = CourtService();
+  late Future<_ServiceData> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _loadData();
+  }
+
+  Future<_ServiceData> _loadData() async {
+    final results = await Future.wait([
+      _service.listCourtServices(widget.court.id),
+      _service.listServiceCatalog(),
+    ]);
+
+    return _ServiceData(
+      services: results[0] as List<CourtServiceItem>,
+      catalog: results[1] as List<ServiceCatalogItem>,
+    );
+  }
+
+  Future<void> _refresh() async {
+    final future = _loadData();
+    setState(() => _future = future);
+    await future;
+  }
+
+  void _showAddService(List<CourtServiceItem> services, List<ServiceCatalogItem> catalog) {
+    final addedIds = services.map((e) => e.serviceId).toSet();
+    final available = catalog.where((item) => !addedIds.contains(item.id)).toList();
+
+    if (available.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Tất cả dịch vụ trong danh mục đã được thêm.')),
+      );
+      return;
+    }
+
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => _AddServiceSheet(
+        court: widget.court,
+        catalog: available,
+        onSaved: (created) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Đã thêm dịch vụ.')),
+          );
+          _refresh();
+        },
+      ),
+    );
+  }
+
+  void _showEditService(CourtServiceItem item) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => _EditServiceSheet(
+        item: item,
+        onSaved: (updated) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Đã cập nhật dịch vụ.')),
+          );
+          _refresh();
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dịch vụ bổ sung'),
+      ),
+      body: FutureBuilder<_ServiceData>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.error_outline, color: Colors.red),
+                  const SizedBox(height: 8),
+                  Text(snapshot.error.toString(), textAlign: TextAlign.center),
+                  const SizedBox(height: 8),
+                  FilledButton.icon(
+                    onPressed: _refresh,
+                    icon: const Icon(Icons.refresh_outlined),
+                    label: const Text('Thử lại'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final data = snapshot.data!;
+          final services = data.services;
+          final catalog = data.catalog;
+
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+              children: [
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Text(
+                        'Dịch vụ đang cung cấp',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                    FilledButton.icon(
+                      onPressed: catalog.isEmpty
+                          ? null
+                          : () => _showAddService(services, catalog),
+                      icon: const Icon(Icons.add_outlined),
+                      label: const Text('Thêm dịch vụ'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                if (services.isEmpty)
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      color: Theme.of(context).colorScheme.surfaceVariant,
+                    ),
+                    child: const Text(
+                      'Chưa có dịch vụ nào. Hãy thêm từ danh mục có sẵn.',
+                    ),
+                  )
+                else
+                  ...services.map(
+                    (service) => _ServiceTile(
+                      item: service,
+                      onEdit: () => _showEditService(service),
+                    ),
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ServiceTile extends StatelessWidget {
+  const _ServiceTile({required this.item, required this.onEdit});
+
+  final CourtServiceItem item;
+  final VoidCallback onEdit;
+
+  @override
+  Widget build(BuildContext context) {
+    final priceText = item.price != null
+        ? '${item.price!.toString()}đ${item.unit != null ? '/${item.unit}' : ''}'
+        : (item.priceLabel ?? 'Đang cập nhật');
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 10),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        title: Text(
+          item.name,
+          style: const TextStyle(fontWeight: FontWeight.w700),
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 4),
+            Text(priceText),
+            if (item.note != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                item.note!,
+                style: TextStyle(color: Colors.grey.shade700),
+              ),
+            ],
+            const SizedBox(height: 6),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  item.isActive ? Icons.check_circle_outline : Icons.pause_circle_outline,
+                  size: 16,
+                  color: item.isActive ? Colors.green : Colors.grey,
+                ),
+                const SizedBox(width: 6),
+                Text(item.isActive ? 'Đang bật' : 'Đang tắt'),
+              ],
+            ),
+          ],
+        ),
+        trailing: IconButton(
+          tooltip: 'Chỉnh sửa',
+          icon: const Icon(Icons.edit_outlined),
+          onPressed: onEdit,
+        ),
+      ),
+    );
+  }
+}
+
+class _AddServiceSheet extends StatefulWidget {
+  const _AddServiceSheet({
+    required this.court,
+    required this.catalog,
+    required this.onSaved,
+  });
+
+  final Court court;
+  final List<ServiceCatalogItem> catalog;
+  final ValueChanged<CourtServiceItem> onSaved;
+
+  @override
+  State<_AddServiceSheet> createState() => _AddServiceSheetState();
+}
+
+class _AddServiceSheetState extends State<_AddServiceSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _priceCtrl = TextEditingController();
+  final _noteCtrl = TextEditingController();
+  ServiceCatalogItem? _selected;
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _priceCtrl.dispose();
+    _noteCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate() || _selected == null) return;
+
+    setState(() => _saving = true);
+    final service = CourtService();
+    final price = int.tryParse(_priceCtrl.text.trim());
+
+    try {
+      final created = await service.createCourtService(
+        courtId: widget.court.id,
+        serviceId: _selected!.id,
+        price: price,
+        note: _noteCtrl.text,
+        unit: _selected!.unit,
+        serviceName: _selected!.name,
+        isActive: true,
+      );
+      widget.onSaved(created);
+    } catch (err) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(err.toString())),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottom = MediaQuery.of(context).viewInsets.bottom;
+
+    return AnimatedPadding(
+      duration: const Duration(milliseconds: 200),
+      padding: EdgeInsets.only(bottom: bottom),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Expanded(
+                    child: Text(
+                      'Thêm dịch vụ mới',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: _saving ? null : () => Navigator.pop(context),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<ServiceCatalogItem>(
+                decoration: const InputDecoration(
+                  labelText: 'Chọn dịch vụ từ danh mục',
+                  prefixIcon: Icon(Icons.list_alt_outlined),
+                ),
+                items: widget.catalog
+                    .map(
+                      (item) => DropdownMenuItem(
+                        value: item,
+                        child: Text(item.unit != null
+                            ? '${item.name} (${item.unit})'
+                            : item.name),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (value) => setState(() => _selected = value),
+                validator: (value) {
+                  if (value == null) {
+                    return 'Vui lòng chọn dịch vụ';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _priceCtrl,
+                decoration: InputDecoration(
+                  labelText: 'Giá (đơn vị: ${_selected?.unit ?? 'đ'})',
+                  hintText: 'Ví dụ: 50000',
+                  prefixIcon: const Icon(Icons.payments_outlined),
+                ),
+                keyboardType: TextInputType.number,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Vui lòng nhập giá';
+                  }
+                  final parsed = int.tryParse(value.trim());
+                  if (parsed == null || parsed < 0) {
+                    return 'Giá không hợp lệ';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _noteCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Ghi chú (không bắt buộc)',
+                  prefixIcon: Icon(Icons.note_alt_outlined),
+                ),
+                maxLines: 2,
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _saving ? null : _submit,
+                  icon: _saving
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.save_outlined),
+                  label: const Text('Lưu dịch vụ'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EditServiceSheet extends StatefulWidget {
+  const _EditServiceSheet({required this.item, required this.onSaved});
+
+  final CourtServiceItem item;
+  final ValueChanged<CourtServiceItem> onSaved;
+
+  @override
+  State<_EditServiceSheet> createState() => _EditServiceSheetState();
+}
+
+class _EditServiceSheetState extends State<_EditServiceSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _priceCtrl;
+  late final TextEditingController _noteCtrl;
+  late bool _isActive;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _priceCtrl = TextEditingController(
+      text: widget.item.price != null ? widget.item.price.toString() : '',
+    );
+    _noteCtrl = TextEditingController(text: widget.item.note ?? '');
+    _isActive = widget.item.isActive;
+  }
+
+  @override
+  void dispose() {
+    _priceCtrl.dispose();
+    _noteCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _saving = true);
+    final service = CourtService();
+    final price = int.tryParse(_priceCtrl.text.trim());
+
+    try {
+      final updated = await service.updateCourtService(
+        id: widget.item.id,
+        price: price,
+        note: _noteCtrl.text,
+        unit: widget.item.unit,
+        serviceName: widget.item.name,
+        isActive: _isActive,
+      );
+      widget.onSaved(updated);
+    } catch (err) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(err.toString())),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottom = MediaQuery.of(context).viewInsets.bottom;
+
+    return AnimatedPadding(
+      duration: const Duration(milliseconds: 200),
+      padding: EdgeInsets.only(bottom: bottom),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'Chỉnh sửa giá dịch vụ',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(widget.item.name),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: _saving ? null : () => Navigator.pop(context),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _priceCtrl,
+                decoration: InputDecoration(
+                  labelText: 'Giá (đơn vị: ${widget.item.unit ?? 'đ'})',
+                  prefixIcon: const Icon(Icons.payments_outlined),
+                ),
+                keyboardType: TextInputType.number,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Vui lòng nhập giá';
+                  }
+                  final parsed = int.tryParse(value.trim());
+                  if (parsed == null || parsed < 0) {
+                    return 'Giá không hợp lệ';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _noteCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Ghi chú (không bắt buộc)',
+                  prefixIcon: Icon(Icons.note_alt_outlined),
+                ),
+                maxLines: 2,
+              ),
+              const SizedBox(height: 12),
+              SwitchListTile.adaptive(
+                value: _isActive,
+                onChanged: (value) => setState(() => _isActive = value),
+                title: const Text('Hiển thị dịch vụ cho người dùng'),
+                secondary: Icon(
+                  _isActive
+                      ? Icons.visibility_outlined
+                      : Icons.visibility_off_outlined,
+                ),
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _saving ? null : _submit,
+                  icon: _saving
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.save_outlined),
+                  label: const Text('Lưu thay đổi'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ServiceData {
+  _ServiceData({required this.services, required this.catalog});
+
+  final List<CourtServiceItem> services;
+  final List<ServiceCatalogItem> catalog;
+}

--- a/lib/pages/manager/court_services_page.dart
+++ b/lib/pages/manager/court_services_page.dart
@@ -16,6 +16,7 @@ class CourtServicesPage extends StatefulWidget {
 class _CourtServicesPageState extends State<CourtServicesPage> {
   final _service = CourtService();
   late Future<_ServiceData> _future;
+  _ServiceData? _cached;
 
   @override
   void initState() {
@@ -37,8 +38,46 @@ class _CourtServicesPageState extends State<CourtServicesPage> {
 
   Future<void> _refresh() async {
     final future = _loadData();
-    setState(() => _future = future);
+    setState(() {
+      _cached = null;
+      _future = future;
+    });
     await future;
+  }
+
+  void _updateCachedService(CourtServiceItem updated) {
+    if (_cached == null) return;
+
+    final updatedServices = List<CourtServiceItem>.from(_cached!.services);
+    final index = updatedServices.indexWhere((item) => item.id == updated.id);
+
+    if (index == -1) return;
+
+    updatedServices[index] = updated;
+
+    final next = _ServiceData(
+      services: updatedServices,
+      catalog: _cached!.catalog,
+    );
+
+    setState(() {
+      _cached = next;
+      _future = Future.value(next);
+    });
+  }
+
+  void _addCachedService(CourtServiceItem created) {
+    if (_cached == null) return;
+
+    final next = _ServiceData(
+      services: [..._cached!.services, created],
+      catalog: _cached!.catalog,
+    );
+
+    setState(() {
+      _cached = next;
+      _future = Future.value(next);
+    });
   }
 
   void _showAddService(List<CourtServiceItem> services, List<ServiceCatalogItem> catalog) {
@@ -63,6 +102,7 @@ class _CourtServicesPageState extends State<CourtServicesPage> {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Đã thêm dịch vụ.')),
           );
+          _addCachedService(created);
           _refresh();
         },
       ),
@@ -80,6 +120,7 @@ class _CourtServicesPageState extends State<CourtServicesPage> {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Đã cập nhật dịch vụ.')),
           );
+          _updateCachedService(updated);
           _refresh();
         },
       ),
@@ -119,6 +160,7 @@ class _CourtServicesPageState extends State<CourtServicesPage> {
           }
 
           final data = snapshot.data!;
+          _cached = data;
           final services = data.services;
           final catalog = data.catalog;
 

--- a/lib/pages/manager/manager_court_page.dart
+++ b/lib/pages/manager/manager_court_page.dart
@@ -35,6 +35,7 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
   void _showEditSheet(Court court) {
     showModalBottomSheet<void>(
       context: context,
+      backgroundColor: Colors.transparent,
       isScrollControlled: true,
       builder: (context) {
         return _EditCourtSheet(
@@ -281,124 +282,253 @@ class _EditCourtSheetState extends State<_EditCourtSheet> {
   Widget build(BuildContext context) {
     final bottom = MediaQuery.of(context).viewInsets.bottom;
 
-    return Padding(
-      padding: EdgeInsets.only(
-        left: 16,
-        right: 16,
-        top: 12,
-        bottom: bottom + 16,
-      ),
-      child: SingleChildScrollView(
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Center(
-                child: Container(
-                  width: 50,
-                  height: 4,
-                  margin: const EdgeInsets.only(bottom: 16),
-                  decoration: BoxDecoration(
-                    color: Colors.grey.shade400,
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
-              ),
-              const Text(
-                'Chỉnh sửa thông tin sân',
-                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-              ),
-              const SizedBox(height: 12),
-              TextFormField(
-                controller: _nameCtrl,
-                decoration: const InputDecoration(labelText: 'Tên sân'),
-                validator: (value) {
-                  if (value == null || value.trim().isEmpty) {
-                    return 'Vui lòng nhập tên sân';
-                  }
-                  return null;
-                },
-              ),
-              TextFormField(
-                controller: _locationCtrl,
-                decoration: const InputDecoration(labelText: 'Địa chỉ'),
-                validator: (value) {
-                  if (value == null || value.trim().isEmpty) {
-                    return 'Vui lòng nhập địa chỉ';
-                  }
-                  return null;
-                },
-              ),
-              TextFormField(
-                controller: _phoneCtrl,
-                decoration: const InputDecoration(labelText: 'Số điện thoại'),
-                keyboardType: TextInputType.phone,
-                validator: (value) {
-                  final phone = value?.trim() ?? '';
-                  if (phone.isEmpty) return 'Vui lòng nhập số điện thoại';
-                  if (!_phoneReg.hasMatch(phone)) {
-                    return 'Số điện thoại phải theo định dạng 0xxxxxxxxx hoặc +84xxxxxxxxx';
-                  }
-                  return null;
-                },
-              ),
-              TextFormField(
-                initialValue: _quantity.toString(),
-                decoration: const InputDecoration(labelText: 'Số sân hiện có'),
-                keyboardType: TextInputType.number,
-                onChanged: (value) {
-                  final parsed = int.tryParse(value);
-                  if (parsed != null && parsed > 0) {
-                    _quantity = parsed;
-                  }
-                },
-                validator: (value) {
-                  final parsed = int.tryParse(value ?? '');
-                  if (parsed == null || parsed <= 0) {
-                    return 'Số sân phải lớn hơn 0';
-                  }
-                  return null;
-                },
-              ),
-              TextFormField(
-                controller: _descCtrl,
-                decoration: const InputDecoration(labelText: 'Mô tả / nội quy'),
-                maxLines: 3,
-              ),
-              SwitchListTile.adaptive(
-                contentPadding: EdgeInsets.zero,
-                value: _isActive,
-                onChanged: (value) => setState(() => _isActive = value),
-                title: const Text('Hiển thị sân cho người dùng đặt lịch'),
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: [
-                  Expanded(
-                    child: FilledButton.icon(
-                      onPressed: _submitting ? null : _submit,
-                      icon: _submitting
-                          ? const SizedBox(
-                              width: 18,
-                              height: 18,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : const Icon(Icons.save_outlined),
-                      label: const Text('Lưu thay đổi'),
+    return AnimatedPadding(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+      padding: EdgeInsets.only(bottom: bottom),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.08),
+              blurRadius: 20,
+              offset: const Offset(0, -4),
+            ),
+          ],
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Center(
+                  child: Container(
+                    width: 48,
+                    height: 5,
+                    margin: const EdgeInsets.only(bottom: 18),
+                    decoration: BoxDecoration(
+                      color: Colors.grey.shade400,
+                      borderRadius: BorderRadius.circular(50),
                     ),
                   ),
-                  const SizedBox(width: 8),
-                  OutlinedButton(
-                    onPressed: _submitting ? null : () => Navigator.pop(context),
-                    child: const Text('Hủy'),
+                ),
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                        color:
+                            Theme.of(context).colorScheme.primary.withOpacity(0.08),
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(
+                        Icons.sports_tennis_outlined,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    const Expanded(
+                      child: Text(
+                        'Chỉnh sửa thông tin sân',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 18,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: _submitting ? null : () => Navigator.pop(context),
+                      icon: const Icon(Icons.close),
+                      tooltip: 'Đóng',
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                _LabeledField(
+                  label: 'Tên sân',
+                  child: TextFormField(
+                    controller: _nameCtrl,
+                    decoration: const InputDecoration(
+                      hintText: 'Ví dụ: Quang Sport',
+                      prefixIcon: Icon(Icons.home_work_outlined),
+                    ),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Vui lòng nhập tên sân';
+                      }
+                      return null;
+                    },
                   ),
-                ],
-              ),
-            ],
+                ),
+                _LabeledField(
+                  label: 'Địa chỉ',
+                  child: TextFormField(
+                    controller: _locationCtrl,
+                    decoration: const InputDecoration(
+                      hintText: 'Số nhà, đường, quận/huyện...',
+                      prefixIcon: Icon(Icons.place_outlined),
+                    ),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Vui lòng nhập địa chỉ';
+                      }
+                      return null;
+                    },
+                  ),
+                ),
+                Row(
+                  children: [
+                    Expanded(
+                      child: _LabeledField(
+                        label: 'Số điện thoại',
+                        child: TextFormField(
+                          controller: _phoneCtrl,
+                          decoration: const InputDecoration(
+                            hintText: '0xxxxxxxxx / +84xxxxxxxxx',
+                            prefixIcon: Icon(Icons.call_outlined),
+                          ),
+                          keyboardType: TextInputType.phone,
+                          validator: (value) {
+                            final phone = value?.trim() ?? '';
+                            if (phone.isEmpty) {
+                              return 'Vui lòng nhập số điện thoại';
+                            }
+                            if (!_phoneReg.hasMatch(phone)) {
+                              return 'Số điện thoại phải theo định dạng 0xxxxxxxxx hoặc +84xxxxxxxxx';
+                            }
+                            return null;
+                          },
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _LabeledField(
+                        label: 'Số sân',
+                        child: TextFormField(
+                          initialValue: _quantity.toString(),
+                          decoration: const InputDecoration(
+                            hintText: 'Nhập số sân',
+                            prefixIcon: Icon(Icons.grid_view_outlined),
+                          ),
+                          keyboardType: TextInputType.number,
+                          onChanged: (value) {
+                            final parsed = int.tryParse(value);
+                            if (parsed != null && parsed > 0) {
+                              _quantity = parsed;
+                            }
+                          },
+                          validator: (value) {
+                            final parsed = int.tryParse(value ?? '');
+                            if (parsed == null || parsed <= 0) {
+                              return 'Số sân phải lớn hơn 0';
+                            }
+                            return null;
+                          },
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                _LabeledField(
+                  label: 'Mô tả / nội quy',
+                  child: TextFormField(
+                    controller: _descCtrl,
+                    decoration: const InputDecoration(
+                      hintText: 'Thông tin chi tiết giúp khách hiểu hơn...',
+                      prefixIcon: Icon(Icons.notes_outlined),
+                    ),
+                    maxLines: 3,
+                  ),
+                ),
+                Container(
+                  margin: const EdgeInsets.only(top: 8),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    color: Theme.of(context).colorScheme.surfaceVariant,
+                  ),
+                  child: SwitchListTile.adaptive(
+                    contentPadding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                    value: _isActive,
+                    onChanged: (value) => setState(() => _isActive = value),
+                    title: const Text('Hiển thị sân cho người dùng đặt lịch'),
+                    secondary: Icon(
+                      _isActive ? Icons.visibility_outlined : Icons.visibility_off_outlined,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed:
+                            _submitting ? null : () => Navigator.pop(context),
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                        child: const Text('Hủy'),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton.icon(
+                        onPressed: _submitting ? null : _submit,
+                        icon: _submitting
+                            ? const SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Icons.save_outlined),
+                        label: const Text('Lưu thay đổi'),
+                        style: FilledButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _LabeledField extends StatelessWidget {
+  const _LabeledField({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Text(
+              label,
+              style: TextStyle(
+                fontWeight: FontWeight.w600,
+                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.85),
+              ),
+            ),
+          ),
+          child,
+        ],
       ),
     );
   }

--- a/lib/pages/manager/manager_court_page.dart
+++ b/lib/pages/manager/manager_court_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../models/court.dart';
 import '../../services/court_service.dart';
+import 'court_images_page.dart';
 
 class ManagerCourtPage extends StatefulWidget {
   const ManagerCourtPage({super.key});
@@ -49,6 +50,14 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
           },
         );
       },
+    );
+  }
+
+  void _openImageManager(Court court) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => CourtImagesPage(court: court),
+      ),
     );
   }
 
@@ -114,6 +123,7 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
               ...courts.map((court) => _CourtCard(
                     court: court,
                     onEdit: () => _showEditSheet(court),
+                    onManageImages: () => _openImageManager(court),
                   )),
             ],
           ),
@@ -124,10 +134,15 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
 }
 
 class _CourtCard extends StatelessWidget {
-  const _CourtCard({required this.court, required this.onEdit});
+  const _CourtCard({
+    required this.court,
+    required this.onEdit,
+    required this.onManageImages,
+  });
 
   final Court court;
   final VoidCallback onEdit;
+  final VoidCallback onManageImages;
 
   @override
   Widget build(BuildContext context) {
@@ -199,8 +214,17 @@ class _CourtCard extends StatelessWidget {
             Text(
               court.description?.isNotEmpty == true
                   ? court.description!
-                  : 'Chưa có mô tả cho sân này.',
+              : 'Chưa có mô tả cho sân này.',
               style: TextStyle(color: Colors.grey.shade800),
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                onPressed: onManageImages,
+                icon: const Icon(Icons.photo_library_outlined),
+                label: const Text('Quản lý hình ảnh'),
+              ),
             ),
           ],
         ),

--- a/lib/pages/manager/manager_court_page.dart
+++ b/lib/pages/manager/manager_court_page.dart
@@ -119,16 +119,69 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
           );
         }
 
+        final theme = Theme.of(context);
+
         return RefreshIndicator(
           onRefresh: _refresh,
           child: ListView(
-            padding: const EdgeInsets.only(bottom: 16),
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
             children: [
-              const Text(
-                'Thông tin sân',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      theme.colorScheme.primary.withOpacity(0.08),
+                      theme.colorScheme.secondary.withOpacity(0.08),
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: theme.colorScheme.primary.withOpacity(0.08),
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primary.withOpacity(0.12),
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(
+                        Icons.sports_tennis_outlined,
+                        color: theme.colorScheme.primary,
+                        size: 28,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Sân & dịch vụ',
+                            style: theme.textTheme.titleMedium
+                                ?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Quản lý thông tin sân, hình ảnh và dịch vụ đi kèm.',
+                            style: theme.textTheme.bodyMedium
+                                ?.copyWith(color: theme.hintColor),
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: _refresh,
+                      icon: const Icon(Icons.refresh_outlined),
+                      tooltip: 'Tải lại',
+                    ),
+                  ],
+                ),
               ),
-              const SizedBox(height: 12),
+              const SizedBox(height: 14),
               ...courts.map((court) => _CourtCard(
                     court: court,
                     onEdit: () => _showEditSheet(court),
@@ -158,58 +211,83 @@ class _CourtCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    final theme = Theme.of(context);
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 14),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(18),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 18,
+            offset: const Offset(0, 8),
+          ),
+        ],
+        border: Border.all(
+          color: theme.colorScheme.outlineVariant.withOpacity(0.5),
+        ),
+      ),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                Container(
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary.withOpacity(0.1),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.sports_tennis_outlined,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(width: 12),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Row(
                         children: [
-                          Text(
-                            court.name,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
+                          Expanded(
+                            child: Text(
+                              court.name,
+                              style: theme.textTheme.titleMedium
+                                  ?.copyWith(fontWeight: FontWeight.w700),
                             ),
                           ),
-                          const SizedBox(width: 8),
-                          Chip(
-                            avatar: Icon(
-                              court.isActive
-                                  ? Icons.check_circle_outline
-                                  : Icons.visibility_off_outlined,
-                              size: 16,
-                              color: court.isActive ? Colors.green : Colors.grey,
-                            ),
-                            label: Text(
-                              court.isActive ? 'Đang hiển thị' : 'Đang ẩn',
-                              style: TextStyle(
-                                color:
-                                    court.isActive ? Colors.green : Colors.grey,
-                              ),
-                            ),
-                            side: BorderSide(
-                              color:
-                                  court.isActive ? Colors.green : Colors.grey,
-                            ),
+                          _StatusChip(isActive: court.isActive),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        court.location,
+                        style: theme.textTheme.bodyMedium
+                            ?.copyWith(color: theme.hintColor),
+                      ),
+                      const SizedBox(height: 10),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 6,
+                        children: [
+                          _InfoPill(
+                            icon: Icons.call_outlined,
+                            label: 'Liên hệ',
+                            value: court.phonePretty,
+                          ),
+                          _InfoPill(
+                            icon: Icons.grid_view_outlined,
+                            label: 'Số sân',
+                            value: court.courtQuantity.toString(),
                           ),
                         ],
                       ),
-                      const SizedBox(height: 6),
-                      Text(court.location),
-                      const SizedBox(height: 4),
-                      Text('SĐT: ${court.phonePretty}'),
-                      const SizedBox(height: 4),
-                      Text('Số sân: ${court.courtQuantity}'),
                     ],
                   ),
                 ),
@@ -221,33 +299,143 @@ class _CourtCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 12),
-            const Text('Mô tả & nội quy'),
-            const SizedBox(height: 6),
-            Text(
-              court.description?.isNotEmpty == true
-                  ? court.description!
-              : 'Chưa có mô tả cho sân này.',
-              style: TextStyle(color: Colors.grey.shade800),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceVariant.withOpacity(0.55),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.notes_outlined,
+                        size: 18,
+                        color: theme.colorScheme.primary,
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        'Mô tả & nội quy',
+                        style: theme.textTheme.titleSmall
+                            ?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    court.description?.isNotEmpty == true
+                        ? court.description!
+                        : 'Chưa có mô tả cho sân này.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withOpacity(0.8),
+                    ),
+                  ),
+                ],
+              ),
             ),
             const SizedBox(height: 12),
             Row(
-              mainAxisAlignment: MainAxisAlignment.end,
               children: [
-                TextButton.icon(
-                  onPressed: onManageServices,
-                  icon: const Icon(Icons.miscellaneous_services_outlined),
-                  label: const Text('Quản lý dịch vụ'),
+                Expanded(
+                  child: FilledButton.tonalIcon(
+                    onPressed: onManageServices,
+                    icon: const Icon(Icons.miscellaneous_services_outlined),
+                    label: const Text('Quản lý dịch vụ'),
+                  ),
                 ),
-                const SizedBox(width: 4),
-                TextButton.icon(
-                  onPressed: onManageImages,
-                  icon: const Icon(Icons.photo_library_outlined),
-                  label: const Text('Quản lý hình ảnh'),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: onManageImages,
+                    icon: const Icon(Icons.photo_library_outlined),
+                    label: const Text('Quản lý hình ảnh'),
+                  ),
                 ),
               ],
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _InfoPill extends StatelessWidget {
+  const _InfoPill({required this.icon, required this.label, required this.value});
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: theme.colorScheme.primary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: theme.textTheme.labelMedium
+                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            value,
+            style: theme.textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: theme.colorScheme.onSurface,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.isActive});
+
+  final bool isActive;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = isActive ? Colors.green : theme.colorScheme.outline;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(30),
+        border: Border.all(color: color.withOpacity(0.6)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            isActive ? Icons.check_circle_outline : Icons.visibility_off_outlined,
+            size: 16,
+            color: color,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            isActive ? 'Đang hiển thị' : 'Đang ẩn',
+            style: theme.textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: color,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/manager/manager_court_page.dart
+++ b/lib/pages/manager/manager_court_page.dart
@@ -1,70 +1,132 @@
 import 'package:flutter/material.dart';
 
-class ManagerCourtPage extends StatelessWidget {
+import '../../models/court.dart';
+import '../../services/court_service.dart';
+
+class ManagerCourtPage extends StatefulWidget {
   const ManagerCourtPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final courts = [
-      _CourtProfile(
-        name: 'Sân A1',
-        address: '123 Trần Phú, Quận 5',
-        phone: '0909 888 777',
-        services: const ['Gửi xe', 'Khăn nước', 'Thuê vợt'],
-      ),
-      _CourtProfile(
-        name: 'Sân A2',
-        address: '123 Trần Phú, Quận 5',
-        phone: '0903 111 222',
-        services: const ['Gửi xe', 'Nước suối'],
-      ),
-    ];
+  State<ManagerCourtPage> createState() => _ManagerCourtPageState();
+}
 
-    return ListView(
-      children: [
-        const Text(
-          'Thông tin sân',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 12),
-        ...courts.map((court) => _CourtCard(profile: court)).toList(),
-        const SizedBox(height: 12),
-        Card(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
+class _ManagerCourtPageState extends State<ManagerCourtPage> {
+  final _courtService = CourtService();
+  late Future<List<Court>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _loadCourts();
+  }
+
+  Future<List<Court>> _loadCourts() {
+    return _courtService.listOwnerCourts(perPage: 100);
+  }
+
+  Future<void> _refresh() async {
+    final future = _loadCourts();
+    setState(() {
+      _future = future;
+    });
+    await future;
+  }
+
+  void _showEditSheet(Court court) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        return _EditCourtSheet(
+          court: court,
+          onSaved: (updated) {
+            Navigator.of(context).pop();
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Đã cập nhật thông tin sân.')),
+            );
+            _refresh();
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<Court>>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
               children: [
-                const Text('Dịch vụ đi kèm', style: TextStyle(fontWeight: FontWeight.bold)),
+                const Icon(Icons.error_outline, color: Colors.red),
                 const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  children: const [
-                    _ServiceChip(label: 'Gửi xe • 5.000đ'),
-                    _ServiceChip(label: 'Thuê vợt • 25.000đ'),
-                    _ServiceChip(label: 'Nước suối • 8.000đ'),
-                  ],
+                Text(
+                  snapshot.error.toString(),
+                  textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 8),
-                OutlinedButton.icon(
-                  onPressed: () {},
-                  icon: const Icon(Icons.add_circle_outline),
-                  label: const Text('Thêm dịch vụ'),
+                FilledButton.icon(
+                  onPressed: _refresh,
+                  icon: const Icon(Icons.refresh_outlined),
+                  label: const Text('Thử lại'),
                 ),
               ],
             ),
+          );
+        }
+
+        final courts = snapshot.data ?? [];
+        if (courts.isEmpty) {
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text('Bạn chưa có sân nào để chỉnh sửa.'),
+                const SizedBox(height: 8),
+                FilledButton.icon(
+                  onPressed: _refresh,
+                  icon: const Icon(Icons.refresh_outlined),
+                  label: const Text('Tải lại'),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return RefreshIndicator(
+          onRefresh: _refresh,
+          child: ListView(
+            padding: const EdgeInsets.only(bottom: 16),
+            children: [
+              const Text(
+                'Thông tin sân',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 12),
+              ...courts.map((court) => _CourtCard(
+                    court: court,
+                    onEdit: () => _showEditSheet(court),
+                  )),
+            ],
           ),
-        ),
-      ],
+        );
+      },
     );
   }
 }
 
 class _CourtCard extends StatelessWidget {
-  final _CourtProfile profile;
+  const _CourtCard({required this.court, required this.onEdit});
 
-  const _CourtCard({required this.profile});
+  final Court court;
+  final VoidCallback onEdit;
 
   @override
   Widget build(BuildContext context) {
@@ -82,49 +144,63 @@ class _CourtCard extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(profile.name, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                      Row(
+                        children: [
+                          Text(
+                            court.name,
+                            style: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 16,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Chip(
+                            avatar: Icon(
+                              court.isActive
+                                  ? Icons.check_circle_outline
+                                  : Icons.visibility_off_outlined,
+                              size: 16,
+                              color: court.isActive ? Colors.green : Colors.grey,
+                            ),
+                            label: Text(
+                              court.isActive ? 'Đang hiển thị' : 'Đang ẩn',
+                              style: TextStyle(
+                                color:
+                                    court.isActive ? Colors.green : Colors.grey,
+                              ),
+                            ),
+                            side: BorderSide(
+                              color:
+                                  court.isActive ? Colors.green : Colors.grey,
+                            ),
+                          ),
+                        ],
+                      ),
                       const SizedBox(height: 6),
-                      Text(profile.address),
+                      Text(court.location),
                       const SizedBox(height: 4),
-                      Text('SĐT: ${profile.phone}'),
+                      Text('SĐT: ${court.phonePretty}'),
+                      const SizedBox(height: 4),
+                      Text('Số sân: ${court.courtQuantity}'),
                     ],
                   ),
                 ),
                 IconButton(
                   tooltip: 'Chỉnh sửa',
                   icon: const Icon(Icons.edit_outlined),
-                  onPressed: () {},
-                )
+                  onPressed: onEdit,
+                ),
               ],
             ),
             const SizedBox(height: 12),
             const Text('Mô tả & nội quy'),
             const SizedBox(height: 6),
             Text(
-              'Giữ sạch sân, không mang giày đinh. Check-in trước 10 phút. Có nước uống và khăn lạnh tại quầy.',
+              court.description?.isNotEmpty == true
+                  ? court.description!
+                  : 'Chưa có mô tả cho sân này.',
               style: TextStyle(color: Colors.grey.shade800),
             ),
-            const SizedBox(height: 12),
-            Wrap(
-              spacing: 6,
-              children: profile.services.map((s) => Chip(label: Text(s))).toList(),
-            ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                OutlinedButton.icon(
-                  onPressed: () {},
-                  icon: const Icon(Icons.image_outlined),
-                  label: const Text('Cập nhật hình ảnh'),
-                ),
-                const SizedBox(width: 8),
-                OutlinedButton.icon(
-                  onPressed: () {},
-                  icon: const Icon(Icons.rule_folder_outlined),
-                  label: const Text('Nội quy chi tiết'),
-                ),
-              ],
-            )
           ],
         ),
       ),
@@ -132,30 +208,198 @@ class _CourtCard extends StatelessWidget {
   }
 }
 
-class _CourtProfile {
-  final String name;
-  final String address;
-  final String phone;
-  final List<String> services;
+class _EditCourtSheet extends StatefulWidget {
+  const _EditCourtSheet({required this.court, required this.onSaved});
 
-  _CourtProfile({
-    required this.name,
-    required this.address,
-    required this.phone,
-    required this.services,
-  });
+  final Court court;
+  final ValueChanged<Court> onSaved;
+
+  @override
+  State<_EditCourtSheet> createState() => _EditCourtSheetState();
 }
 
-class _ServiceChip extends StatelessWidget {
-  final String label;
+class _EditCourtSheetState extends State<_EditCourtSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _phoneReg = RegExp(r'^(?:0|\+84)\d{9}$');
+  late final TextEditingController _nameCtrl;
+  late final TextEditingController _locationCtrl;
+  late final TextEditingController _phoneCtrl;
+  late final TextEditingController _descCtrl;
+  late int _quantity;
+  late bool _isActive;
+  bool _submitting = false;
 
-  const _ServiceChip({required this.label});
+  @override
+  void initState() {
+    super.initState();
+    _nameCtrl = TextEditingController(text: widget.court.name);
+    _locationCtrl = TextEditingController(text: widget.court.location);
+    _phoneCtrl = TextEditingController(text: widget.court.phoneLocal);
+    _descCtrl = TextEditingController(text: widget.court.description ?? '');
+    _quantity = widget.court.courtQuantity;
+    _isActive = widget.court.isActive;
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _locationCtrl.dispose();
+    _phoneCtrl.dispose();
+    _descCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _submitting = true);
+    final service = CourtService();
+
+    try {
+      final updated = await service.updateCourt(
+        courtId: widget.court.id,
+        name: _nameCtrl.text,
+        location: _locationCtrl.text,
+        phone: _phoneCtrl.text,
+        courtQuantity: _quantity,
+        isActive: _isActive,
+        description: _descCtrl.text,
+      );
+      widget.onSaved(updated);
+    } catch (err) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(err.toString())),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Chip(
-      label: Text(label),
-      avatar: const Icon(Icons.miscellaneous_services, size: 16),
+    final bottom = MediaQuery.of(context).viewInsets.bottom;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 12,
+        bottom: bottom + 16,
+      ),
+      child: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Center(
+                child: Container(
+                  width: 50,
+                  height: 4,
+                  margin: const EdgeInsets.only(bottom: 16),
+                  decoration: BoxDecoration(
+                    color: Colors.grey.shade400,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const Text(
+                'Chỉnh sửa thông tin sân',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _nameCtrl,
+                decoration: const InputDecoration(labelText: 'Tên sân'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Vui lòng nhập tên sân';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                controller: _locationCtrl,
+                decoration: const InputDecoration(labelText: 'Địa chỉ'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Vui lòng nhập địa chỉ';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                controller: _phoneCtrl,
+                decoration: const InputDecoration(labelText: 'Số điện thoại'),
+                keyboardType: TextInputType.phone,
+                validator: (value) {
+                  final phone = value?.trim() ?? '';
+                  if (phone.isEmpty) return 'Vui lòng nhập số điện thoại';
+                  if (!_phoneReg.hasMatch(phone)) {
+                    return 'Số điện thoại phải theo định dạng 0xxxxxxxxx hoặc +84xxxxxxxxx';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                initialValue: _quantity.toString(),
+                decoration: const InputDecoration(labelText: 'Số sân hiện có'),
+                keyboardType: TextInputType.number,
+                onChanged: (value) {
+                  final parsed = int.tryParse(value);
+                  if (parsed != null && parsed > 0) {
+                    _quantity = parsed;
+                  }
+                },
+                validator: (value) {
+                  final parsed = int.tryParse(value ?? '');
+                  if (parsed == null || parsed <= 0) {
+                    return 'Số sân phải lớn hơn 0';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                controller: _descCtrl,
+                decoration: const InputDecoration(labelText: 'Mô tả / nội quy'),
+                maxLines: 3,
+              ),
+              SwitchListTile.adaptive(
+                contentPadding: EdgeInsets.zero,
+                value: _isActive,
+                onChanged: (value) => setState(() => _isActive = value),
+                title: const Text('Hiển thị sân cho người dùng đặt lịch'),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: _submitting ? null : _submit,
+                      icon: _submitting
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.save_outlined),
+                      label: const Text('Lưu thay đổi'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  OutlinedButton(
+                    onPressed: _submitting ? null : () => Navigator.pop(context),
+                    child: const Text('Hủy'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/manager/manager_court_page.dart
+++ b/lib/pages/manager/manager_court_page.dart
@@ -28,9 +28,7 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
 
   Future<void> _refresh() async {
     final future = _loadCourts();
-    setState(() {
-      _future = future;
-    });
+    setState(() => _future = future);
     await future;
   }
 
@@ -56,22 +54,20 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
 
   void _openImageManager(Court court) {
     Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => CourtImagesPage(court: court),
-      ),
+      MaterialPageRoute(builder: (_) => CourtImagesPage(court: court)),
     );
   }
 
   void _openServiceManager(Court court) {
     Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => CourtServicesPage(court: court),
-      ),
+      MaterialPageRoute(builder: (_) => CourtServicesPage(court: court)),
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return FutureBuilder<List<Court>>(
       future: _future,
       builder: (context, snapshot) {
@@ -81,22 +77,22 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
 
         if (snapshot.hasError) {
           return Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.error_outline, color: Colors.red),
-                const SizedBox(height: 8),
-                Text(
-                  snapshot.error.toString(),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 8),
-                FilledButton.icon(
-                  onPressed: _refresh,
-                  icon: const Icon(Icons.refresh_outlined),
-                  label: const Text('Thử lại'),
-                ),
-              ],
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.error_outline, color: theme.colorScheme.error),
+                  const SizedBox(height: 8),
+                  Text(snapshot.error.toString(), textAlign: TextAlign.center),
+                  const SizedBox(height: 12),
+                  FilledButton.icon(
+                    onPressed: _refresh,
+                    icon: const Icon(Icons.refresh_outlined),
+                    label: const Text('Thử lại'),
+                  ),
+                ],
+              ),
             ),
           );
         }
@@ -104,94 +100,318 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
         final courts = snapshot.data ?? [];
         if (courts.isEmpty) {
           return Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Text('Bạn chưa có sân nào để chỉnh sửa.'),
-                const SizedBox(height: 8),
-                FilledButton.icon(
-                  onPressed: _refresh,
-                  icon: const Icon(Icons.refresh_outlined),
-                  label: const Text('Tải lại'),
-                ),
-              ],
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Bạn chưa có sân nào để quản lý.',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Tạo sân trong hệ thống trước, sau đó quay lại đây để cập nhật thông tin, hình ảnh và dịch vụ.',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  FilledButton.icon(
+                    onPressed: _refresh,
+                    icon: const Icon(Icons.refresh_outlined),
+                    label: const Text('Tải lại'),
+                  ),
+                ],
+              ),
             ),
           );
         }
 
-        final theme = Theme.of(context);
+        // NOTE: giảm padding ngang để card "ăn" thêm chiều ngang
+        const pageHPad = 12.0;
 
         return RefreshIndicator(
           onRefresh: _refresh,
-          child: ListView(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-            children: [
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [
-                      theme.colorScheme.primary.withOpacity(0.08),
-                      theme.colorScheme.secondary.withOpacity(0.08),
-                    ],
+          child: CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(pageHPad, 16, pageHPad, 10),
+                sliver: SliverToBoxAdapter(
+                  child: _ManagerHeaderCard(
+                    courtCount: courts.length,
+                    onRefresh: _refresh,
                   ),
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(
-                    color: theme.colorScheme.primary.withOpacity(0.08),
-                  ),
-                ),
-                child: Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.primary.withOpacity(0.12),
-                        shape: BoxShape.circle,
-                      ),
-                      child: Icon(
-                        Icons.sports_tennis_outlined,
-                        color: theme.colorScheme.primary,
-                        size: 28,
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Sân & dịch vụ',
-                            style: theme.textTheme.titleMedium
-                                ?.copyWith(fontWeight: FontWeight.w700),
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            'Quản lý thông tin sân, hình ảnh và dịch vụ đi kèm.',
-                            style: theme.textTheme.bodyMedium
-                                ?.copyWith(color: theme.hintColor),
-                          ),
-                        ],
-                      ),
-                    ),
-                    IconButton(
-                      onPressed: _refresh,
-                      icon: const Icon(Icons.refresh_outlined),
-                      tooltip: 'Tải lại',
-                    ),
-                  ],
                 ),
               ),
-              const SizedBox(height: 14),
-              ...courts.map((court) => _CourtCard(
-                    court: court,
-                    onEdit: () => _showEditSheet(court),
-                    onManageImages: () => _openImageManager(court),
-                    onManageServices: () => _openServiceManager(court),
-                  )),
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(pageHPad, 0, pageHPad, 12),
+                sliver: SliverToBoxAdapter(
+                  child: _OverviewSection(courts: courts),
+                ),
+              ),
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(pageHPad, 6, pageHPad, 12),
+                sliver: SliverList.separated(
+                  itemCount: courts.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 12),
+                  itemBuilder: (context, index) {
+                    final court = courts[index];
+                    return _CourtCard(
+                      court: court,
+                      onEdit: () => _showEditSheet(court),
+                      onManageImages: () => _openImageManager(court),
+                      onManageServices: () => _openServiceManager(court),
+                    );
+                  },
+                ),
+              ),
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(pageHPad, 0, pageHPad, 24),
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: _ManagerTipsCard(
+                      onRefresh: _refresh,
+                      onOpenServices: () => _openServiceManager(courts.first),
+                      onOpenImages: () => _openImageManager(courts.first),
+                    ),
+                  ),
+                ),
+              ),
             ],
           ),
         );
       },
+    );
+  }
+}
+
+class _ManagerHeaderCard extends StatelessWidget {
+  const _ManagerHeaderCard({
+    required this.courtCount,
+    required this.onRefresh,
+  });
+
+  final int courtCount;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        gradient: LinearGradient(
+          colors: [
+            cs.primary.withOpacity(0.10),
+            cs.tertiary.withOpacity(0.08),
+          ],
+        ),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.6)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                color: cs.primary.withOpacity(0.12),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Icon(Icons.sports_tennis_outlined, color: cs.primary),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Sân & dịch vụ',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Bạn đang quản lý $courtCount sân. Cập nhật mô tả, hình ảnh và dịch vụ để tăng chuyển đổi đặt sân.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            IconButton.filledTonal(
+              onPressed: onRefresh,
+              tooltip: 'Tải lại',
+              icon: const Icon(Icons.refresh_outlined),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OverviewSection extends StatelessWidget {
+  const _OverviewSection({required this.courts});
+  final List<Court> courts;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    final total = courts.length;
+    final active = courts.where((e) => e.isActive).length;
+    final totalSubCourts =
+        courts.fold<int>(0, (sum, c) => sum + c.courtQuantity);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Tổng quan',
+          style: theme.textTheme.titleMedium
+              ?.copyWith(fontWeight: FontWeight.w900),
+        ),
+        const SizedBox(height: 10),
+
+        // FIX OVERFLOW:
+        // - childAspectRatio giảm để mỗi tile cao hơn
+        // - tile bên trong xử lý text mềm + FittedBox cho value
+        GridView.count(
+          crossAxisCount: 2,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          mainAxisSpacing: 10,
+          crossAxisSpacing: 10,
+          childAspectRatio: 2.0,
+          children: [
+            _StatTile(
+              title: 'Sân đang quản lý',
+              value: '$total',
+              icon: Icons.home_work_outlined,
+            ),
+            _StatTile(
+              title: 'Đang hiển thị',
+              value: '$active',
+              icon: Icons.visibility_outlined,
+            ),
+            _StatTile(
+              title: 'Tổng số sân con',
+              value: '$totalSubCourts',
+              icon: Icons.grid_view_outlined,
+            ),
+            _StatTile(
+              title: 'Việc cần làm',
+              value: 'Hình ảnh • Dịch vụ',
+              icon: Icons.checklist_outlined,
+              isTextValue: true,
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        Text(
+          'Mẹo: thêm ít nhất 5 ảnh và 3 dịch vụ để tăng độ tin cậy khi khách chọn sân.',
+          style:
+              theme.textTheme.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  const _StatTile({
+    required this.title,
+    required this.value,
+    required this.icon,
+    this.isTextValue = false,
+  });
+
+  final String title;
+  final String value;
+  final IconData icon;
+  final bool isTextValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHighest.withOpacity(0.55),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.6)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: cs.primary.withOpacity(0.10),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(icon, color: cs.primary, size: 20),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  maxLines: 2, // FIX: cho phép 2 dòng
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: cs.onSurfaceVariant,
+                    fontWeight: FontWeight.w800,
+                    height: 1.1, // FIX: giảm line-height
+                  ),
+                ),
+                const SizedBox(height: 4),
+                if (isTextValue)
+                  Text(
+                    value,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w900,
+                      height: 1.0,
+                    ),
+                  )
+                else
+                  FittedBox(
+                    fit: BoxFit.scaleDown, // FIX: value không bao giờ tràn
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      value,
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w900,
+                        height: 1.0,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -212,25 +432,14 @@ class _CourtCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final cs = theme.colorScheme;
 
-    return Container(
-      margin: const EdgeInsets.only(bottom: 14),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surface,
-        borderRadius: BorderRadius.circular(18),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.06),
-            blurRadius: 18,
-            offset: const Offset(0, 8),
-          ),
-        ],
-        border: Border.all(
-          color: theme.colorScheme.outlineVariant.withOpacity(0.5),
-        ),
-      ),
+    return Card(
+      elevation: 0.8,
+      shadowColor: Colors.black.withOpacity(0.10),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+        padding: const EdgeInsets.fromLTRB(14, 14, 14, 14),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -238,63 +447,88 @@ class _CourtCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Container(
-                  padding: const EdgeInsets.all(10),
+                  width: 44,
+                  height: 44,
                   decoration: BoxDecoration(
-                    color: theme.colorScheme.primary.withOpacity(0.1),
-                    shape: BoxShape.circle,
+                    color: cs.primary.withOpacity(0.10),
+                    borderRadius: BorderRadius.circular(14),
                   ),
-                  child: Icon(
-                    Icons.sports_tennis_outlined,
-                    color: theme.colorScheme.primary,
-                  ),
+                  child: Icon(Icons.home_work_outlined, color: cs.primary),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      Text(
+                        court.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
                       Row(
                         children: [
+                          _StatusChip(isActive: court.isActive),
+                          const SizedBox(width: 8),
                           Expanded(
                             child: Text(
-                              court.name,
-                              style: theme.textTheme.titleMedium
-                                  ?.copyWith(fontWeight: FontWeight.w700),
+                              court.location,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: cs.onSurfaceVariant,
+                              ),
                             ),
-                          ),
-                          _StatusChip(isActive: court.isActive),
-                        ],
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        court.location,
-                        style: theme.textTheme.bodyMedium
-                            ?.copyWith(color: theme.hintColor),
-                      ),
-                      const SizedBox(height: 10),
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 6,
-                        children: [
-                          _InfoPill(
-                            icon: Icons.call_outlined,
-                            label: 'Liên hệ',
-                            value: court.phonePretty,
-                          ),
-                          _InfoPill(
-                            icon: Icons.grid_view_outlined,
-                            label: 'Số sân',
-                            value: court.courtQuantity.toString(),
                           ),
                         ],
                       ),
                     ],
                   ),
                 ),
-                IconButton(
-                  tooltip: 'Chỉnh sửa',
-                  icon: const Icon(Icons.edit_outlined),
-                  onPressed: onEdit,
+                PopupMenuButton<int>(
+                  tooltip: 'Tác vụ',
+                  onSelected: (v) {
+                    switch (v) {
+                      case 0:
+                        onEdit();
+                        break;
+                      case 1:
+                        onManageImages();
+                        break;
+                      case 2:
+                        onManageServices();
+                        break;
+                    }
+                  },
+                  itemBuilder: (_) => const [
+                    PopupMenuItem(value: 0, child: Text('Chỉnh sửa thông tin')),
+                    PopupMenuItem(value: 1, child: Text('Quản lý hình ảnh')),
+                    PopupMenuItem(value: 2, child: Text('Quản lý dịch vụ')),
+                  ],
+                  child: const Padding(
+                    padding: EdgeInsets.all(6),
+                    child: Icon(Icons.more_horiz),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _InfoPill(
+                  icon: Icons.call_outlined,
+                  label: 'Liên hệ',
+                  value: court.phonePretty,
+                ),
+                _InfoPill(
+                  icon: Icons.grid_view_outlined,
+                  label: 'Số sân',
+                  value: court.courtQuantity.toString(),
                 ),
               ],
             ),
@@ -303,34 +537,33 @@ class _CourtCard extends StatelessWidget {
               width: double.infinity,
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceVariant.withOpacity(0.55),
-                borderRadius: BorderRadius.circular(12),
+                color: cs.surfaceContainerHighest.withOpacity(0.55),
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(color: cs.outlineVariant.withOpacity(0.6)),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(
                     children: [
-                      Icon(
-                        Icons.notes_outlined,
-                        size: 18,
-                        color: theme.colorScheme.primary,
-                      ),
-                      const SizedBox(width: 6),
+                      Icon(Icons.notes_outlined, size: 18, color: cs.primary),
+                      const SizedBox(width: 8),
                       Text(
                         'Mô tả & nội quy',
-                        style: theme.textTheme.titleSmall
-                            ?.copyWith(fontWeight: FontWeight.w700),
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w900,
+                        ),
                       ),
                     ],
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    court.description?.isNotEmpty == true
-                        ? court.description!
+                    (court.description?.trim().isNotEmpty ?? false)
+                        ? court.description!.trim()
                         : 'Chưa có mô tả cho sân này.',
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurface.withOpacity(0.8),
+                      color: cs.onSurface.withOpacity(0.85),
+                      height: 1.35,
                     ),
                   ),
                 ],
@@ -343,15 +576,15 @@ class _CourtCard extends StatelessWidget {
                   child: FilledButton.tonalIcon(
                     onPressed: onManageServices,
                     icon: const Icon(Icons.miscellaneous_services_outlined),
-                    label: const Text('Quản lý dịch vụ'),
+                    label: const Text('Dịch vụ'),
                   ),
                 ),
-                const SizedBox(width: 8),
+                const SizedBox(width: 10),
                 Expanded(
-                  child: OutlinedButton.icon(
+                  child: FilledButton.tonalIcon(
                     onPressed: onManageImages,
                     icon: const Icon(Icons.photo_library_outlined),
-                    label: const Text('Quản lý hình ảnh'),
+                    label: const Text('Hình ảnh'),
                   ),
                 ),
               ],
@@ -364,7 +597,11 @@ class _CourtCard extends StatelessWidget {
 }
 
 class _InfoPill extends StatelessWidget {
-  const _InfoPill({required this.icon, required this.label, required this.value});
+  const _InfoPill({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
 
   final IconData icon;
   final String label;
@@ -373,28 +610,33 @@ class _InfoPill extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
-        borderRadius: BorderRadius.circular(24),
+        color: cs.surfaceContainerHighest.withOpacity(0.55),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.6)),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(icon, size: 16, color: theme.colorScheme.primary),
+          Icon(icon, size: 16, color: cs.primary),
           const SizedBox(width: 6),
           Text(
             label,
-            style: theme.textTheme.labelMedium
-                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: cs.onSurfaceVariant,
+              fontWeight: FontWeight.w700,
+            ),
           ),
           const SizedBox(width: 6),
           Text(
             value,
             style: theme.textTheme.labelMedium?.copyWith(
-              fontWeight: FontWeight.w700,
-              color: theme.colorScheme.onSurface,
+              fontWeight: FontWeight.w900,
+              color: cs.onSurface,
             ),
           ),
         ],
@@ -411,19 +653,25 @@ class _StatusChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = isActive ? Colors.green : theme.colorScheme.outline;
+    final cs = theme.colorScheme;
+
+    final color = isActive ? Colors.green : cs.outline;
+    final bg = color.withOpacity(0.12);
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.12),
-        borderRadius: BorderRadius.circular(30),
-        border: Border.all(color: color.withOpacity(0.6)),
+        color: bg,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withOpacity(0.55)),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
           Icon(
-            isActive ? Icons.check_circle_outline : Icons.visibility_off_outlined,
+            isActive
+                ? Icons.check_circle_outline
+                : Icons.visibility_off_outlined,
             size: 16,
             color: color,
           ),
@@ -431,8 +679,131 @@ class _StatusChip extends StatelessWidget {
           Text(
             isActive ? 'Đang hiển thị' : 'Đang ẩn',
             style: theme.textTheme.labelMedium?.copyWith(
-              fontWeight: FontWeight.w700,
+              fontWeight: FontWeight.w900,
               color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ManagerTipsCard extends StatelessWidget {
+  const _ManagerTipsCard({
+    required this.onRefresh,
+    required this.onOpenServices,
+    required this.onOpenImages,
+  });
+
+  final VoidCallback onRefresh;
+  final VoidCallback onOpenServices;
+  final VoidCallback onOpenImages;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: cs.outlineVariant.withOpacity(0.6)),
+        color: cs.surfaceContainerHighest.withOpacity(0.35),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.auto_awesome_outlined, color: cs.primary),
+              const SizedBox(width: 8),
+              Text(
+                'Gợi ý tối ưu trang sân',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const Spacer(),
+              IconButton(
+                onPressed: onRefresh,
+                tooltip: 'Tải lại',
+                icon: const Icon(Icons.refresh_outlined),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Trang sẽ đầy và “có sức sống” hơn nếu bạn hoàn thiện đủ 3 nhóm nội dung:',
+            style: theme.textTheme.bodyMedium
+                ?.copyWith(color: cs.onSurfaceVariant),
+          ),
+          const SizedBox(height: 10),
+          const _Bullet(
+              'Hình ảnh: thêm ảnh sân, khu vực gửi xe, nhà vệ sinh, bảng giá.'),
+          const _Bullet('Dịch vụ: nước uống, thuê vợt, cầu, khăn, bãi xe.'),
+          const _Bullet(
+              'Mô tả/nội quy: giờ mở cửa, quy định giày, đặt cọc (nếu có).'),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: onOpenImages,
+                  icon: const Icon(Icons.photo_library_outlined),
+                  label: const Text('Bổ sung hình ảnh'),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: onOpenServices,
+                  icon: const Icon(Icons.miscellaneous_services_outlined),
+                  label: const Text('Bổ sung dịch vụ'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Bullet extends StatelessWidget {
+  const _Bullet(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Container(
+              width: 6,
+              height: 6,
+              decoration: BoxDecoration(
+                color: cs.primary,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: cs.onSurface.withOpacity(0.85),
+              ),
             ),
           ),
         ],
@@ -454,12 +825,15 @@ class _EditCourtSheet extends StatefulWidget {
 class _EditCourtSheetState extends State<_EditCourtSheet> {
   final _formKey = GlobalKey<FormState>();
   final _phoneReg = RegExp(r'^(?:0|\+84)\d{9}$');
+
   late final TextEditingController _nameCtrl;
   late final TextEditingController _locationCtrl;
   late final TextEditingController _phoneCtrl;
   late final TextEditingController _descCtrl;
+
   late int _quantity;
   late bool _isActive;
+
   bool _submitting = false;
 
   @override
@@ -510,227 +884,275 @@ class _EditCourtSheetState extends State<_EditCourtSheet> {
     }
   }
 
+  InputDecoration _decoration({
+    required String hint,
+    required IconData icon,
+  }) {
+    return InputDecoration(
+      hintText: hint,
+      prefixIcon: Icon(icon),
+      filled: true,
+      isDense: true,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(14),
+        borderSide: BorderSide.none,
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final bottom = MediaQuery.of(context).viewInsets.bottom;
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
 
-    return AnimatedPadding(
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeOut,
-      padding: EdgeInsets.only(bottom: bottom),
-      child: Container(
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surface,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.08),
-              blurRadius: 20,
-              offset: const Offset(0, -4),
-            ),
-          ],
-        ),
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Center(
-                  child: Container(
-                    width: 48,
-                    height: 5,
-                    margin: const EdgeInsets.only(bottom: 18),
-                    decoration: BoxDecoration(
-                      color: Colors.grey.shade400,
-                      borderRadius: BorderRadius.circular(50),
-                    ),
-                  ),
-                ),
-                Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                        color:
-                            Theme.of(context).colorScheme.primary.withOpacity(0.08),
-                        shape: BoxShape.circle,
-                      ),
-                      child: Icon(
-                        Icons.sports_tennis_outlined,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    const Expanded(
-                      child: Text(
-                        'Chỉnh sửa thông tin sân',
-                        style: TextStyle(
-                          fontWeight: FontWeight.w700,
-                          fontSize: 18,
-                        ),
-                      ),
-                    ),
-                    IconButton(
-                      onPressed: _submitting ? null : () => Navigator.pop(context),
-                      icon: const Icon(Icons.close),
-                      tooltip: 'Đóng',
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                _LabeledField(
-                  label: 'Tên sân',
-                  child: TextFormField(
-                    controller: _nameCtrl,
-                    decoration: const InputDecoration(
-                      hintText: 'Ví dụ: Quang Sport',
-                      prefixIcon: Icon(Icons.home_work_outlined),
-                    ),
-                    validator: (value) {
-                      if (value == null || value.trim().isEmpty) {
-                        return 'Vui lòng nhập tên sân';
-                      }
-                      return null;
-                    },
-                  ),
-                ),
-                _LabeledField(
-                  label: 'Địa chỉ',
-                  child: TextFormField(
-                    controller: _locationCtrl,
-                    decoration: const InputDecoration(
-                      hintText: 'Số nhà, đường, quận/huyện...',
-                      prefixIcon: Icon(Icons.place_outlined),
-                    ),
-                    validator: (value) {
-                      if (value == null || value.trim().isEmpty) {
-                        return 'Vui lòng nhập địa chỉ';
-                      }
-                      return null;
-                    },
-                  ),
-                ),
-                Row(
-                  children: [
-                    Expanded(
-                      child: _LabeledField(
-                        label: 'Số điện thoại',
-                        child: TextFormField(
-                          controller: _phoneCtrl,
-                          decoration: const InputDecoration(
-                            hintText: '0xxxxxxxxx / +84xxxxxxxxx',
-                            prefixIcon: Icon(Icons.call_outlined),
-                          ),
-                          keyboardType: TextInputType.phone,
-                          validator: (value) {
-                            final phone = value?.trim() ?? '';
-                            if (phone.isEmpty) {
-                              return 'Vui lòng nhập số điện thoại';
-                            }
-                            if (!_phoneReg.hasMatch(phone)) {
-                              return 'Số điện thoại phải theo định dạng 0xxxxxxxxx hoặc +84xxxxxxxxx';
-                            }
-                            return null;
-                          },
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: _LabeledField(
-                        label: 'Số sân',
-                        child: TextFormField(
-                          initialValue: _quantity.toString(),
-                          decoration: const InputDecoration(
-                            hintText: 'Nhập số sân',
-                            prefixIcon: Icon(Icons.grid_view_outlined),
-                          ),
-                          keyboardType: TextInputType.number,
-                          onChanged: (value) {
-                            final parsed = int.tryParse(value);
-                            if (parsed != null && parsed > 0) {
-                              _quantity = parsed;
-                            }
-                          },
-                          validator: (value) {
-                            final parsed = int.tryParse(value ?? '');
-                            if (parsed == null || parsed <= 0) {
-                              return 'Số sân phải lớn hơn 0';
-                            }
-                            return null;
-                          },
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                _LabeledField(
-                  label: 'Mô tả / nội quy',
-                  child: TextFormField(
-                    controller: _descCtrl,
-                    decoration: const InputDecoration(
-                      hintText: 'Thông tin chi tiết giúp khách hiểu hơn...',
-                      prefixIcon: Icon(Icons.notes_outlined),
-                    ),
-                    maxLines: 3,
-                  ),
-                ),
-                Container(
-                  margin: const EdgeInsets.only(top: 8),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(12),
-                    color: Theme.of(context).colorScheme.surfaceVariant,
-                  ),
-                  child: SwitchListTile.adaptive(
-                    contentPadding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-                    value: _isActive,
-                    onChanged: (value) => setState(() => _isActive = value),
-                    title: const Text('Hiển thị sân cho người dùng đặt lịch'),
-                    secondary: Icon(
-                      _isActive ? Icons.visibility_outlined : Icons.visibility_off_outlined,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Row(
-                  children: [
-                    Expanded(
-                      child: OutlinedButton(
-                        onPressed:
-                            _submitting ? null : () => Navigator.pop(context),
-                        style: OutlinedButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(vertical: 14),
-                        ),
-                        child: const Text('Hủy'),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: FilledButton.icon(
-                        onPressed: _submitting ? null : _submit,
-                        icon: _submitting
-                            ? const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(strokeWidth: 2),
-                              )
-                            : const Icon(Icons.save_outlined),
-                        label: const Text('Lưu thay đổi'),
-                        style: FilledButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(vertical: 14),
-                        ),
-                      ),
-                    ),
-                  ],
+    return SafeArea(
+      top: false,
+      child: DraggableScrollableSheet(
+        initialChildSize: 0.78,
+        minChildSize: 0.55,
+        maxChildSize: 0.95,
+        builder: (context, scrollCtrl) {
+          return Container(
+            decoration: BoxDecoration(
+              color: cs.surface,
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(26)),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.12),
+                  blurRadius: 24,
+                  offset: const Offset(0, -8),
                 ),
               ],
             ),
-          ),
-        ),
+            child: Column(
+              children: [
+                const SizedBox(height: 10),
+                Container(
+                  width: 46,
+                  height: 5,
+                  decoration: BoxDecoration(
+                    color: cs.outlineVariant,
+                    borderRadius: BorderRadius.circular(99),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(18, 4, 10, 10),
+                  child: Row(
+                    children: [
+                      Container(
+                        width: 40,
+                        height: 40,
+                        decoration: BoxDecoration(
+                          color: cs.primary.withOpacity(0.10),
+                          borderRadius: BorderRadius.circular(14),
+                        ),
+                        child: Icon(Icons.edit_outlined, color: cs.primary),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          'Chỉnh sửa thông tin sân',
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                      ),
+                      IconButton(
+                        onPressed:
+                            _submitting ? null : () => Navigator.pop(context),
+                        tooltip: 'Đóng',
+                        icon: const Icon(Icons.close),
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(height: 1),
+                Expanded(
+                  child: SingleChildScrollView(
+                    controller: scrollCtrl,
+                    padding: const EdgeInsets.fromLTRB(18, 14, 18, 18),
+                    child: Form(
+                      key: _formKey,
+                      child: Column(
+                        children: [
+                          _LabeledField(
+                            label: 'Tên sân',
+                            child: TextFormField(
+                              controller: _nameCtrl,
+                              textInputAction: TextInputAction.next,
+                              decoration: _decoration(
+                                hint: 'Ví dụ: Quang Sport',
+                                icon: Icons.home_work_outlined,
+                              ),
+                              validator: (value) {
+                                if (value == null || value.trim().isEmpty) {
+                                  return 'Vui lòng nhập tên sân';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                          _LabeledField(
+                            label: 'Địa chỉ',
+                            child: TextFormField(
+                              controller: _locationCtrl,
+                              textInputAction: TextInputAction.next,
+                              decoration: _decoration(
+                                hint: 'Số nhà, đường, quận/huyện...',
+                                icon: Icons.place_outlined,
+                              ),
+                              validator: (value) {
+                                if (value == null || value.trim().isEmpty) {
+                                  return 'Vui lòng nhập địa chỉ';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: _LabeledField(
+                                  label: 'Số điện thoại',
+                                  child: TextFormField(
+                                    controller: _phoneCtrl,
+                                    textInputAction: TextInputAction.next,
+                                    decoration: _decoration(
+                                      hint: '0xxxxxxxxx / +84xxxxxxxxx',
+                                      icon: Icons.call_outlined,
+                                    ),
+                                    keyboardType: TextInputType.phone,
+                                    validator: (value) {
+                                      final phone = value?.trim() ?? '';
+                                      if (phone.isEmpty)
+                                        return 'Vui lòng nhập số điện thoại';
+                                      if (!_phoneReg.hasMatch(phone)) {
+                                        return 'Sai định dạng 0xxxxxxxxx hoặc +84xxxxxxxxx';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: _LabeledField(
+                                  label: 'Số sân',
+                                  child: TextFormField(
+                                    initialValue: _quantity.toString(),
+                                    decoration: _decoration(
+                                      hint: 'Nhập số sân',
+                                      icon: Icons.grid_view_outlined,
+                                    ),
+                                    keyboardType: TextInputType.number,
+                                    onChanged: (value) {
+                                      final parsed = int.tryParse(value);
+                                      if (parsed != null && parsed > 0)
+                                        _quantity = parsed;
+                                    },
+                                    validator: (value) {
+                                      final parsed = int.tryParse(value ?? '');
+                                      if (parsed == null || parsed <= 0) {
+                                        return 'Số sân phải lớn hơn 0';
+                                      }
+                                      return null;
+                                    },
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          _LabeledField(
+                            label: 'Mô tả / nội quy',
+                            child: TextFormField(
+                              controller: _descCtrl,
+                              decoration: _decoration(
+                                hint:
+                                    'Thông tin chi tiết giúp khách hiểu hơn...',
+                                icon: Icons.notes_outlined,
+                              ),
+                              maxLines: 4,
+                            ),
+                          ),
+                          Container(
+                            decoration: BoxDecoration(
+                              color:
+                                  cs.surfaceContainerHighest.withOpacity(0.55),
+                              borderRadius: BorderRadius.circular(16),
+                              border: Border.all(
+                                  color: cs.outlineVariant.withOpacity(0.6)),
+                            ),
+                            child: SwitchListTile.adaptive(
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 6,
+                              ),
+                              value: _isActive,
+                              onChanged: _submitting
+                                  ? null
+                                  : (v) => setState(() => _isActive = v),
+                              title: const Text(
+                                  'Hiển thị sân cho người dùng đặt lịch'),
+                              subtitle: Text(
+                                _isActive
+                                    ? 'Sân sẽ xuất hiện trên danh sách đặt lịch.'
+                                    : 'Sân bị ẩn khỏi danh sách đặt lịch.',
+                              ),
+                              secondary: Icon(
+                                _isActive
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: OutlinedButton(
+                                  onPressed: _submitting
+                                      ? null
+                                      : () => Navigator.pop(context),
+                                  style: OutlinedButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 14),
+                                  ),
+                                  child: const Text('Hủy'),
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: FilledButton.icon(
+                                  onPressed: _submitting ? null : _submit,
+                                  icon: _submitting
+                                      ? const SizedBox(
+                                          width: 18,
+                                          height: 18,
+                                          child: CircularProgressIndicator(
+                                              strokeWidth: 2),
+                                        )
+                                      : const Icon(Icons.save_outlined),
+                                  label: const Text('Lưu thay đổi'),
+                                  style: FilledButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 14),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
       ),
     );
   }
@@ -744,6 +1166,7 @@ class _LabeledField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Column(
@@ -753,9 +1176,9 @@ class _LabeledField extends StatelessWidget {
             padding: const EdgeInsets.only(bottom: 6),
             child: Text(
               label,
-              style: TextStyle(
-                fontWeight: FontWeight.w600,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.85),
+              style: theme.textTheme.labelLarge?.copyWith(
+                fontWeight: FontWeight.w800,
+                color: theme.colorScheme.onSurface.withOpacity(0.85),
               ),
             ),
           ),

--- a/lib/pages/manager/manager_court_page.dart
+++ b/lib/pages/manager/manager_court_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../models/court.dart';
 import '../../services/court_service.dart';
 import 'court_images_page.dart';
+import 'court_services_page.dart';
 
 class ManagerCourtPage extends StatefulWidget {
   const ManagerCourtPage({super.key});
@@ -57,6 +58,14 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => CourtImagesPage(court: court),
+      ),
+    );
+  }
+
+  void _openServiceManager(Court court) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => CourtServicesPage(court: court),
       ),
     );
   }
@@ -124,6 +133,7 @@ class _ManagerCourtPageState extends State<ManagerCourtPage> {
                     court: court,
                     onEdit: () => _showEditSheet(court),
                     onManageImages: () => _openImageManager(court),
+                    onManageServices: () => _openServiceManager(court),
                   )),
             ],
           ),
@@ -138,11 +148,13 @@ class _CourtCard extends StatelessWidget {
     required this.court,
     required this.onEdit,
     required this.onManageImages,
+    required this.onManageServices,
   });
 
   final Court court;
   final VoidCallback onEdit;
   final VoidCallback onManageImages;
+  final VoidCallback onManageServices;
 
   @override
   Widget build(BuildContext context) {
@@ -218,13 +230,21 @@ class _CourtCard extends StatelessWidget {
               style: TextStyle(color: Colors.grey.shade800),
             ),
             const SizedBox(height: 12),
-            Align(
-              alignment: Alignment.centerRight,
-              child: TextButton.icon(
-                onPressed: onManageImages,
-                icon: const Icon(Icons.photo_library_outlined),
-                label: const Text('Quản lý hình ảnh'),
-              ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton.icon(
+                  onPressed: onManageServices,
+                  icon: const Icon(Icons.miscellaneous_services_outlined),
+                  label: const Text('Quản lý dịch vụ'),
+                ),
+                const SizedBox(width: 4),
+                TextButton.icon(
+                  onPressed: onManageImages,
+                  icon: const Icon(Icons.photo_library_outlined),
+                  label: const Text('Quản lý hình ảnh'),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/services/court_service.dart
+++ b/lib/services/court_service.dart
@@ -1,3 +1,4 @@
+import 'package:http/http.dart' as http;
 import 'package:pocketbase/pocketbase.dart';
 
 import '../models/court.dart';
@@ -11,6 +12,20 @@ class CourtServiceException implements Exception {
 
   @override
   String toString() => message;
+}
+
+class CourtImageFile {
+  const CourtImageFile({
+    required this.recordId,
+    required this.fileName,
+    required this.url,
+    required this.recordFiles,
+  });
+
+  final String recordId;
+  final String fileName;
+  final String url;
+  final List<String> recordFiles;
 }
 
 class CourtService {
@@ -142,6 +157,111 @@ class CourtService {
     } catch (_) {
       throw CourtServiceException(
         'Có lỗi xảy ra khi cập nhật thông tin sân. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<List<CourtImageFile>> listCourtImages(String courtId) async {
+    final pb = await getPocketbaseInstance();
+    final escapedId = _escapeFilterValue(courtId);
+
+    try {
+      final result = await pb.collection('court_images').getList(
+            filter: "court_id='$escapedId'",
+            perPage: 100,
+          );
+
+      final images = <CourtImageFile>[];
+
+      for (final record in result.items) {
+        final fileNames = _extractFileNames(record, 'image');
+
+        for (final name in fileNames) {
+          images.add(
+            CourtImageFile(
+              recordId: record.id,
+              fileName: name,
+              url: pb.files.getUrl(record, name).toString(),
+              recordFiles: List.unmodifiable(fileNames),
+            ),
+          );
+        }
+      }
+
+      return images;
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể tải hình ảnh sân. Vui lòng thử lại.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi tải hình ảnh sân. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<void> uploadCourtImages({
+    required String courtId,
+    required List<http.MultipartFile> files,
+  }) async {
+    if (files.isEmpty) {
+      throw CourtServiceException('Vui lòng chọn ít nhất một hình ảnh.');
+    }
+
+    final pb = await getPocketbaseInstance();
+
+    try {
+      await pb.collection('court_images').create(
+        body: {'court_id': courtId},
+        files: files,
+      );
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể tải lên hình ảnh. Vui lòng thử lại.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi tải lên hình ảnh. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<void> removeCourtImage({
+    required String recordId,
+    required String fileName,
+  }) async {
+    final pb = await getPocketbaseInstance();
+
+    try {
+      final record = await pb.collection('court_images').getOne(recordId);
+      final fileNames = _extractFileNames(record, 'image');
+
+      final remaining = fileNames.where((name) => name != fileName).toList();
+
+      if (remaining.isEmpty) {
+        await pb.collection('court_images').delete(recordId);
+      } else {
+        await pb.collection('court_images').update(
+          recordId,
+          body: {'image': remaining},
+        );
+      }
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể xóa hình ảnh. Vui lòng thử lại.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi xóa hình ảnh. Vui lòng thử lại.',
       );
     }
   }
@@ -288,6 +408,15 @@ class CourtService {
     String field,
   ) {
     final value = record.data[field];
+    final files = _extractFileNames(record, field);
+
+    return files
+        .map((fileName) => pb.files.getUrl(record, fileName).toString())
+        .toList(growable: false);
+  }
+
+  List<String> _extractFileNames(RecordModel record, String field) {
+    final value = record.data[field];
     final files = <String>[];
 
     if (value is String && value.isNotEmpty) {
@@ -300,9 +429,7 @@ class CourtService {
       }
     }
 
-    return files
-        .map((fileName) => pb.files.getUrl(record, fileName).toString())
-        .toList(growable: false);
+    return files;
   }
 
   String _escapeFilterValue(String value) {

--- a/lib/services/court_service.dart
+++ b/lib/services/court_service.dart
@@ -47,6 +47,45 @@ class CourtService {
     }
   }
 
+  Future<List<Court>> listOwnerCourts({
+    int page = 1,
+    int perPage = 50,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final authRecord = pb.authStore.record;
+
+    if (authRecord == null) {
+      throw CourtServiceException(
+        'Bạn cần đăng nhập để xem danh sách sân của mình.',
+      );
+    }
+
+    final escapedOwner = _escapeFilterValue(authRecord.id);
+
+    try {
+      final result = await pb.collection(collection).getList(
+            page: page,
+            perPage: perPage,
+            filter: "owner='$escapedOwner'",
+          );
+
+      return result.items
+          .map((record) => _mapRecordToCourt(pb, record))
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể tải danh sách sân. Vui lòng thử lại sau.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi tải danh sách sân. Vui lòng thử lại.',
+      );
+    }
+  }
+
   Future<Court> getCourt(String id) async {
     final pb = await getPocketbaseInstance();
 
@@ -63,6 +102,46 @@ class CourtService {
     } catch (_) {
       throw CourtServiceException(
         'Đã xảy ra lỗi khi lấy thông tin sân. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<Court> updateCourt({
+    required String courtId,
+    required String name,
+    required String location,
+    required String phone,
+    required int courtQuantity,
+    bool isActive = true,
+    String? description,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    try {
+      final record = await pb.collection(collection).update(
+        courtId,
+        body: {
+          'name': name.trim(),
+          'location': location.trim(),
+          'phone': phone.trim(),
+          'court_quantity': courtQuantity,
+          'is_active': isActive,
+          'description': description?.trim().isEmpty == true
+              ? null
+              : description?.trim(),
+        },
+      );
+
+      return _mapRecordToCourt(pb, record);
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể cập nhật thông tin sân. Vui lòng thử lại.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi cập nhật thông tin sân. Vui lòng thử lại.',
       );
     }
   }

--- a/lib/services/court_service.dart
+++ b/lib/services/court_service.dart
@@ -31,6 +31,39 @@ class CourtImageFile {
 class CourtService {
   static const collection = 'courts';
 
+  Future<List<ServiceCatalogItem>> listServiceCatalog({
+    int page = 1,
+    int perPage = 200,
+    bool onlyActive = true,
+  }) async {
+    final pb = await getPocketbaseInstance();
+
+    try {
+      final filter = onlyActive ? "is_active=true" : null;
+      final result = await pb.collection('service_catalog').getList(
+            page: page,
+            perPage: perPage,
+            filter: filter,
+          );
+
+      return result.items
+          .map(ServiceCatalogItem.fromRecord)
+          .where((item) => item.name.trim().isNotEmpty)
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể tải danh sách dịch vụ. Vui lòng thử lại.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi tải danh sách dịch vụ. Vui lòng thử lại.',
+      );
+    }
+  }
+
   Future<List<Court>> listCourts({
     int page = 1,
     int perPage = 20,
@@ -97,6 +130,128 @@ class CourtService {
     } catch (_) {
       throw CourtServiceException(
         'Có lỗi xảy ra khi tải danh sách sân. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<List<CourtServiceItem>> listCourtServices(
+    String courtId, {
+    bool includeInactive = true,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final escapedId = _escapeFilterValue(courtId);
+
+    try {
+      final filter = includeInactive
+          ? "court_id='$escapedId'"
+          : "court_id='$escapedId' && is_active=true";
+
+      final result = await pb.collection('court_services').getList(
+            filter: filter,
+            perPage: 200,
+            expand: 'service_id',
+          );
+
+      return result.items
+          .map(
+            (record) => CourtServiceItem.fromRecord(
+              record,
+              catalog: _extractExpandedCatalog(
+                record,
+                (record.data['service_id'] as String?) ?? '',
+              ),
+            ),
+          )
+          .where((item) => includeInactive || item.isActive)
+          .toList(growable: false);
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể tải danh sách dịch vụ của sân. Vui lòng thử lại.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi tải danh sách dịch vụ của sân. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<CourtServiceItem> createCourtService({
+    required String courtId,
+    required String serviceId,
+    int? price,
+    String? note,
+    String? unit,
+    String? serviceName,
+    bool isActive = true,
+  }) async {
+    final pb = await getPocketbaseInstance();
+
+    try {
+      final record = await pb.collection('court_services').create(body: {
+        'court_id': courtId,
+        'service_id': serviceId,
+        'price': price,
+        'note': note?.trim().isEmpty == true ? null : note?.trim(),
+        'unit': unit?.trim().isEmpty == true ? null : unit?.trim(),
+        'service_name': serviceName?.trim().isEmpty == true
+            ? null
+            : serviceName?.trim(),
+        'is_active': isActive,
+      });
+
+      return CourtServiceItem.fromRecord(record);
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể thêm dịch vụ cho sân. Vui lòng thử lại.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi thêm dịch vụ cho sân. Vui lòng thử lại.',
+      );
+    }
+  }
+
+  Future<CourtServiceItem> updateCourtService({
+    required String id,
+    int? price,
+    String? note,
+    String? unit,
+    String? serviceName,
+    bool? isActive,
+  }) async {
+    final pb = await getPocketbaseInstance();
+
+    try {
+      final record = await pb.collection('court_services').update(
+        id,
+        body: {
+          'price': price,
+          'note': note?.trim().isEmpty == true ? null : note?.trim(),
+          'unit': unit?.trim().isEmpty == true ? null : unit?.trim(),
+          'service_name': serviceName?.trim().isEmpty == true
+              ? null
+              : serviceName?.trim(),
+          if (isActive != null) 'is_active': isActive,
+        },
+      );
+
+      return CourtServiceItem.fromRecord(record);
+    } on ClientException catch (error) {
+      throw CourtServiceException(
+        _mapClientException(
+          error,
+          fallback: 'Không thể cập nhật dịch vụ. Vui lòng thử lại.',
+        ),
+      );
+    } catch (_) {
+      throw CourtServiceException(
+        'Có lỗi xảy ra khi cập nhật dịch vụ. Vui lòng thử lại.',
       );
     }
   }


### PR DESCRIPTION
## Summary
- load and show the logged-in owner's courts instead of static placeholders
- add editable bottom sheet to update court name, address, phone, quantity, and visibility
- extend court service with owner filtering and update call using PocketBase

## Testing
- not run (environment missing Flutter/Dart SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942348fe608832aaa5a92e8fa0283e2)