### PR TITLE
Add VNPAY payment flow

### DIFF
--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -11,17 +11,20 @@ import 'package:badminton_booking_app/services/booking_realtime_service.dart';
 import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
 import 'package:badminton_booking_app/services/payment_service.dart';
+import 'package:badminton_booking_app/services/vnpay_service.dart';
 
 class BookingManager extends ChangeNotifier {
   BookingManager({
     required this.detailData,
     BookingService? bookingService,
     PaymentService? paymentService,
+    VnpayService? vnpayService,
     this.slotDuration = const Duration(hours: 1),
     this.unitGroupSize = 5,
   })  : assert(unitGroupSize > 0, 'unitGroupSize must be positive'),
         _bookingService = bookingService ?? BookingService(),
-        _paymentService = paymentService ?? PaymentService() {
+        _paymentService = paymentService ?? PaymentService(),
+        _vnpayService = vnpayService ?? VnpayService() {
     _selectedDate = _normalizeDate(DateTime.now());
 
     Future.microtask(() => loadBookings());
@@ -32,6 +35,7 @@ class BookingManager extends ChangeNotifier {
   final int unitGroupSize;
   final BookingService _bookingService;
   final PaymentService _paymentService;
+  final VnpayService _vnpayService;
   final BookingRealtimeService _realtimeService = BookingRealtimeService();
 
   DateTime _selectedDate = DateTime.now();
@@ -445,6 +449,73 @@ class BookingManager extends ChangeNotifier {
     }
   }
 
+  Future<VnpayPaymentSession> startVnpayPayment() async {
+    final bookings = awaitingPaymentBookings.toList(growable: false);
+    if (bookings.isEmpty) {
+      throw BookingManagerException('Không có lượt đặt nào cần thanh toán.');
+    }
+    if (bookings.length > 1) {
+      throw BookingManagerException(
+        'Vui lòng thanh toán từng lượt đặt để dùng VNPAY.',
+      );
+    }
+
+    final booking = bookings.first;
+    final amountMinor = _calculateBookingAmount(booking);
+    final description =
+        'Thanh toán đặt sân ${detailData.court.name} (${booking.id})';
+
+    try {
+      return await _vnpayService.createPaymentSession(
+        bookingId: booking.id,
+        amountMinor: amountMinor,
+        currency: 'VND',
+        description: description,
+      );
+    } on VnpayServiceException catch (error) {
+      throw BookingManagerException(error.message);
+    }
+  }
+
+  Future<PaymentCheckResult> checkVnpayPaymentStatus(String bookingId) async {
+    final status = await _paymentService.getLatestPaymentStatusForBooking(
+      bookingId: bookingId,
+      provider: 'vnpay',
+    );
+    switch (status) {
+      case 'succeeded':
+        return PaymentCheckResult.succeeded;
+      case 'failed':
+      case 'refunded':
+        return PaymentCheckResult.failed;
+      case 'pending':
+      default:
+        return PaymentCheckResult.pending;
+    }
+  }
+
+  Future<void> confirmVnpayBooking(String bookingId) async {
+    _isConfirmingPayment = true;
+    notifyListeners();
+    try {
+      final updated = await _bookingService.markAsConfirmed(bookingId);
+      final updatedList = List<CourtBooking>.from(_loadedBookings);
+      final index = updatedList.indexWhere((item) => item.id == updated.id);
+      if (index >= 0) {
+        updatedList[index] = updated;
+      } else {
+        updatedList.add(updated);
+      }
+      _loadedBookings = updatedList;
+      _updateCache(_loadedBookings, _selectedDate);
+      notifyListeners();
+      await loadBookings(forceRefresh: true);
+    } finally {
+      _isConfirmingPayment = false;
+      notifyListeners();
+    }
+  }
+
   int _calculateBookingAmount(CourtBooking booking) {
     final slots = booking.splitToSlots(slotDuration);
     var total = 0.0;
@@ -595,3 +666,5 @@ class BookingManagerException implements Exception {
   @override
   String toString() => message;
 }
+
+enum PaymentCheckResult { pending, succeeded, failed }

--- a/lib/pages/court/payment_page.dart
+++ b/lib/pages/court/payment_page.dart
@@ -5,6 +5,7 @@ import 'package:badminton_booking_app/utils/booking_helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class PaymentPage extends StatefulWidget {
   const PaymentPage({super.key});
@@ -32,7 +33,7 @@ class _PaymentPageState extends State<PaymentPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Payment'),
+        title: const Text('Thanh toán VNPAY'),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),
@@ -69,7 +70,7 @@ class _PaymentPageState extends State<PaymentPage> {
                         width: 22,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Text('Pay now'),
+                    : const Text('Thanh toán ngay'),
               ),
             ),
             const SizedBox(height: 16),
@@ -250,7 +251,10 @@ class _PaymentPageState extends State<PaymentPage> {
     setState(() => _isProcessingPayment = true);
 
     try {
-      await context.read<BookingManager>().confirmPaymentBookings();
+      final manager = context.read<BookingManager>();
+      final session = await manager.startVnpayPayment();
+      await _launchVnpay(session.paymentUrl);
+      await _waitForVnpayConfirmation(manager, session.bookingId);
       if (!mounted) return;
       await _showPaymentSuccess(context);
       if (!mounted) return;
@@ -264,6 +268,53 @@ class _PaymentPageState extends State<PaymentPage> {
       if (!mounted) return;
       setState(() => _isProcessingPayment = false);
     }
+  }
+
+  Future<void> _launchVnpay(String paymentUrl) async {
+    final uri = Uri.tryParse(paymentUrl);
+    if (uri == null) {
+      throw BookingManagerException('Đường dẫn thanh toán không hợp lệ.');
+    }
+    final canLaunch = await canLaunchUrl(uri);
+    if (!canLaunch) {
+      throw BookingManagerException(
+        'Không thể mở VNPAY. Vui lòng kiểm tra thiết bị.',
+      );
+    }
+    final launched = await launchUrl(
+      uri,
+      mode: LaunchMode.externalApplication,
+    );
+    if (!launched) {
+      throw BookingManagerException('Không thể mở trang thanh toán VNPAY.');
+    }
+  }
+
+  Future<void> _waitForVnpayConfirmation(
+    BookingManager manager,
+    String bookingId,
+  ) async {
+    const timeout = Duration(minutes: 3);
+    const interval = Duration(seconds: 3);
+    final deadline = DateTime.now().add(timeout);
+
+    while (DateTime.now().isBefore(deadline)) {
+      final status = await manager.checkVnpayPaymentStatus(bookingId);
+      if (status == PaymentCheckResult.succeeded) {
+        await manager.confirmVnpayBooking(bookingId);
+        return;
+      }
+      if (status == PaymentCheckResult.failed) {
+        throw BookingManagerException(
+          'Thanh toán không thành công hoặc đã bị huỷ.',
+        );
+      }
+      await Future<void>.delayed(interval);
+    }
+
+    throw BookingManagerException(
+      'Chưa nhận được xác nhận thanh toán. Vui lòng kiểm tra lại sau.',
+    );
   }
 
   Future<void> _showPaymentSuccess(BuildContext context) {

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -56,6 +56,29 @@ class PaymentService {
     }
   }
 
+  Future<String?> getLatestPaymentStatusForBooking({
+    required String bookingId,
+    required String provider,
+  }) async {
+    final pb = await getPocketbaseInstance();
+    try {
+      final result = await pb.collection('payment').getList(
+            page: 1,
+            perPage: 1,
+            filter: 'booking_id = "$bookingId" && provider = "$provider"',
+            sort: '-created',
+          );
+      if (result.items.isEmpty) {
+        return null;
+      }
+      return result.items.first.data['status'] as String?;
+    } on ClientException catch (error) {
+      throw PaymentServiceException(_mapClientException(error));
+    } catch (_) {
+      throw PaymentServiceException('Không thể kiểm tra trạng thái thanh toán.');
+    }
+  }
+
   String _mapClientException(ClientException error) {
     if (error.response != null) {
       final data = error.response!['data'];

--- a/lib/services/vnpay_service.dart
+++ b/lib/services/vnpay_service.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+class VnpayServiceException implements Exception {
+  VnpayServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class VnpayPaymentSession {
+  VnpayPaymentSession({
+    required this.paymentUrl,
+    required this.bookingId,
+    this.paymentId,
+    this.transactionRef,
+  });
+
+  final String paymentUrl;
+  final String bookingId;
+  final String? paymentId;
+  final String? transactionRef;
+}
+
+class VnpayService {
+  VnpayService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  Future<VnpayPaymentSession> createPaymentSession({
+    required String bookingId,
+    required int amountMinor,
+    required String currency,
+    required String description,
+    String? returnUrl,
+  }) async {
+    final baseUrl = dotenv.env['VNPAY_API_BASE_URL'];
+    if (baseUrl == null || baseUrl.isEmpty) {
+      throw VnpayServiceException(
+        'Thiếu cấu hình VNPAY_API_BASE_URL để tạo phiên thanh toán.',
+      );
+    }
+
+    final createPath =
+        dotenv.env['VNPAY_CREATE_PATH'] ?? '/vnpay/create-payment';
+    final uri = Uri.parse(baseUrl).resolve(createPath);
+
+    final body = <String, dynamic>{
+      'bookingId': bookingId,
+      'amountMinor': amountMinor,
+      'currency': currency,
+      'description': description,
+      if (returnUrl != null && returnUrl.isNotEmpty) 'returnUrl': returnUrl,
+    };
+
+    http.Response response;
+    try {
+      response = await _client.post(
+        uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(body),
+      );
+    } catch (_) {
+      throw VnpayServiceException(
+        'Không thể kết nối tới máy chủ VNPAY. Vui lòng thử lại.',
+      );
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw VnpayServiceException(
+        'Không thể tạo phiên thanh toán VNPAY (mã ${response.statusCode}).',
+      );
+    }
+
+    final payload = jsonDecode(response.body);
+    if (payload is! Map<String, dynamic>) {
+      throw VnpayServiceException('Phản hồi VNPAY không hợp lệ.');
+    }
+
+    final paymentUrl = payload['paymentUrl'] as String?;
+    if (paymentUrl == null || paymentUrl.isEmpty) {
+      throw VnpayServiceException('Thiếu đường dẫn thanh toán VNPAY.');
+    }
+
+    return VnpayPaymentSession(
+      paymentUrl: paymentUrl,
+      bookingId: bookingId,
+      paymentId: payload['paymentId'] as String?,
+      transactionRef: payload['transactionRef'] as String?,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   curved_navigation_bar: ^1.0.6
   image_picker: ^1.2.0
   http: ^1.5.0
+  url_launcher: ^6.3.1
   intl: ^0.19.0
   fl_chart: ^0.69.0
 

--- a/recommender_system/app/main.py
+++ b/recommender_system/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from app.routers import recommend, feedback, events, admin
+from app.routers import recommend, feedback, events, admin, vnpay
 
 app = FastAPI(title="Badminton Recommendation Service")
 
@@ -15,3 +15,4 @@ app.include_router(recommend.router)
 app.include_router(feedback.router)
 app.include_router(events.router)
 app.include_router(admin.router)
+app.include_router(vnpay.router)

--- a/recommender_system/app/routers/vnpay.py
+++ b/recommender_system/app/routers/vnpay.py
@@ -1,0 +1,180 @@
+import hashlib
+import hmac
+import os
+import urllib.parse
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from pocketbase_client import create_record, get_list, update_record
+
+router = APIRouter(prefix="/vnpay", tags=["vnpay"])
+
+
+class CreatePaymentRequest(BaseModel):
+    booking_id: str = Field(..., alias="bookingId")
+    amount_minor: int = Field(..., alias="amountMinor", ge=1)
+    currency: str = Field(..., alias="currency")
+    description: str = Field(..., alias="description")
+    return_url: Optional[str] = Field(None, alias="returnUrl")
+
+
+class CreatePaymentResponse(BaseModel):
+    payment_url: str = Field(..., alias="paymentUrl")
+    payment_id: Optional[str] = Field(None, alias="paymentId")
+    transaction_ref: str = Field(..., alias="transactionRef")
+
+
+def _get_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise HTTPException(
+            status_code=500, detail=f"Missing required env: {name}"
+        )
+    return value
+
+
+def _vnpay_timestamp() -> str:
+    now = datetime.now(timezone(timedelta(hours=7)))
+    return now.strftime("%Y%m%d%H%M%S")
+
+
+def _sign_params(params: Dict[str, Any], secret: str) -> str:
+    ordered = sorted((k, str(v)) for k, v in params.items() if v is not None)
+    query = urllib.parse.urlencode(ordered, doseq=True)
+    signature = hmac.new(
+        secret.encode("utf-8"),
+        query.encode("utf-8"),
+        hashlib.sha512,
+    ).hexdigest()
+    return signature
+
+
+def _build_payment_url(params: Dict[str, Any], base_url: str, secret: str) -> str:
+    signature = _sign_params(params, secret)
+    params_with_hash = {**params, "vnp_SecureHash": signature}
+    query = urllib.parse.urlencode(sorted(params_with_hash.items()))
+    return f"{base_url}?{query}"
+
+
+@router.post("/create-payment", response_model=CreatePaymentResponse)
+async def create_payment(payload: CreatePaymentRequest, request: Request):
+    vnp_tmn_code = _get_env("VNPAY_TMN_CODE")
+    vnp_hash_secret = _get_env("VNPAY_HASH_SECRET")
+    vnp_base_url = _get_env("VNPAY_BASE_URL")
+    vnp_return_url = payload.return_url or _get_env("VNPAY_RETURN_URL")
+
+    amount_minor = payload.amount_minor
+    vnp_amount = amount_minor * 100
+    transaction_ref = f"{payload.booking_id}-{int(datetime.now().timestamp())}"
+
+    vnp_params: Dict[str, Any] = {
+        "vnp_Version": "2.1.0",
+        "vnp_Command": "pay",
+        "vnp_TmnCode": vnp_tmn_code,
+        "vnp_Amount": vnp_amount,
+        "vnp_CurrCode": payload.currency,
+        "vnp_TxnRef": transaction_ref,
+        "vnp_OrderInfo": payload.description,
+        "vnp_OrderType": "other",
+        "vnp_Locale": "vn",
+        "vnp_ReturnUrl": vnp_return_url,
+        "vnp_IpAddr": request.client.host if request.client else "127.0.0.1",
+        "vnp_CreateDate": _vnpay_timestamp(),
+    }
+
+    payment_record = await create_record(
+        "payment",
+        {
+            "booking_id": payload.booking_id,
+            "amount_minor": amount_minor,
+            "currency": payload.currency,
+            "provider": "vnpay",
+            "status": "pending",
+            "transaction_ref": transaction_ref,
+            "payload": payload.model_dump_json(by_alias=True),
+        },
+    )
+
+    payment_url = _build_payment_url(vnp_params, vnp_base_url, vnp_hash_secret)
+
+    return CreatePaymentResponse(
+        paymentUrl=payment_url,
+        paymentId=payment_record.get("id"),
+        transactionRef=transaction_ref,
+    )
+
+
+def _extract_vnpay_params(query: Dict[str, str]) -> Dict[str, str]:
+    return {k: v for k, v in query.items() if k.startswith("vnp_")}
+
+
+def _verify_signature(params: Dict[str, str], secret: str) -> bool:
+    secure_hash = params.pop("vnp_SecureHash", None)
+    params.pop("vnp_SecureHashType", None)
+    if not secure_hash:
+        return False
+    signature = _sign_params(params, secret)
+    return signature == secure_hash
+
+
+@router.get("/ipn")
+async def vnpay_ipn(request: Request):
+    params = _extract_vnpay_params(dict(request.query_params))
+    vnp_hash_secret = _get_env("VNPAY_HASH_SECRET")
+
+    if not _verify_signature(params.copy(), vnp_hash_secret):
+        return {"RspCode": "97", "Message": "Invalid signature"}
+
+    txn_ref = params.get("vnp_TxnRef")
+    response_code = params.get("vnp_ResponseCode")
+    transaction_status = params.get("vnp_TransactionStatus")
+
+    if not txn_ref:
+        return {"RspCode": "01", "Message": "Missing transaction ref"}
+
+    status = "pending"
+    if response_code == "00" and transaction_status == "00":
+        status = "succeeded"
+    elif response_code and response_code != "00":
+        status = "failed"
+    elif transaction_status and transaction_status != "00":
+        status = "failed"
+
+    result = await get_list(
+        "payment",
+        page=1,
+        per_page=1,
+        filter_expr=f'transaction_ref = "{txn_ref}"',
+        sort="-created",
+    )
+    items = result.get("items", [])
+    if not items:
+        return {"RspCode": "01", "Message": "Payment not found"}
+
+    payment = items[0]
+    await update_record(
+        "payment",
+        payment["id"],
+        {
+            "status": status,
+            "payload": urllib.parse.urlencode(params),
+        },
+    )
+
+    return {"RspCode": "00", "Message": "Confirm Success"}
+
+
+@router.get("/return")
+async def vnpay_return(request: Request):
+    params = _extract_vnpay_params(dict(request.query_params))
+    vnp_hash_secret = _get_env("VNPAY_HASH_SECRET")
+    if not _verify_signature(params.copy(), vnp_hash_secret):
+        raise HTTPException(status_code=400, detail="Invalid signature")
+    return {
+        "responseCode": params.get("vnp_ResponseCode"),
+        "transactionStatus": params.get("vnp_TransactionStatus"),
+        "transactionRef": params.get("vnp_TxnRef"),
+    }


### PR DESCRIPTION
### Motivation
- Hỗ trợ thanh toán bằng VNPAY cho các lượt đặt sân hiện có và nối tiếp luồng `held` → `awaiting_payment` → `confirmed` trong schema hiện tại.
- Tận dụng collection `payment` và `court_bookings` để lưu giao dịch và cập nhật trạng thái booking.
- Cần một phiên thanh toán do backend tạo (ký + URL), client mở trang VNPAY và xác nhận kết quả qua IPN/record trong `payment`.

### Description
- Thêm `lib/services/vnpay_service.dart` với `VnpayService` và `VnpayPaymentSession` để gọi backend tạo phiên thanh toán (sử dụng `VNPAY_API_BASE_URL` và `VNPAY_CREATE_PATH` từ env).
- Tích hợp VNPAY vào `BookingManager` bằng các hàm `startVnpayPayment`, `checkVnpayPaymentStatus` và `confirmVnpayBooking`, và thêm enum `PaymentCheckResult` để ánh xạ trạng thái.
- Cập nhật UI ở `lib/pages/court/payment_page.dart` để khởi tạo phiên VNPAY, mở URL bằng `url_launcher`, poll trạng thái thanh toán và xác nhận booking khi nhận được `succeeded`.
- Mở rộng `lib/services/payment_service.dart` với `getLatestPaymentStatusForBooking` để truy vấn trạng thái thanh toán gần nhất cho một `booking_id`/`provider` và thêm dependency `url_launcher` vào `pubspec.yaml`.

### Testing
- Không có bài kiểm thử tự động nào được thực thi trong môi trường này (không chạy CI/unit tests).
- Thử chạy `dart format` trên các file thay đổi không thành công do lệnh `dart` không có sẵn trong môi trường (format chưa được áp dụng tự động).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947fd541e28832a8cb7bc29b49fff60)