### PR TITLE
Add geocoding script to backfill court latitude/longitude

### DIFF
--- a/recommender_system/geocode_courts.py
+++ b/recommender_system/geocode_courts.py
@@ -1,0 +1,266 @@
+import argparse
+import asyncio
+import os
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+
+from pocketbase_client import client as pb_client
+from pocketbase_client import get_list, update_record
+
+
+DEFAULT_PROVIDER = "nominatim"
+DEFAULT_ADDRESS_FIELD = "location"
+DEFAULT_LAT_FIELD = "latitude"
+DEFAULT_LNG_FIELD = "longitud3"
+
+
+class GeocodeError(RuntimeError):
+    pass
+
+
+def _env_or_default(key: str, fallback: str) -> str:
+    value = os.getenv(key)
+    return value.strip() if value else fallback
+
+
+async def _geocode_nominatim(
+    client: httpx.AsyncClient,
+    address: str,
+    *,
+    user_agent: str,
+) -> Optional[Tuple[float, float]]:
+    response = await client.get(
+        "https://nominatim.openstreetmap.org/search",
+        params={
+            "q": address,
+            "format": "json",
+            "limit": 1,
+        },
+        headers={"User-Agent": user_agent},
+    )
+    response.raise_for_status()
+    results = response.json()
+    if not results:
+        return None
+    result = results[0]
+    return float(result["lat"]), float(result["lon"])
+
+
+async def _geocode_google(
+    client: httpx.AsyncClient,
+    address: str,
+    *,
+    api_key: str,
+) -> Optional[Tuple[float, float]]:
+    response = await client.get(
+        "https://maps.googleapis.com/maps/api/geocode/json",
+        params={"address": address, "key": api_key},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if payload.get("status") != "OK":
+        return None
+    result = payload["results"][0]["geometry"]["location"]
+    return float(result["lat"]), float(result["lng"])
+
+
+async def _geocode_mapbox(
+    client: httpx.AsyncClient,
+    address: str,
+    *,
+    api_key: str,
+) -> Optional[Tuple[float, float]]:
+    response = await client.get(
+        f"https://api.mapbox.com/geocoding/v5/mapbox.places/{address}.json",
+        params={"access_token": api_key, "limit": 1},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    features = payload.get("features", [])
+    if not features:
+        return None
+    lng, lat = features[0]["center"]
+    return float(lat), float(lng)
+
+
+async def geocode_address(
+    client: httpx.AsyncClient,
+    provider: str,
+    address: str,
+    *,
+    user_agent: str,
+    api_key: Optional[str],
+) -> Optional[Tuple[float, float]]:
+    if provider == "nominatim":
+        return await _geocode_nominatim(client, address, user_agent=user_agent)
+    if provider == "google":
+        if not api_key:
+            raise GeocodeError("Missing GOOGLE_MAPS_API_KEY for Google Geocoding.")
+        return await _geocode_google(client, address, api_key=api_key)
+    if provider == "mapbox":
+        if not api_key:
+            raise GeocodeError("Missing MAPBOX_TOKEN for Mapbox Geocoding.")
+        return await _geocode_mapbox(client, address, api_key=api_key)
+    raise GeocodeError(f"Unsupported provider: {provider}")
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
+async def run_geocoding(args: argparse.Namespace) -> None:
+    geocode_client = httpx.AsyncClient(timeout=20.0)
+    processed = 0
+    updated = 0
+    skipped = 0
+    page = 1
+
+    try:
+        while True:
+            data = await get_list("courts", page=page, per_page=args.per_page)
+            items = data.get("items", [])
+            if not items:
+                break
+
+            for item in items:
+                if args.max_records and processed >= args.max_records:
+                    return
+
+                processed += 1
+                address = item.get(args.address_field)
+                if _is_missing(address):
+                    skipped += 1
+                    print(f"[SKIP] {item.get('id')} missing address field.")
+                    continue
+
+                lat_value = item.get(args.lat_field)
+                lng_value = item.get(args.lng_field)
+                if not _is_missing(lat_value) and not _is_missing(lng_value):
+                    skipped += 1
+                    print(f"[SKIP] {item.get('id')} already has coordinates.")
+                    continue
+
+                coords = await geocode_address(
+                    geocode_client,
+                    args.provider,
+                    str(address),
+                    user_agent=args.user_agent,
+                    api_key=args.api_key,
+                )
+                if coords is None:
+                    skipped += 1
+                    print(f"[MISS] {item.get('id')} no geocode match.")
+                    await asyncio.sleep(args.rate_limit)
+                    continue
+
+                lat, lng = coords
+                if args.dry_run:
+                    print(
+                        "[DRY-RUN]",
+                        item.get("id"),
+                        f"{args.lat_field}={lat}",
+                        f"{args.lng_field}={lng}",
+                    )
+                else:
+                    await update_record(
+                        "courts",
+                        item["id"],
+                        {args.lat_field: lat, args.lng_field: lng},
+                    )
+                    updated += 1
+                    print(f"[UPDATE] {item.get('id')} -> {lat}, {lng}")
+
+                await asyncio.sleep(args.rate_limit)
+
+            page += 1
+    finally:
+        await geocode_client.aclose()
+        await pb_client.aclose()
+
+    print(
+        "Done.",
+        f"processed={processed}",
+        f"updated={updated}",
+        f"skipped={skipped}",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Geocode court addresses and store latitude/longitude in PocketBase.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["nominatim", "google", "mapbox"],
+        default=_env_or_default("GEOCODE_PROVIDER", DEFAULT_PROVIDER),
+        help="Geocoding provider to use.",
+    )
+    parser.add_argument(
+        "--address-field",
+        default=_env_or_default("GEOCODE_ADDRESS_FIELD", DEFAULT_ADDRESS_FIELD),
+        help="Field name containing the address text.",
+    )
+    parser.add_argument(
+        "--lat-field",
+        default=_env_or_default("GEOCODE_LAT_FIELD", DEFAULT_LAT_FIELD),
+        help="Field name for latitude in PocketBase.",
+    )
+    parser.add_argument(
+        "--lng-field",
+        default=_env_or_default("GEOCODE_LNG_FIELD", DEFAULT_LNG_FIELD),
+        help="Field name for longitude in PocketBase.",
+    )
+    parser.add_argument(
+        "--rate-limit",
+        type=float,
+        default=float(os.getenv("GEOCODE_RATE_LIMIT", "1.0")),
+        help="Delay in seconds between geocoding requests.",
+    )
+    parser.add_argument(
+        "--per-page",
+        type=int,
+        default=50,
+        help="Number of courts to fetch per page from PocketBase.",
+    )
+    parser.add_argument(
+        "--max-records",
+        type=int,
+        default=0,
+        help="Maximum number of courts to process (0 for no limit).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print updates without writing to PocketBase.",
+    )
+    return parser
+
+
+def _resolve_api_key(provider: str) -> Optional[str]:
+    if provider == "google":
+        return os.getenv("GOOGLE_MAPS_API_KEY")
+    if provider == "mapbox":
+        return os.getenv("MAPBOX_TOKEN")
+    return None
+
+
+async def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.api_key = _resolve_api_key(args.provider)
+    args.user_agent = _env_or_default(
+        "NOMINATIM_USER_AGENT",
+        "badminton-booking-app-geocoder/1.0",
+    )
+    if args.provider in {"google", "mapbox"} and not args.api_key:
+        raise GeocodeError("Missing API key for selected provider.")
+    await run_geocoding(args)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/recommender_system/geocode_courts.py
+++ b/recommender_system/geocode_courts.py
@@ -105,10 +105,12 @@ async def geocode_address(
     raise GeocodeError(f"Unsupported provider: {provider}")
 
 
-def _is_missing(value: Any) -> bool:
+def _is_missing(value: Any, *, zero_is_missing: bool) -> bool:
     if value is None:
         return True
     if isinstance(value, str) and not value.strip():
+        return True
+    if zero_is_missing and isinstance(value, (int, float)) and value == 0:
         return True
     return False
 
@@ -133,14 +135,17 @@ async def run_geocoding(args: argparse.Namespace) -> None:
 
                 processed += 1
                 address = item.get(args.address_field)
-                if _is_missing(address):
+                if _is_missing(address, zero_is_missing=False):
                     skipped += 1
                     print(f"[SKIP] {item.get('id')} missing address field.")
                     continue
 
                 lat_value = item.get(args.lat_field)
                 lng_value = item.get(args.lng_field)
-                if not _is_missing(lat_value) and not _is_missing(lng_value):
+                if (
+                    not _is_missing(lat_value, zero_is_missing=args.zero_is_missing)
+                    and not _is_missing(lng_value, zero_is_missing=args.zero_is_missing)
+                ):
                     skipped += 1
                     print(f"[SKIP] {item.get('id')} already has coordinates.")
                     continue
@@ -237,6 +242,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         help="Print updates without writing to PocketBase.",
+    )
+    parser.add_argument(
+        "--zero-is-missing",
+        action=argparse.BooleanOptionalAction,
+        default=os.getenv("GEOCODE_ZERO_IS_MISSING", "true").lower() != "false",
+        help="Treat 0 values as missing coordinates (default: true).",
     )
     return parser
 

--- a/recommender_system/geocode_courts.py
+++ b/recommender_system/geocode_courts.py
@@ -14,6 +14,7 @@ DEFAULT_PROVIDER = "nominatim"
 DEFAULT_ADDRESS_FIELD = "location"
 DEFAULT_LAT_FIELD = "latitude"
 DEFAULT_LNG_FIELD = "longitud3"
+DEFAULT_COUNTRY_SUFFIX = "Việt Nam"
 
 
 class GeocodeError(RuntimeError):
@@ -115,6 +116,16 @@ async def geocode_address(
     raise GeocodeError(f"Unsupported provider: {provider}")
 
 
+def _normalize_address(address: str, *, country_suffix: str) -> str:
+    normalized = address.strip()
+    if not country_suffix:
+        return normalized
+    lowered = normalized.lower()
+    if "viet nam" in lowered or "việt nam" in lowered:
+        return normalized
+    return f"{normalized}, {country_suffix}"
+
+
 def _is_missing(value: Any, *, zero_is_missing: bool) -> bool:
     if value is None:
         return True
@@ -160,16 +171,28 @@ async def run_geocoding(args: argparse.Namespace) -> None:
                     print(f"[SKIP] {item.get('id')} already has coordinates.")
                     continue
 
+                geocode_address_text = _normalize_address(
+                    str(address),
+                    country_suffix=args.address_country_suffix,
+                )
+                print(
+                    "[GEOCODE]",
+                    f"id={item.get('id')}",
+                    f"address={geocode_address_text}",
+                )
                 coords = await geocode_address(
                     geocode_client,
                     args.provider,
-                    str(address),
+                    geocode_address_text,
                     user_agent=args.user_agent,
                     api_key=args.api_key,
                 )
                 if coords is None:
                     skipped += 1
-                    print(f"[MISS] {item.get('id')} no geocode match.")
+                    print(
+                        f"[MISS] {item.get('id')} no geocode match.",
+                        f"address={address}",
+                    )
                     await asyncio.sleep(args.rate_limit)
                     continue
 
@@ -269,6 +292,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.getenv("GEOCODE_ZERO_IS_MISSING", "true").lower() != "false",
         help="Treat 0 values as missing coordinates (default: true).",
     )
+    parser.add_argument(
+        "--address-country-suffix",
+        default=os.getenv("GEOCODE_ADDRESS_COUNTRY_SUFFIX", DEFAULT_COUNTRY_SUFFIX),
+        help="Append this suffix if the address lacks a country name.",
+    )
     return parser
 
 
@@ -287,6 +315,14 @@ async def main() -> None:
     args.user_agent = _env_or_default(
         "NOMINATIM_USER_AGENT",
         "badminton-booking-app-geocoder/1.0",
+    )
+    print(
+        "[CONFIG]",
+        f"provider={args.provider}",
+        f"address_field={args.address_field}",
+        f"lat_field={args.lat_field}",
+        f"lng_field={args.lng_field}",
+        f"country_suffix={args.address_country_suffix}",
     )
     if args.provider in {"google", "mapbox"} and not args.api_key:
         raise GeocodeError("Missing API key for selected provider.")

--- a/recommender_system/geocode_courts.py
+++ b/recommender_system/geocode_courts.py
@@ -4,6 +4,7 @@ import os
 from typing import Any, Dict, Optional, Tuple
 
 import httpx
+from urllib.parse import quote
 
 from pocketbase_client import client as pb_client
 from pocketbase_client import get_list, update_record
@@ -29,14 +30,18 @@ async def _geocode_nominatim(
     address: str,
     *,
     user_agent: str,
+    country_code: Optional[str],
 ) -> Optional[Tuple[float, float]]:
+    params: Dict[str, Any] = {
+        "q": address,
+        "format": "json",
+        "limit": 1,
+    }
+    if country_code:
+        params["countrycodes"] = country_code
     response = await client.get(
         "https://nominatim.openstreetmap.org/search",
-        params={
-            "q": address,
-            "format": "json",
-            "limit": 1,
-        },
+        params=params,
         headers={"User-Agent": user_agent},
     )
     response.raise_for_status()
@@ -72,7 +77,7 @@ async def _geocode_mapbox(
     api_key: str,
 ) -> Optional[Tuple[float, float]]:
     response = await client.get(
-        f"https://api.mapbox.com/geocoding/v5/mapbox.places/{address}.json",
+        f"https://api.mapbox.com/geocoding/v5/mapbox.places/{quote(address)}.json",
         params={"access_token": api_key, "limit": 1},
     )
     response.raise_for_status()
@@ -93,7 +98,12 @@ async def geocode_address(
     api_key: Optional[str],
 ) -> Optional[Tuple[float, float]]:
     if provider == "nominatim":
-        return await _geocode_nominatim(client, address, user_agent=user_agent)
+        return await _geocode_nominatim(
+            client,
+            address,
+            user_agent=user_agent,
+            country_code=os.getenv("GEOCODE_COUNTRY_CODE"),
+        )
     if provider == "google":
         if not api_key:
             raise GeocodeError("Missing GOOGLE_MAPS_API_KEY for Google Geocoding.")
@@ -172,11 +182,21 @@ async def run_geocoding(args: argparse.Namespace) -> None:
                         f"{args.lng_field}={lng}",
                     )
                 else:
-                    await update_record(
-                        "courts",
-                        item["id"],
-                        {args.lat_field: lat, args.lng_field: lng},
-                    )
+                    try:
+                        await update_record(
+                            "courts",
+                            item["id"],
+                            {args.lat_field: lat, args.lng_field: lng},
+                        )
+                    except httpx.HTTPStatusError as exc:
+                        status = exc.response.status_code
+                        print(
+                            f"[ERROR] {item.get('id')} update failed ({status}).",
+                            exc.response.text,
+                        )
+                        skipped += 1
+                        await asyncio.sleep(args.rate_limit)
+                        continue
                     updated += 1
                     print(f"[UPDATE] {item.get('id')} -> {lat}, {lng}")
 


### PR DESCRIPTION
### Motivation
- Provide an automated way to convert existing court address text into numeric coordinates to avoid manual updates.
- Support multiple geocoding providers (`nominatim`, `google`, `mapbox`) to allow flexible API usage.
- Respect provider rate limits and allow dry-run so bulk updates to PocketBase are safe and controllable.

### Description
- Add `recommender_system/geocode_courts.py` which fetches `courts` via `get_list` and writes coordinates with `update_record` to PocketBase.
- Implement provider-specific geocode functions for Nominatim, Google, and Mapbox and a generic `geocode_address` wrapper. 
- Add a CLI with configurable field names (`--address-field`, `--lat-field`, `--lng-field`), `--provider`, `--rate-limit`, pagination, `--dry-run`, and env-var overrides. 
- Default behavior uses `location` for the address and `latitude` / `longitud3` for coordinate fields to match the current schema.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947daa1a00c832a83a569e2a1180709)