### PR TITLE
Fix court header stat pill overflow

### DIFF
--- a/lib/models/court_review.dart
+++ b/lib/models/court_review.dart
@@ -3,7 +3,7 @@ import 'package:pocketbase/pocketbase.dart';
 import '../utils/pocketbase_utils.dart';
 
 class CourtReview {
-  const CourtReview({
+  CourtReview({
     required this.id,
     required this.courtId,
     required this.userId,

--- a/lib/models/court_review.dart
+++ b/lib/models/court_review.dart
@@ -1,0 +1,59 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../utils/pocketbase_utils.dart';
+
+class CourtReview {
+  const CourtReview({
+    required this.id,
+    required this.courtId,
+    required this.userId,
+    required this.userName,
+    required this.stars,
+    required this.comment,
+    required this.createdAt,
+    this.likes = 0,
+    this.likedByMe = false,
+  });
+
+  factory CourtReview.fromRecord(RecordModel record, PocketBase pocketBase) {
+    final data = record.data;
+    final userRecord = resolveExpandedRecord(record.expand?['user_id']);
+    final userData = userRecord?.data;
+
+    return CourtReview(
+      id: record.id,
+      courtId: _resolveRelationId(data['court_id']),
+      userId: _resolveRelationId(data['user_id'], fallback: userRecord?.id),
+      userName: sanitizeDisplayName(
+        (data['display_name'] as String?) ??
+            (userData?['username'] as String?) ??
+            (userData?['email'] as String?),
+      ),
+      stars: (data['rating'] as num?)?.toDouble() ?? 0,
+      comment: (data['comment'] as String?)?.trim() ?? '',
+      createdAt: DateTime.parse(data['created'] as String),
+      likes: (data['likes'] as num?)?.toInt() ?? 0,
+      likedByMe: (data['liked_by_me'] as bool?) ?? false,
+    );
+  }
+
+  final String id;
+  final String courtId;
+  final String userId;
+  final String userName;
+  final double stars;
+  final String comment;
+  final DateTime createdAt;
+  final int likes;
+  final bool likedByMe;
+
+  static String _resolveRelationId(dynamic value, {String? fallback}) {
+    if (value is String) {
+      return value;
+    }
+    if (value is List && value.isNotEmpty && value.first is String) {
+      return value.first as String;
+    }
+    return fallback ?? '';
+  }
+}

--- a/lib/models/court_review.dart
+++ b/lib/models/court_review.dart
@@ -25,8 +25,7 @@ class CourtReview {
       courtId: _resolveRelationId(data['court_id']),
       userId: _resolveRelationId(data['user_id'], fallback: userRecord?.id),
       userName: sanitizeDisplayName(
-        (data['display_name'] as String?) ??
-            (userData?['username'] as String?) ??
+        (userData?['username'] as String?) ??
             (userData?['email'] as String?),
       ),
       stars: (data['rating'] as num?)?.toDouble() ?? 0,

--- a/lib/models/court_review.dart
+++ b/lib/models/court_review.dart
@@ -44,8 +44,8 @@ class CourtReview {
   final double stars;
   final String comment;
   final DateTime createdAt;
-  final int likes;
-  final bool likedByMe;
+  int likes;
+  bool likedByMe;
 
   static String _resolveRelationId(dynamic value, {String? fallback}) {
     if (value is String) {

--- a/lib/pages/court/court_detail.dart
+++ b/lib/pages/court/court_detail.dart
@@ -167,7 +167,7 @@ class _CourtDetailState extends State<CourtDetail>
                 emptyMessage: 'This court has no photos yet.',
               ),
               Rules(items: _buildDefaultRules()),
-              const ReviewTab(initialReviews: []),
+              ReviewTab(courtId: _detailData.court.id),
             ],
           ),
         ),

--- a/lib/pages/court/court_page.dart
+++ b/lib/pages/court/court_page.dart
@@ -259,14 +259,15 @@ class _CourtPageState extends State<CourtPage> {
                     ),
                   ),
                   const SizedBox(height: 10),
-                  Row(
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
                     children: [
                       _buildStatPill(
                         context,
                         icon: Icons.sports_tennis,
                         label: '$courtCount courts available',
                       ),
-                      const SizedBox(width: 8),
                       _buildStatPill(
                         context,
                         icon: Icons.favorite,
@@ -319,6 +320,8 @@ class _CourtPageState extends State<CourtPage> {
               color: colorScheme.onPrimary,
               fontWeight: FontWeight.w700,
             ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           )
         ],
       ),

--- a/lib/pages/court/tabs/review_tab.dart
+++ b/lib/pages/court/tabs/review_tab.dart
@@ -1,57 +1,18 @@
 import 'package:flutter/material.dart';
 
-class Review {
-  final String id;
-  final String userName;
-  final double stars; // 1..5
-  final String comment;
-  final DateTime createdAt;
-  int likes;
-  bool likedByMe;
-
-  Review({
-    required this.id,
-    required this.userName,
-    required this.stars,
-    required this.comment,
-    required this.createdAt,
-    this.likes = 0,
-    this.likedByMe = false,
-  });
-}
-
-final List<Review> kSampleReviews = [
-  Review(
-    id: 'r1',
-    userName: 'Hữu Minh',
-    stars: 5,
-    comment:
-        'Clean courts, bright lights, clear lines. The owner is very supportive. Peak hours are a bit busy but booking ahead works.',
-    createdAt: DateTime.now().subtract(const Duration(days: 1, hours: 3)),
-    likes: 2,
-  ),
-  Review(
-    id: 'r2',
-    userName: 'Ngọc Anh',
-    stars: 4,
-    comment:
-        'Reasonable prices. Would be perfect with more fans at court #3. Overall worth returning.',
-    createdAt: DateTime.now().subtract(const Duration(days: 4)),
-  ),
-  Review(
-    id: 'r3',
-    userName: 'Quốc Việt',
-    stars: 3,
-    comment:
-        'The floor was a bit slippery on a rainy day—hope drainage improves. Staff were fine.',
-    createdAt: DateTime.now().subtract(const Duration(days: 9)),
-    likes: 1,
-  ),
-];
+import '../../../models/court_review.dart';
+import '../../../services/review_service.dart';
 
 class ReviewTab extends StatefulWidget {
-  final List<Review> initialReviews;
-  const ReviewTab({super.key, this.initialReviews = const []});
+  final String courtId;
+  final List<CourtReview> initialReviews;
+  final ReviewService? reviewService;
+  const ReviewTab({
+    super.key,
+    required this.courtId,
+    this.initialReviews = const [],
+    this.reviewService,
+  });
 
   @override
   State<ReviewTab> createState() => _ReviewTabState();
@@ -60,7 +21,10 @@ class ReviewTab extends StatefulWidget {
 enum _SortBy { newest, highest, lowest, mostLiked }
 
 class _ReviewTabState extends State<ReviewTab> {
-  late List<Review> _reviews;
+  late List<CourtReview> _reviews;
+  late final ReviewService _reviewService;
+  bool _isLoading = false;
+  String? _errorMessage;
   _SortBy _sortBy = _SortBy.newest;
   int _filterStars = 0; // 0: all, 1..5: filter by stars
 
@@ -68,9 +32,32 @@ class _ReviewTabState extends State<ReviewTab> {
   void initState() {
     super.initState();
     _reviews = [...widget.initialReviews];
+    _reviewService = widget.reviewService ?? ReviewService();
+    _loadReviews();
   }
 
-  void _addReview(Review r) {
+  Future<void> _loadReviews() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+    try {
+      final reviews = await _reviewService.fetchReviews(widget.courtId);
+      if (!mounted) return;
+      setState(() {
+        _reviews = reviews;
+        _isLoading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = error.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _addReview(CourtReview r) {
     setState(() => _reviews.insert(0, r));
   }
 
@@ -102,8 +89,8 @@ class _ReviewTabState extends State<ReviewTab> {
     return d;
   }
 
-  List<Review> get _visible {
-    List<Review> out = [..._reviews];
+  List<CourtReview> get _visible {
+    List<CourtReview> out = [..._reviews];
     if (_filterStars != 0) {
       out = out.where((e) => e.stars.round() == _filterStars).toList();
     }
@@ -224,7 +211,8 @@ class _ReviewTabState extends State<ReviewTab> {
           ),
           const Spacer(),
           TextButton.icon(
-            onPressed: () => _openWriteReview(context),
+            onPressed:
+                _isLoading ? null : () => _openWriteReview(context, cs),
             icon: const Icon(Icons.edit_outlined),
             label: const Text('Write a review'),
           ),
@@ -246,9 +234,13 @@ class _ReviewTabState extends State<ReviewTab> {
           SliverFillRemaining(
             hasScrollBody: false,
             child: _EmptyState(
-              message: _reviews.isEmpty
-                  ? 'No reviews yet. Be the first!'
-                  : 'No items match the filter.',
+              message: _isLoading
+                  ? 'Loading reviews...'
+                  : _errorMessage != null
+                      ? 'Unable to load reviews. Please try again.'
+                      : _reviews.isEmpty
+                          ? 'No reviews yet. Be the first!'
+                          : 'No items match the filter.',
             ),
           )
         else
@@ -278,8 +270,8 @@ class _ReviewTabState extends State<ReviewTab> {
     );
   }
 
-  void _openWriteReview(BuildContext context) async {
-    final r = await showModalBottomSheet<Review>(
+  void _openWriteReview(BuildContext context, ColorScheme cs) async {
+    final draft = await showModalBottomSheet<_ReviewDraft>(
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
@@ -294,10 +286,25 @@ class _ReviewTabState extends State<ReviewTab> {
       ),
     );
 
-    if (r != null) _addReview(r);
+    if (draft == null) return;
+    try {
+      final review = await _reviewService.submitReview(
+        courtId: widget.courtId,
+        stars: draft.stars,
+        comment: draft.comment,
+        displayName: draft.displayName,
+      );
+      if (!mounted) return;
+      _addReview(review);
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    }
   }
 
-  void _report(Review r) {
+  void _report(CourtReview r) {
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
@@ -422,7 +429,7 @@ class _StarPickerState extends State<StarPicker> {
 
 // ===================== REVIEW CARD =====================
 class ReviewCard extends StatefulWidget {
-  final Review review;
+  final CourtReview review;
   final VoidCallback onLike;
   final VoidCallback onReport;
   const ReviewCard({
@@ -612,14 +619,14 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
                       );
                       return;
                     }
-                    final r = Review(
-                      id: DateTime.now().millisecondsSinceEpoch.toString(),
-                      userName: name,
-                      stars: _stars.toDouble(),
-                      comment: cmt,
-                      createdAt: DateTime.now(),
+                    Navigator.pop(
+                      context,
+                      _ReviewDraft(
+                        displayName: name,
+                        stars: _stars,
+                        comment: cmt,
+                      ),
                     );
-                    Navigator.pop(context, r);
                   },
                   child: const Text('Submit review'),
                 ),
@@ -656,6 +663,18 @@ class _FilterChipLike extends StatelessWidget {
       ),
     );
   }
+}
+
+class _ReviewDraft {
+  final String displayName;
+  final int stars;
+  final String comment;
+
+  const _ReviewDraft({
+    required this.displayName,
+    required this.stars,
+    required this.comment,
+  });
 }
 
 String timeAgo(DateTime dt) {

--- a/lib/pages/court/tabs/review_tab.dart
+++ b/lib/pages/court/tabs/review_tab.dart
@@ -34,6 +34,13 @@ class _ReviewTabState extends State<ReviewTab> {
     _reviews = [...widget.initialReviews];
     _reviewService = widget.reviewService ?? ReviewService();
     _loadReviews();
+    _subscribeToReviews();
+  }
+
+  @override
+  void dispose() {
+    _reviewService.unsubscribe();
+    super.dispose();
   }
 
   Future<void> _loadReviews() async {
@@ -54,6 +61,17 @@ class _ReviewTabState extends State<ReviewTab> {
         _errorMessage = error.toString();
         _isLoading = false;
       });
+    }
+  }
+
+  Future<void> _subscribeToReviews() async {
+    try {
+      await _reviewService.subscribeToReviews(
+        courtId: widget.courtId,
+        onChange: (_) => _loadReviews(),
+      );
+    } catch (_) {
+      // Ignore realtime errors to keep UI functional without socket.
     }
   }
 

--- a/lib/pages/court/tabs/review_tab.dart
+++ b/lib/pages/court/tabs/review_tab.dart
@@ -358,8 +358,15 @@ class StarRow extends StatelessWidget {
   final double rating; // 0..5 (đọc)
   final double size;
   final int maxStars;
+  final Color filledColor;
+  final Color emptyColor;
   const StarRow(
-      {super.key, required this.rating, this.size = 18, this.maxStars = 5});
+      {super.key,
+      required this.rating,
+      this.size = 18,
+      this.maxStars = 5,
+      this.filledColor = Colors.amber,
+      this.emptyColor = const Color(0xFFFFD54F)});
 
   @override
   Widget build(BuildContext context) {
@@ -377,7 +384,12 @@ class StarRow extends StatelessWidget {
         }
         return Padding(
           padding: const EdgeInsets.only(right: 2),
-          child: Icon(icon, size: size),
+          child: Icon(
+            icon,
+            size: size,
+            color:
+                i < full || (i == full && hasHalf) ? filledColor : emptyColor,
+          ),
         );
       }),
     );
@@ -387,7 +399,15 @@ class StarRow extends StatelessWidget {
 class StarPicker extends StatefulWidget {
   final int initial; // 1..5
   final void Function(int) onChanged;
-  const StarPicker({super.key, this.initial = 5, required this.onChanged});
+  final Color filledColor;
+  final Color emptyColor;
+  const StarPicker({
+    super.key,
+    this.initial = 5,
+    required this.onChanged,
+    this.filledColor = Colors.amber,
+    this.emptyColor = const Color(0xFFFFD54F),
+  });
 
   @override
   State<StarPicker> createState() => _StarPickerState();
@@ -412,7 +432,10 @@ class _StarPickerState extends State<StarPicker> {
             setState(() => _v = idx);
             widget.onChanged(_v);
           },
-          icon: Icon(filled ? Icons.star : Icons.star_outline),
+          icon: Icon(
+            filled ? Icons.star : Icons.star_outline,
+            color: filled ? widget.filledColor : widget.emptyColor,
+          ),
         );
       }),
     );

--- a/lib/pages/court/tabs/review_tab.dart
+++ b/lib/pages/court/tabs/review_tab.dart
@@ -271,18 +271,10 @@ class _ReviewTabState extends State<ReviewTab> {
   }
 
   void _openWriteReview(BuildContext context, ColorScheme cs) async {
-    final draft = await showModalBottomSheet<_ReviewDraft>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (_) => Padding(
-        padding: EdgeInsets.only(
-          bottom: MediaQuery.of(context).viewInsets.bottom,
-        ),
-        child: _WriteReviewSheet(),
+    final draft = await Navigator.of(context).push<_ReviewDraft>(
+      MaterialPageRoute(
+        builder: (_) => const _WriteReviewPage(),
+        fullscreenDialog: true,
       ),
     );
 
@@ -532,12 +524,14 @@ class _ReviewCardState extends State<ReviewCard> {
 }
 
 // ===================== WRITE REVIEW SHEET =====================
-class _WriteReviewSheet extends StatefulWidget {
+class _WriteReviewPage extends StatefulWidget {
+  const _WriteReviewPage();
+
   @override
-  State<_WriteReviewSheet> createState() => _WriteReviewSheetState();
+  State<_WriteReviewPage> createState() => _WriteReviewPageState();
 }
 
-class _WriteReviewSheetState extends State<_WriteReviewSheet> {
+class _WriteReviewPageState extends State<_WriteReviewPage> {
   int _stars = 5;
   final _name = TextEditingController();
   final _comment = TextEditingController();
@@ -553,88 +547,87 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: 44,
-            height: 4,
-            decoration: BoxDecoration(
-              color: cs.outlineVariant,
-              borderRadius: BorderRadius.circular(8),
-            ),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Write a review'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: EdgeInsets.fromLTRB(
+            16,
+            16,
+            16,
+            16 + MediaQuery.of(context).viewInsets.bottom,
           ),
-          const SizedBox(height: 12),
-          const Text('Write a review',
-              style: TextStyle(fontWeight: FontWeight.w700, fontSize: 18)),
-          const SizedBox(height: 12),
-          Align(
-              alignment: Alignment.centerLeft,
-              child: Text('Rate', style: TextStyle(color: cs.onSurface))),
-          StarPicker(
-            initial: 5,
-            onChanged: (v) => _stars = v,
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: _name,
-            decoration: const InputDecoration(
-              labelText: 'Display name',
-              hintText: 'e.g., Minh Nguyen',
-            ),
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: _comment,
-            minLines: 3,
-            maxLines: 6,
-            decoration: const InputDecoration(
-              labelText: 'Review content',
-              hintText: 'Share your experience…',
-            ),
-          ),
-          const SizedBox(height: 12),
-          Row(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Expanded(
-                child: OutlinedButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text('Cancel'),
+              Text('Rate', style: TextStyle(color: cs.onSurface)),
+              StarPicker(
+                initial: 5,
+                onChanged: (v) => _stars = v,
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _name,
+                decoration: const InputDecoration(
+                  labelText: 'Display name',
+                  hintText: 'e.g., Minh Nguyen',
                 ),
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: FilledButton(
-                  onPressed: () {
-                    final name = _name.text.trim().isEmpty
-                        ? 'User'
-                        : _name.text.trim();
-                    final cmt = _comment.text.trim();
-                    if (cmt.isEmpty) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                            content: Text('Please enter your review content.')),
-                      );
-                      return;
-                    }
-                    Navigator.pop(
-                      context,
-                      _ReviewDraft(
-                        displayName: name,
-                        stars: _stars,
-                        comment: cmt,
-                      ),
-                    );
-                  },
-                  child: const Text('Submit review'),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _comment,
+                minLines: 3,
+                maxLines: 6,
+                decoration: const InputDecoration(
+                  labelText: 'Review content',
+                  hintText: 'Share your experience…',
                 ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('Cancel'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: FilledButton(
+                      onPressed: () {
+                        final name = _name.text.trim().isEmpty
+                            ? 'User'
+                            : _name.text.trim();
+                        final cmt = _comment.text.trim();
+                        if (cmt.isEmpty) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content:
+                                  Text('Please enter your review content.'),
+                            ),
+                          );
+                          return;
+                        }
+                        Navigator.pop(
+                          context,
+                          _ReviewDraft(
+                            displayName: name,
+                            stars: _stars,
+                            comment: cmt,
+                          ),
+                        );
+                      },
+                      child: const Text('Submit review'),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
-          const SizedBox(height: 6),
-        ],
+        ),
       ),
     );
   }

--- a/lib/pages/court/tabs/review_tab.dart
+++ b/lib/pages/court/tabs/review_tab.dart
@@ -524,25 +524,7 @@ class _ReviewCardState extends State<ReviewCard> {
                   child: Text(_expanded ? 'Collapse' : 'See more'),
                 ),
 
-              // hành động
-              Row(
-                children: [
-                  IconButton(
-                    onPressed: widget.onLike,
-                    icon: Icon(
-                      r.likedByMe ? Icons.favorite : Icons.favorite_border,
-                      color: r.likedByMe ? cs.primary : null,
-                    ),
-                  ),
-                  Text('${r.likes}'),
-                  const SizedBox(width: 8),
-                  TextButton.icon(
-                    onPressed: widget.onReport,
-                    icon: const Icon(Icons.flag_outlined, size: 18),
-                    label: const Text('Report'),
-                  ),
-                ],
-              ),
+              // hành động đã ẩn theo yêu cầu
             ],
           ),
         ),

--- a/lib/pages/court/tabs/review_tab.dart
+++ b/lib/pages/court/tabs/review_tab.dart
@@ -271,11 +271,16 @@ class _ReviewTabState extends State<ReviewTab> {
   }
 
   void _openWriteReview(BuildContext context, ColorScheme cs) async {
-    final draft = await Navigator.of(context).push<_ReviewDraft>(
-      MaterialPageRoute(
-        builder: (_) => const _WriteReviewPage(),
-        fullscreenDialog: true,
-      ),
+    final draft = await showDialog<_ReviewDraft>(
+      context: context,
+      builder: (dialogContext) {
+        return Dialog(
+          insetPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          child: const _WriteReviewDialog(),
+        );
+      },
     );
 
     if (draft == null) return;
@@ -547,14 +552,14 @@ class _ReviewCardState extends State<ReviewCard> {
 }
 
 // ===================== WRITE REVIEW SHEET =====================
-class _WriteReviewPage extends StatefulWidget {
-  const _WriteReviewPage();
+class _WriteReviewDialog extends StatefulWidget {
+  const _WriteReviewDialog();
 
   @override
-  State<_WriteReviewPage> createState() => _WriteReviewPageState();
+  State<_WriteReviewDialog> createState() => _WriteReviewDialogState();
 }
 
-class _WriteReviewPageState extends State<_WriteReviewPage> {
+class _WriteReviewDialogState extends State<_WriteReviewDialog> {
   int _stars = 5;
   final _name = TextEditingController();
   final _comment = TextEditingController();
@@ -570,86 +575,96 @@ class _WriteReviewPageState extends State<_WriteReviewPage> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Write a review'),
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: EdgeInsets.fromLTRB(
-            16,
-            16,
-            16,
-            16 + MediaQuery.of(context).viewInsets.bottom,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('Rate', style: TextStyle(color: cs.onSurface)),
-              StarPicker(
-                initial: 5,
-                onChanged: (v) => _stars = v,
-              ),
-              const SizedBox(height: 8),
-              TextField(
-                controller: _name,
-                decoration: const InputDecoration(
-                  labelText: 'Display name',
-                  hintText: 'e.g., Minh Nguyen',
-                ),
-              ),
-              const SizedBox(height: 8),
-              TextField(
-                controller: _comment,
-                minLines: 3,
-                maxLines: 6,
-                decoration: const InputDecoration(
-                  labelText: 'Review content',
-                  hintText: 'Share your experience…',
-                ),
-              ),
-              const SizedBox(height: 16),
-              Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton(
-                      onPressed: () => Navigator.pop(context),
-                      child: const Text('Cancel'),
-                    ),
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: EdgeInsets.fromLTRB(
+          20,
+          16,
+          20,
+          16 + MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                const Expanded(
+                  child: Text(
+                    'Write a review',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: FilledButton(
-                      onPressed: () {
-                        final name = _name.text.trim().isEmpty
-                            ? 'User'
-                            : _name.text.trim();
-                        final cmt = _comment.text.trim();
-                        if (cmt.isEmpty) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content:
-                                  Text('Please enter your review content.'),
-                            ),
-                          );
-                          return;
-                        }
-                        Navigator.pop(
-                          context,
-                          _ReviewDraft(
-                            displayName: name,
-                            stars: _stars,
-                            comment: cmt,
+                ),
+                IconButton(
+                  onPressed: () => Navigator.pop(context),
+                  icon: const Icon(Icons.close),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text('Rate', style: TextStyle(color: cs.onSurface)),
+            StarPicker(
+              initial: 5,
+              onChanged: (v) => _stars = v,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _name,
+              decoration: const InputDecoration(
+                labelText: 'Display name',
+                hintText: 'e.g., Minh Nguyen',
+              ),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _comment,
+              minLines: 3,
+              maxLines: 6,
+              decoration: const InputDecoration(
+                labelText: 'Review content',
+                hintText: 'Share your experience…',
+              ),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Cancel'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton(
+                    onPressed: () {
+                      final name = _name.text.trim().isEmpty
+                          ? 'User'
+                          : _name.text.trim();
+                      final cmt = _comment.text.trim();
+                      if (cmt.isEmpty) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Please enter your review content.'),
                           ),
                         );
-                      },
-                      child: const Text('Submit review'),
-                    ),
+                        return;
+                      }
+                      Navigator.pop(
+                        context,
+                        _ReviewDraft(
+                          displayName: name,
+                          stars: _stars,
+                          comment: cmt,
+                        ),
+                      );
+                    },
+                    child: const Text('Submit review'),
                   ),
-                ],
-              ),
-            ],
-          ),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/court/tabs/review_tab.dart
+++ b/lib/pages/court/tabs/review_tab.dart
@@ -307,7 +307,6 @@ class _ReviewTabState extends State<ReviewTab> {
         courtId: widget.courtId,
         stars: draft.stars,
         comment: draft.comment,
-        displayName: draft.displayName,
       );
       if (!mounted) return;
       _addReview(review);
@@ -561,12 +560,10 @@ class _WriteReviewDialog extends StatefulWidget {
 
 class _WriteReviewDialogState extends State<_WriteReviewDialog> {
   int _stars = 5;
-  final _name = TextEditingController();
   final _comment = TextEditingController();
 
   @override
   void dispose() {
-    _name.dispose();
     _comment.dispose();
     super.dispose();
   }
@@ -609,14 +606,6 @@ class _WriteReviewDialogState extends State<_WriteReviewDialog> {
             ),
             const SizedBox(height: 8),
             TextField(
-              controller: _name,
-              decoration: const InputDecoration(
-                labelText: 'Display name',
-                hintText: 'e.g., Minh Nguyen',
-              ),
-            ),
-            const SizedBox(height: 8),
-            TextField(
               controller: _comment,
               minLines: 3,
               maxLines: 6,
@@ -636,30 +625,26 @@ class _WriteReviewDialogState extends State<_WriteReviewDialog> {
                 ),
                 const SizedBox(width: 12),
                 Expanded(
-                  child: FilledButton(
-                    onPressed: () {
-                      final name = _name.text.trim().isEmpty
-                          ? 'User'
-                          : _name.text.trim();
-                      final cmt = _comment.text.trim();
-                      if (cmt.isEmpty) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(
-                            content: Text('Please enter your review content.'),
+                    child: FilledButton(
+                      onPressed: () {
+                        final cmt = _comment.text.trim();
+                        if (cmt.isEmpty) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Please enter your review content.'),
+                            ),
+                          );
+                          return;
+                        }
+                        Navigator.pop(
+                          context,
+                          _ReviewDraft(
+                            stars: _stars,
+                            comment: cmt,
                           ),
                         );
-                        return;
-                      }
-                      Navigator.pop(
-                        context,
-                        _ReviewDraft(
-                          displayName: name,
-                          stars: _stars,
-                          comment: cmt,
-                        ),
-                      );
-                    },
-                    child: const Text('Submit review'),
+                      },
+                      child: const Text('Submit review'),
                   ),
                 ),
               ],
@@ -697,12 +682,10 @@ class _FilterChipLike extends StatelessWidget {
 }
 
 class _ReviewDraft {
-  final String displayName;
   final int stars;
   final String comment;
 
   const _ReviewDraft({
-    required this.displayName,
     required this.stars,
     required this.comment,
   });

--- a/lib/services/court_service.dart
+++ b/lib/services/court_service.dart
@@ -78,9 +78,10 @@ class CourtService {
             filter: filter,
           );
 
-      return result.items
+      final courts = result.items
           .map((record) => _mapRecordToCourt(pb, record))
           .toList(growable: false);
+      return _applyRatings(pb, courts);
     } on ClientException catch (error) {
       throw CourtServiceException(
         _mapClientException(
@@ -117,9 +118,10 @@ class CourtService {
             filter: "owner='$escapedOwner'",
           );
 
-      return result.items
+      final courts = result.items
           .map((record) => _mapRecordToCourt(pb, record))
           .toList(growable: false);
+      return _applyRatings(pb, courts);
     } on ClientException catch (error) {
       throw CourtServiceException(
         _mapClientException(
@@ -601,6 +603,53 @@ class CourtService {
     }
 
     return null;
+  }
+
+  Future<List<Court>> _applyRatings(
+    PocketBase pb,
+    List<Court> courts,
+  ) async {
+    if (courts.isEmpty) return courts;
+    final ratingByCourt = await _fetchAverageRatings(
+      pb,
+      courts.map((court) => court.id).toList(),
+    );
+    return courts
+        .map((court) => court.copyWith(rating: ratingByCourt[court.id]))
+        .toList(growable: false);
+  }
+
+  Future<Map<String, double>> _fetchAverageRatings(
+    PocketBase pb,
+    List<String> courtIds,
+  ) async {
+    if (courtIds.isEmpty) return {};
+    final filter = courtIds
+        .map((id) => "court_id='${_escapeFilterValue(id)}'")
+        .join(' || ');
+    final records = await pb.collection('court_ratings').getFullList(
+          filter: filter,
+          fields: 'court_id,rating',
+        );
+    final totals = <String, double>{};
+    final counts = <String, int>{};
+    for (final record in records) {
+      final data = record.data;
+      final courtId = data['court_id'] as String?;
+      if (courtId == null || courtId.isEmpty) continue;
+      final rating = data['rating'];
+      if (rating is! num) continue;
+      totals[courtId] = (totals[courtId] ?? 0) + rating.toDouble();
+      counts[courtId] = (counts[courtId] ?? 0) + 1;
+    }
+    final averages = <String, double>{};
+    totals.forEach((courtId, total) {
+      final count = counts[courtId] ?? 0;
+      if (count > 0) {
+        averages[courtId] = total / count;
+      }
+    });
+    return averages;
   }
 
   Court _mapRecordToCourt(PocketBase pb, RecordModel record) {

--- a/lib/services/court_service.dart
+++ b/lib/services/court_service.dart
@@ -81,7 +81,8 @@ class CourtService {
       final courts = result.items
           .map((record) => _mapRecordToCourt(pb, record))
           .toList(growable: false);
-      return _applyRatings(pb, courts);
+      final withRatings = await _applyRatings(pb, courts);
+      return _applyPricing(pb, withRatings);
     } on ClientException catch (error) {
       throw CourtServiceException(
         _mapClientException(
@@ -121,7 +122,8 @@ class CourtService {
       final courts = result.items
           .map((record) => _mapRecordToCourt(pb, record))
           .toList(growable: false);
-      return _applyRatings(pb, courts);
+      final withRatings = await _applyRatings(pb, courts);
+      return _applyPricing(pb, withRatings);
     } on ClientException catch (error) {
       throw CourtServiceException(
         _mapClientException(
@@ -650,6 +652,52 @@ class CourtService {
       }
     });
     return averages;
+  }
+
+  Future<List<Court>> _applyPricing(
+    PocketBase pb,
+    List<Court> courts,
+  ) async {
+    if (courts.isEmpty) return courts;
+    final priceByCourt = await _fetchMinPricePerHour(
+      pb,
+      courts.map((court) => court.id).toList(),
+    );
+    return courts
+        .map(
+          (court) => court.copyWith(
+            pricePerHour: priceByCourt[court.id] ?? court.pricePerHour,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  Future<Map<String, int>> _fetchMinPricePerHour(
+    PocketBase pb,
+    List<String> courtIds,
+  ) async {
+    if (courtIds.isEmpty) return {};
+    final filter = courtIds
+        .map((id) => "court_id='${_escapeFilterValue(id)}'")
+        .join(' || ');
+    final records = await pb.collection('court_pricing').getFullList(
+          filter: filter,
+          fields: 'court_id,price_per_hour',
+        );
+    final minPrice = <String, int>{};
+    for (final record in records) {
+      final data = record.data;
+      final courtId = data['court_id'] as String?;
+      if (courtId == null || courtId.isEmpty) continue;
+      final price = data['price_per_hour'];
+      if (price is! num) continue;
+      final value = price.toInt();
+      final current = minPrice[courtId];
+      if (current == null || value < current) {
+        minPrice[courtId] = value;
+      }
+    }
+    return minPrice;
   }
 
   Court _mapRecordToCourt(PocketBase pb, RecordModel record) {

--- a/lib/services/review_service.dart
+++ b/lib/services/review_service.dart
@@ -25,7 +25,6 @@ class ReviewService {
     required String courtId,
     required int stars,
     required String comment,
-    required String displayName,
   }) async {
     final pb = await getPocketbaseInstance();
     final userId = pb.authStore.record?.id;
@@ -37,7 +36,6 @@ class ReviewService {
       'user_id': userId,
       'rating': stars,
       'comment': comment,
-      'display_name': displayName,
     });
     return CourtReview.fromRecord(record, pb);
   }

--- a/lib/services/review_service.dart
+++ b/lib/services/review_service.dart
@@ -4,7 +4,7 @@ import '../models/court_review.dart';
 import 'pocketbase_client.dart';
 
 class ReviewService {
-  static const String collection = 'court_reviews';
+  static const String collection = 'court_ratings';
 
   Future<List<CourtReview>> fetchReviews(String courtId) async {
     final pb = await getPocketbaseInstance();

--- a/lib/services/review_service.dart
+++ b/lib/services/review_service.dart
@@ -5,6 +5,7 @@ import 'pocketbase_client.dart';
 
 class ReviewService {
   static const String collection = 'court_ratings';
+  UnsubscribeFunc? _unsubscribe;
 
   Future<List<CourtReview>> fetchReviews(String courtId) async {
     final pb = await getPocketbaseInstance();
@@ -39,5 +40,31 @@ class ReviewService {
       'display_name': displayName,
     });
     return CourtReview.fromRecord(record, pb);
+  }
+
+  Future<void> subscribeToReviews({
+    required String courtId,
+    required void Function(RecordSubscriptionEvent event) onChange,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    await unsubscribe();
+    final escapedCourtId = courtId.replaceAll("'", "\\'");
+    _unsubscribe = await pb.collection(collection).subscribe(
+          '*',
+          onChange,
+          filter: "court_id='$escapedCourtId'",
+        );
+  }
+
+  Future<void> unsubscribe() async {
+    final unsub = _unsubscribe;
+    _unsubscribe = null;
+    if (unsub != null) {
+      await unsub();
+    }
+  }
+
+  Future<void> dispose() async {
+    await unsubscribe();
   }
 }

--- a/lib/services/review_service.dart
+++ b/lib/services/review_service.dart
@@ -1,0 +1,43 @@
+import 'package:pocketbase/pocketbase.dart';
+
+import '../models/court_review.dart';
+import 'pocketbase_client.dart';
+
+class ReviewService {
+  static const String collection = 'court_reviews';
+
+  Future<List<CourtReview>> fetchReviews(String courtId) async {
+    final pb = await getPocketbaseInstance();
+    final result = await pb.collection(collection).getList(
+          page: 1,
+          perPage: 200,
+          filter: "court_id='$courtId'",
+          sort: '-created',
+          expand: 'user_id',
+        );
+    return result.items
+        .map((record) => CourtReview.fromRecord(record, pb))
+        .toList();
+  }
+
+  Future<CourtReview> submitReview({
+    required String courtId,
+    required int stars,
+    required String comment,
+    required String displayName,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    final userId = pb.authStore.record?.id;
+    if (userId == null || userId.isEmpty) {
+      throw StateError('Bạn cần đăng nhập để đánh giá sân.');
+    }
+    final record = await pb.collection(collection).create(body: {
+      'court_id': courtId,
+      'user_id': userId,
+      'rating': stars,
+      'comment': comment,
+      'display_name': displayName,
+    });
+    return CourtReview.fromRecord(record, pb);
+  }
+}


### PR DESCRIPTION
### Motivation
- The court header stat pills caused a `RenderFlex` overflow on narrow layouts, producing a layout error at runtime.
- The existing `Row` forced pills onto a single horizontal line which could exceed available width when labels are long or the screen is small.
- The UI needs to gracefully handle constrained widths by wrapping and truncating pill content.

### Description
- Replace the horizontal `Row` that contains the stat pills with a `Wrap` and set `spacing` and `runSpacing` to allow multi-line wrapping.
- Remove the fixed `SizedBox` spacer between pills and rely on `Wrap` spacing, and add `maxLines: 1` with `overflow: TextOverflow.ellipsis` to the pill `Text` to prevent label overflow.
- All changes were made in `lib/pages/court/court_page.dart`.