### PR TITLE
Add court service add-ons to payment flow

### DIFF
--- a/lib/pages/court/booking_manager.dart
+++ b/lib/pages/court/booking_manager.dart
@@ -12,6 +12,20 @@ import 'package:badminton_booking_app/services/booking_service.dart';
 import 'package:badminton_booking_app/utils/booking_helpers.dart';
 import 'package:badminton_booking_app/services/payment_service.dart';
 
+class SelectedServiceCharge {
+  const SelectedServiceCharge({
+    required this.serviceId,
+    required this.quantity,
+    required this.unitPrice,
+  });
+
+  final String serviceId;
+  final int quantity;
+  final int unitPrice;
+
+  int get totalAmount => quantity * unitPrice;
+}
+
 class BookingManager extends ChangeNotifier {
   static const Duration _awaitingPaymentTimeout = Duration(seconds: 15);
 
@@ -51,6 +65,7 @@ class BookingManager extends ChangeNotifier {
   final Map<SelectedSlot, CourtBooking> _heldBookingsBySlot =
       <SelectedSlot, CourtBooking>{};
   final Set<SelectedSlot> _slotsInProgress = <SelectedSlot>{};
+  final Map<String, int> _selectedServiceQuantities = <String, int>{};
 
   final Map<String, _BookingCacheEntry> _bookingCacheByKey =
       <String, _BookingCacheEntry>{};
@@ -112,6 +127,7 @@ class BookingManager extends ChangeNotifier {
 
   bool get hasHeldBookings => _heldBookingsBySlot.isNotEmpty;
   bool get hasAwaitingPaymentBookings => awaitingPaymentBookings.isNotEmpty;
+  bool get hasSelectedServices => _selectedServiceQuantities.isNotEmpty;
 
   DateTime? get awaitingPaymentExpiresAt {
     DateTime? earliest;
@@ -137,6 +153,7 @@ class BookingManager extends ChangeNotifier {
     for (final slot in _selectedSlots) {
       totalPrice += calculateSlotPrice(detailData, slot, slotDuration);
     }
+    totalPrice += totalSelectedServicePrice;
     return totalPrice;
   }
 
@@ -159,6 +176,7 @@ class BookingManager extends ChangeNotifier {
       return;
     }
     _currentUserId = userId;
+    _selectedServiceQuantities.clear();
     _syncSelectedSlotsWithBookings();
     notifyListeners();
     unawaited(loadBookings(forceRefresh: true));
@@ -505,7 +523,90 @@ class BookingManager extends ChangeNotifier {
     return total.round();
   }
 
+  int calculateServiceAmount() {
+    var total = 0;
+    final services = _mapPayableServicesById();
+    for (final entry in _selectedServiceQuantities.entries) {
+      final service = services[entry.key];
+      if (service == null || entry.value <= 0 || service.price == null) {
+        continue;
+      }
+      total += service.price! * entry.value;
+    }
+    return total;
+  }
+
+  double get totalSelectedServicePrice => calculateServiceAmount().toDouble();
+
+  List<SelectedServiceCharge> get selectedServiceCharges {
+    final services = _mapPayableServicesById();
+    final result = <SelectedServiceCharge>[];
+    for (final entry in _selectedServiceQuantities.entries) {
+      final service = services[entry.key];
+      if (service == null || entry.value <= 0 || service.price == null) {
+        continue;
+      }
+      result.add(
+        SelectedServiceCharge(
+          serviceId: entry.key,
+          quantity: entry.value,
+          unitPrice: service.price!,
+        ),
+      );
+    }
+    return result;
+  }
+
+  List<CourtServiceItem> get payableServices {
+    return detailData.services
+        .where((service) => service.isActive && service.price != null)
+        .toList(growable: false);
+  }
+
+  int serviceQuantity(String serviceId) {
+    return _selectedServiceQuantities[serviceId] ?? 0;
+  }
+
+  void incrementService(String serviceId) {
+    _updateServiceQuantity(serviceId, serviceQuantity(serviceId) + 1);
+  }
+
+  void decrementService(String serviceId) {
+    _updateServiceQuantity(serviceId, serviceQuantity(serviceId) - 1);
+  }
+
+  void _updateServiceQuantity(String serviceId, int quantity) {
+    final services = _mapPayableServicesById();
+    if (!services.containsKey(serviceId)) {
+      return;
+    }
+    if (quantity <= 0) {
+      _selectedServiceQuantities.remove(serviceId);
+    } else {
+      _selectedServiceQuantities[serviceId] = quantity;
+    }
+    notifyListeners();
+  }
+
+  void clearSelectedServices() {
+    if (_selectedServiceQuantities.isEmpty) {
+      return;
+    }
+    _selectedServiceQuantities.clear();
+    notifyListeners();
+  }
+
+  Map<String, CourtServiceItem> _mapPayableServicesById() {
+    return {
+      for (final service in payableServices) service.id: service,
+    };
+  }
+
   int calculateTotalAmount(List<CourtBooking> bookings) {
+    return calculateBookingsAmount(bookings) + calculateServiceAmount();
+  }
+
+  int calculateBookingsAmount(List<CourtBooking> bookings) {
     var total = 0;
     for (final booking in bookings) {
       total += _calculateBookingAmount(booking);

--- a/lib/pages/court/payment_page.dart
+++ b/lib/pages/court/payment_page.dart
@@ -28,7 +28,9 @@ class _PaymentPageState extends State<PaymentPage> {
     final durationLabel = totalDuration.inMinutes == 0
         ? '0 min'
         : '${totalDuration.inMinutes ~/ 60}h ${totalDuration.inMinutes % 60}m';
-    final totalPrice = _totalPrice(provider, slots);
+    final bookingTotal = _totalBookingPrice(provider, slots);
+    final serviceTotal = provider.totalSelectedServicePrice;
+    final totalPrice = bookingTotal + serviceTotal;
     final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
@@ -56,7 +58,17 @@ class _PaymentPageState extends State<PaymentPage> {
                     ),
             ),
             const SizedBox(height: 12),
-            _buildTotalRow(colorScheme, durationLabel, totalPrice),
+            if (provider.payableServices.isNotEmpty) ...[
+              _buildServiceSelector(colorScheme, provider),
+              const SizedBox(height: 12),
+            ],
+            _buildTotalRow(
+              colorScheme,
+              durationLabel,
+              bookingTotal,
+              serviceTotal,
+              totalPrice,
+            ),
             const SizedBox(height: 12),
             SizedBox(
               width: double.infinity,
@@ -102,13 +114,74 @@ class _PaymentPageState extends State<PaymentPage> {
     return Duration(minutes: minutes);
   }
 
-  double _totalPrice(BookingManager provider, List<SelectedSlot> slots) {
+  double _totalBookingPrice(
+      BookingManager provider, List<SelectedSlot> slots) {
     var total = 0.0;
     for (final slot in slots) {
       total +=
           calculateSlotPrice(provider.detailData, slot, provider.slotDuration);
     }
     return total;
+  }
+
+  Widget _buildServiceSelector(
+    ColorScheme colorScheme,
+    BookingManager provider,
+  ) {
+    final services = provider.payableServices;
+    if (services.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outline.withOpacity(0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.add_shopping_cart_outlined, color: colorScheme.primary),
+              const SizedBox(width: 8),
+              Text(
+                'Add-on services',
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          ...services.map(
+            (service) => Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: _ServiceRow(
+                service: service,
+                quantity: provider.serviceQuantity(service.id),
+                onIncrement: () => provider.incrementService(service.id),
+                onDecrement: () => provider.decrementService(service.id),
+              ),
+            ),
+          ),
+          if (provider.totalSelectedServicePrice > 0)
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                'Service subtotal: ${formatCurrency(provider.totalSelectedServicePrice)}',
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: colorScheme.primary,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
   }
 
   Widget _buildCourtInfoCard(CourtDetailData detail, ColorScheme colorScheme) {
@@ -197,7 +270,12 @@ class _PaymentPageState extends State<PaymentPage> {
   }
 
   Widget _buildTotalRow(
-      ColorScheme colorScheme, String durationLabel, double totalPrice) {
+    ColorScheme colorScheme,
+    String durationLabel,
+    double bookingTotal,
+    double serviceTotal,
+    double totalPrice,
+  ) {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -215,6 +293,36 @@ class _PaymentPageState extends State<PaymentPage> {
             ],
           ),
           const SizedBox(height: 8),
+          Row(
+            children: [
+              Icon(Icons.sports_tennis_outlined,
+                  color: colorScheme.onSurfaceVariant),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Court fee',
+                  style: TextStyle(color: colorScheme.onSurfaceVariant),
+                ),
+              ),
+              Text(formatCurrency(bookingTotal)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Row(
+            children: [
+              Icon(Icons.room_service_outlined,
+                  color: colorScheme.onSurfaceVariant),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Services',
+                  style: TextStyle(color: colorScheme.onSurfaceVariant),
+                ),
+              ),
+              Text(formatCurrency(serviceTotal)),
+            ],
+          ),
+          const Divider(height: 20),
           Row(
             children: [
               Icon(Icons.payments_outlined, color: colorScheme.primary),
@@ -301,5 +409,86 @@ class _PaymentPageState extends State<PaymentPage> {
       orElse: () => units.first,
     );
     return unit.label.isEmpty ? 'Court' : unit.label;
+  }
+}
+
+class _ServiceRow extends StatelessWidget {
+  const _ServiceRow({
+    required this.service,
+    required this.quantity,
+    required this.onIncrement,
+    required this.onDecrement,
+  });
+
+  final CourtServiceItem service;
+  final int quantity;
+  final VoidCallback onIncrement;
+  final VoidCallback onDecrement;
+
+  String get _priceLabel {
+    if (service.price != null) {
+      final unitSuffix = service.unit != null && service.unit!.trim().isNotEmpty
+          ? ' / ${service.unit}'
+          : '';
+      return '${formatCurrency(service.price!)}$unitSuffix';
+    }
+    return service.priceLabel?.isNotEmpty == true
+        ? service.priceLabel!
+        : 'Contact court';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(Icons.checklist_rtl, color: colorScheme.primary),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                service.name,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                _priceLabel,
+                style: TextStyle(color: colorScheme.onSurfaceVariant),
+              ),
+              if (service.note != null && service.note!.isNotEmpty) ...[
+                const SizedBox(height: 4),
+                Text(
+                  service.note!,
+                  style: TextStyle(
+                    color: colorScheme.onSurfaceVariant,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.remove_circle_outline),
+              onPressed: quantity > 0 ? onDecrement : null,
+            ),
+            Text(
+              '$quantity',
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            IconButton(
+              icon: const Icon(Icons.add_circle_outline),
+              onPressed: onIncrement,
+            ),
+          ],
+        ),
+      ],
+    );
   }
 }

--- a/lib/pages/court/payment_sheet_page.dart
+++ b/lib/pages/court/payment_sheet_page.dart
@@ -39,8 +39,11 @@ class _PaymentSheetPageState extends State<PaymentSheetPage> {
       final provider = context.read<BookingManager>();
       final bookings = widget.bookings;
       final amountMinor = provider.calculateTotalAmount(bookings);
-      if (bookings.isEmpty || amountMinor <= 0) {
-        throw BookingManagerException('No pending bookings to pay.');
+      final serviceCharges = provider.selectedServiceCharges;
+      if ((bookings.isEmpty && serviceCharges.isEmpty) || amountMinor <= 0) {
+        throw BookingManagerException(
+          'No pending bookings or services to pay.',
+        );
       }
 
       final intent = await _stripePaymentService.createPaymentIntent(
@@ -50,6 +53,15 @@ class _PaymentSheetPageState extends State<PaymentSheetPage> {
               (booking) => StripeBookingPayment(
                 bookingId: booking.id,
                 amountMinor: provider.calculateBookingAmount(booking),
+              ),
+            )
+            .toList(),
+        services: serviceCharges
+            .map(
+              (service) => StripeServicePayment(
+                serviceId: service.serviceId,
+                quantity: service.quantity,
+                amountMinor: service.totalAmount,
               ),
             )
             .toList(),
@@ -68,6 +80,7 @@ class _PaymentSheetPageState extends State<PaymentSheetPage> {
       );
 
       await provider.loadBookings(forceRefresh: true);
+      provider.clearSelectedServices();
       if (!mounted) return;
       Navigator.of(context).pop(true);
     } on StripePaymentException catch (error) {

--- a/lib/services/stripe_payment_service.dart
+++ b/lib/services/stripe_payment_service.dart
@@ -39,10 +39,31 @@ class StripeBookingPayment {
   }
 }
 
+class StripeServicePayment {
+  const StripeServicePayment({
+    required this.serviceId,
+    required this.quantity,
+    required this.amountMinor,
+  });
+
+  final String serviceId;
+  final int quantity;
+  final int amountMinor;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'service_id': serviceId,
+      'quantity': quantity,
+      'amount_minor': amountMinor,
+    };
+  }
+}
+
 class StripePaymentService {
   Future<StripePaymentIntent> createPaymentIntent({
     required String currency,
     required List<StripeBookingPayment> bookings,
+    List<StripeServicePayment> services = const [],
   }) async {
     final endpoint = dotenv.env['STRIPE_PAYMENT_INTENT_URL'];
     if (endpoint == null || endpoint.isEmpty) {
@@ -59,6 +80,8 @@ class StripePaymentService {
         body: jsonEncode({
           'currency': currency,
           'bookings': bookings.map((booking) => booking.toJson()).toList(),
+          if (services.isNotEmpty)
+            'services': services.map((service) => service.toJson()).toList(),
         }),
       );
 


### PR DESCRIPTION
## Summary
- allow players to choose priced court services during checkout and see add-on subtotals
- track selected service quantities in the booking manager and include them in payment totals
- send selected services to the Stripe payment intent request alongside court bookings

## Testing
- Not run (Flutter/Dart SDK not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953638cc258832aaf6223d4ec076ab1)